### PR TITLE
UX: Topics: Set num of partitions to 1 by default

### DIFF
--- a/frontend/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/frontend/src/components/Topics/shared/Form/TopicForm.tsx
@@ -116,6 +116,7 @@ const TopicForm: React.FC<Props> = ({
                   id="topicFormNumberOfPartitions"
                   type="number"
                   placeholder="Number of Partitions"
+                  defaultValue="1"
                   min="1"
                   name="partitions"
                   positiveOnly


### PR DESCRIPTION
**What changes did you make?** (Give an overview)

Fixes #329

I changed the default value of the "Number of Partitions"-field to 1.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to
- [ ] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)


