### PR TITLE
FE: Fix refetching data on window focus

### DIFF
--- a/frontend/src/components/Schemas/Edit/Edit.tsx
+++ b/frontend/src/components/Schemas/Edit/Edit.tsx
@@ -4,6 +4,7 @@ import useAppParams from 'lib/hooks/useAppParams';
 import PageLoader from 'components/common/PageLoader/PageLoader';
 import { useNavigate } from 'react-router-dom';
 import { useGetLatestSchema } from 'lib/hooks/api/schemas';
+import { QUERY_REFETCH_LIMITED_OPTIONS } from 'lib/constants';
 
 import Form from './Form';
 
@@ -14,10 +15,13 @@ const Edit: React.FC = () => {
     isFetching,
     isError,
     data: schema,
-  } = useGetLatestSchema({
-    clusterName,
-    subject,
-  });
+  } = useGetLatestSchema(
+    {
+      clusterName,
+      subject,
+    },
+    QUERY_REFETCH_LIMITED_OPTIONS
+  );
 
   useEffect(() => {
     if (isError) {

--- a/frontend/src/components/Topics/Topic/Edit/Edit.tsx
+++ b/frontend/src/components/Topics/Topic/Edit/Edit.tsx
@@ -7,7 +7,10 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { topicFormValidationSchema } from 'lib/yupExtended';
 import useAppParams from 'lib/hooks/useAppParams';
 import topicParamsTransformer from 'components/Topics/Topic/Edit/topicParamsTransformer';
-import { MILLISECONDS_IN_WEEK } from 'lib/constants';
+import {
+  MILLISECONDS_IN_WEEK,
+  QUERY_REFETCH_LIMITED_OPTIONS,
+} from 'lib/constants';
 import {
   useTopicConfig,
   useTopicDetails,
@@ -30,8 +33,14 @@ export const TOPIC_EDIT_FORM_DEFAULT_PROPS = {
 
 const Edit: React.FC = () => {
   const { clusterName, topicName } = useAppParams<RouteParamsClusterTopic>();
-  const { data: topic } = useTopicDetails({ clusterName, topicName });
-  const { data: topicConfig } = useTopicConfig({ clusterName, topicName });
+  const { data: topic } = useTopicDetails(
+    { clusterName, topicName },
+    QUERY_REFETCH_LIMITED_OPTIONS
+  );
+  const { data: topicConfig } = useTopicConfig(
+    { clusterName, topicName },
+    QUERY_REFETCH_LIMITED_OPTIONS
+  );
   const updateTopic = useUpdateTopic({ clusterName, topicName });
 
   const defaultValues = topicParamsTransformer(topic, topicConfig);

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -73,8 +73,9 @@ export const QUERY_REFETCH_OFF_OPTIONS = {
   refetchIntervalInBackground: false,
 };
 
-export const QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION = {
+export const QUERY_REFETCH_LIMITED_OPTIONS = {
   refetchOnWindowFocus: false,
+  refetchIntervalInBackground: false,
 };
 
 // Cluster Form Constants

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -73,6 +73,10 @@ export const QUERY_REFETCH_OFF_OPTIONS = {
   refetchIntervalInBackground: false,
 };
 
+export const QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION = {
+  refetchOnWindowFocus: false,
+};
+
 // Cluster Form Constants
 export const AUTH_OPTIONS = [
   { value: 'SASL/JAAS', label: 'SASL/JAAS' },

--- a/frontend/src/lib/hooks/api/__tests__/schema.spec.ts
+++ b/frontend/src/lib/hooks/api/__tests__/schema.spec.ts
@@ -5,6 +5,7 @@ import {
 } from 'lib/testHelpers';
 import fetchMock from 'fetch-mock';
 import * as hooks from 'lib/hooks/api/schemas';
+import { QUERY_REFETCH_LIMITED_OPTIONS } from 'lib/constants';
 import { act } from 'react-dom/test-utils';
 import { renderHook, waitFor } from '@testing-library/react';
 import { CompatibilityLevelCompatibilityEnum } from 'generated-sources';
@@ -44,6 +45,16 @@ describe('Schema hooks', () => {
         const mock = fetchMock.getOnce(schemasAPILatestUrl, schemaVersion);
         const { result } = renderQueryHook(() =>
           hooks.useGetLatestSchema({ clusterName, subject })
+        );
+        await expectQueryWorks(mock, result);
+      });
+      it('returns the correct data with queryOptions', async () => {
+        const mock = fetchMock.getOnce(schemasAPILatestUrl, schemaVersion);
+        const { result } = renderQueryHook(() =>
+          hooks.useGetLatestSchema(
+            { clusterName, subject },
+            QUERY_REFETCH_LIMITED_OPTIONS
+          )
         );
         await expectQueryWorks(mock, result);
       });

--- a/frontend/src/lib/hooks/api/__tests__/topics.spec.ts
+++ b/frontend/src/lib/hooks/api/__tests__/topics.spec.ts
@@ -50,7 +50,9 @@ describe('Topics hooks', () => {
   describe('useTopicConfig', () => {
     it('handles useTopicConfig', async () => {
       const mock = fetchMock.getOnce(`${topicPath}/config`, topicConfigPayload);
-      const { result } = renderQueryHook(() => hooks.useTopicConfig(topicParams));
+      const { result } = renderQueryHook(() =>
+        hooks.useTopicConfig(topicParams)
+      );
       await expectQueryWorks(mock, result);
     });
     it('handles useTopicConfig with queryOptions', async () => {

--- a/frontend/src/lib/hooks/api/__tests__/topics.spec.ts
+++ b/frontend/src/lib/hooks/api/__tests__/topics.spec.ts
@@ -9,6 +9,7 @@ import fetchMock from 'fetch-mock';
 import { externalTopicPayload, topicConfigPayload } from 'lib/fixtures/topics';
 import { CreateTopicMessage } from 'generated-sources';
 import { TopicFormData, TopicFormDataRaw } from 'lib/interfaces/topic';
+import { QUERY_REFETCH_LIMITED_OPTIONS } from 'lib/constants';
 
 const clusterName = 'test-cluster';
 const topicName = 'test-topic';
@@ -30,17 +31,35 @@ describe('Topics hooks', () => {
     const { result } = renderQueryHook(() => hooks.useTopics({ clusterName }));
     await expectQueryWorks(mock, result);
   });
-  it('handles useTopicDetails', async () => {
-    const mock = fetchMock.getOnce(topicPath, externalTopicPayload);
-    const { result } = renderQueryHook(() =>
-      hooks.useTopicDetails(topicParams)
-    );
-    await expectQueryWorks(mock, result);
+  describe('useTopicDetails', () => {
+    it('handles useTopicDetails', async () => {
+      const mock = fetchMock.getOnce(topicPath, externalTopicPayload);
+      const { result } = renderQueryHook(() =>
+        hooks.useTopicDetails(topicParams)
+      );
+      await expectQueryWorks(mock, result);
+    });
+    it('handles useTopicDetails with queryOptions', async () => {
+      const mock = fetchMock.getOnce(topicPath, externalTopicPayload);
+      const { result } = renderQueryHook(() =>
+        hooks.useTopicDetails(topicParams, QUERY_REFETCH_LIMITED_OPTIONS)
+      );
+      await expectQueryWorks(mock, result);
+    });
   });
-  it('handles useTopicConfig', async () => {
-    const mock = fetchMock.getOnce(`${topicPath}/config`, topicConfigPayload);
-    const { result } = renderQueryHook(() => hooks.useTopicConfig(topicParams));
-    await expectQueryWorks(mock, result);
+  describe('useTopicConfig', () => {
+    it('handles useTopicConfig', async () => {
+      const mock = fetchMock.getOnce(`${topicPath}/config`, topicConfigPayload);
+      const { result } = renderQueryHook(() => hooks.useTopicConfig(topicParams));
+      await expectQueryWorks(mock, result);
+    });
+    it('handles useTopicConfig with queryOptions', async () => {
+      const mock = fetchMock.getOnce(`${topicPath}/config`, topicConfigPayload);
+      const { result } = renderQueryHook(() =>
+        hooks.useTopicConfig(topicParams, QUERY_REFETCH_LIMITED_OPTIONS)
+      );
+      await expectQueryWorks(mock, result);
+    });
   });
   it('handles useTopicConsumerGroups', async () => {
     const mock = fetchMock.getOnce(`${topicPath}/consumer-groups`, []);

--- a/frontend/src/lib/hooks/api/schemas.ts
+++ b/frontend/src/lib/hooks/api/schemas.ts
@@ -1,11 +1,10 @@
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {useMutation, useQuery, useQueryClient, UseQueryOptions} from '@tanstack/react-query';
 import {
   GLOBAL_COMPATIBILITY_SCHEMAS_QUERY_KEY,
   LATEST_SCHEMA_QUERY_KEY,
   SCHEMA_QUERY_KEY,
   SCHEMAS_VERSION_QUERY_KEY,
 } from 'lib/queries';
-import { QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION } from 'lib/constants';
 import {
   CompatibilityLevel,
   GetAllVersionsBySubjectRequest,
@@ -20,7 +19,10 @@ import {
 import { schemasApiClient } from 'lib/api';
 import { ClusterName } from 'lib/interfaces/cluster';
 
-export function useGetLatestSchema(param: GetLatestSchemaRequest) {
+export function useGetLatestSchema(
+  param: GetLatestSchemaRequest,
+  options?: UseQueryOptions<SchemaSubject>
+) {
   return useQuery<SchemaSubject>({
     queryKey: [
       SCHEMA_QUERY_KEY,
@@ -29,7 +31,7 @@ export function useGetLatestSchema(param: GetLatestSchemaRequest) {
       param.subject,
     ],
     queryFn: () => schemasApiClient.getLatestSchema(param),
-    ...QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION,
+    ...options,
   });
 }
 

--- a/frontend/src/lib/hooks/api/schemas.ts
+++ b/frontend/src/lib/hooks/api/schemas.ts
@@ -1,4 +1,9 @@
-import {useMutation, useQuery, useQueryClient, UseQueryOptions} from '@tanstack/react-query';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseQueryOptions,
+} from '@tanstack/react-query';
 import {
   GLOBAL_COMPATIBILITY_SCHEMAS_QUERY_KEY,
   LATEST_SCHEMA_QUERY_KEY,

--- a/frontend/src/lib/hooks/api/schemas.ts
+++ b/frontend/src/lib/hooks/api/schemas.ts
@@ -5,6 +5,7 @@ import {
   SCHEMA_QUERY_KEY,
   SCHEMAS_VERSION_QUERY_KEY,
 } from 'lib/queries';
+import { QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION } from 'lib/constants';
 import {
   CompatibilityLevel,
   GetAllVersionsBySubjectRequest,
@@ -28,6 +29,7 @@ export function useGetLatestSchema(param: GetLatestSchemaRequest) {
       param.subject,
     ],
     queryFn: () => schemasApiClient.getLatestSchema(param),
+    ...QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION,
   });
 }
 

--- a/frontend/src/lib/hooks/api/topics.ts
+++ b/frontend/src/lib/hooks/api/topics.ts
@@ -4,7 +4,12 @@ import {
   consumerGroupsApiClient,
   messagesApiClient,
 } from 'lib/api';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  UseQueryOptions,
+} from '@tanstack/react-query';
 import {
   CreateTopicMessage,
   GetTopicDetailsRequest,
@@ -12,6 +17,7 @@ import {
   Topic,
   TopicConfig,
   TopicCreation,
+  TopicDetails,
   TopicUpdate,
 } from 'generated-sources';
 import { showServerError, showSuccessAlert } from 'lib/errorHandling';
@@ -21,7 +27,6 @@ import {
   TopicFormDataRaw,
   TopicFormFormattedParams,
 } from 'lib/interfaces/topic';
-import { QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION } from 'lib/constants';
 
 export const topicKeys = {
   all: (clusterName: ClusterName) =>
@@ -50,18 +55,24 @@ export function useTopics(props: GetTopicsRequest) {
     { keepPreviousData: true }
   );
 }
-export function useTopicDetails(props: GetTopicDetailsRequest) {
-  return useQuery(
+export function useTopicDetails(
+  props: GetTopicDetailsRequest,
+  queryOptions?: UseQueryOptions<TopicDetails>
+) {
+  return useQuery<TopicDetails>(
     topicKeys.details(props),
     () => api.getTopicDetails(props),
-    QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION
+    queryOptions
   );
 }
-export function useTopicConfig(props: GetTopicDetailsRequest) {
-  return useQuery(
+export function useTopicConfig(
+  props: GetTopicDetailsRequest,
+  queryOptions?: UseQueryOptions<TopicConfig[]>
+) {
+  return useQuery<TopicConfig[]>(
     topicKeys.config(props),
     () => api.getTopicConfigs(props),
-    QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION
+    queryOptions
   );
 }
 export function useTopicConsumerGroups(props: GetTopicDetailsRequest) {

--- a/frontend/src/lib/hooks/api/topics.ts
+++ b/frontend/src/lib/hooks/api/topics.ts
@@ -21,7 +21,7 @@ import {
   TopicFormDataRaw,
   TopicFormFormattedParams,
 } from 'lib/interfaces/topic';
-import {QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION} from "../../constants";
+import { QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION } from 'lib/constants';
 
 export const topicKeys = {
   all: (clusterName: ClusterName) =>
@@ -51,10 +51,18 @@ export function useTopics(props: GetTopicsRequest) {
   );
 }
 export function useTopicDetails(props: GetTopicDetailsRequest) {
-  return useQuery(topicKeys.details(props), () => api.getTopicDetails(props), QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION);
+  return useQuery(
+    topicKeys.details(props),
+    () => api.getTopicDetails(props),
+    QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION
+  );
 }
 export function useTopicConfig(props: GetTopicDetailsRequest) {
-  return useQuery(topicKeys.config(props), () => api.getTopicConfigs(props), QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION);
+  return useQuery(
+    topicKeys.config(props),
+    () => api.getTopicConfigs(props),
+    QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION
+  );
 }
 export function useTopicConsumerGroups(props: GetTopicDetailsRequest) {
   return useQuery(topicKeys.consumerGroups(props), () =>

--- a/frontend/src/lib/hooks/api/topics.ts
+++ b/frontend/src/lib/hooks/api/topics.ts
@@ -21,6 +21,7 @@ import {
   TopicFormDataRaw,
   TopicFormFormattedParams,
 } from 'lib/interfaces/topic';
+import {QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION} from "../../constants";
 
 export const topicKeys = {
   all: (clusterName: ClusterName) =>
@@ -50,10 +51,10 @@ export function useTopics(props: GetTopicsRequest) {
   );
 }
 export function useTopicDetails(props: GetTopicDetailsRequest) {
-  return useQuery(topicKeys.details(props), () => api.getTopicDetails(props));
+  return useQuery(topicKeys.details(props), () => api.getTopicDetails(props), QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION);
 }
 export function useTopicConfig(props: GetTopicDetailsRequest) {
-  return useQuery(topicKeys.config(props), () => api.getTopicConfigs(props));
+  return useQuery(topicKeys.config(props), () => api.getTopicConfigs(props), QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION);
 }
 export function useTopicConsumerGroups(props: GetTopicDetailsRequest) {
   return useQuery(topicKeys.consumerGroups(props), () =>


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Closes #348
I created a new constant QUERY_REFETCH_ON_WINDOW_FOCUS_OFF_OPTION that just has refetchOnWindowFocus false rather than

export const QUERY_REFETCH_OFF_OPTIONS = {
refetchOnMount: false,
refetchOnWindowFocus: false,
refetchIntervalInBackground: false,
};

I created this new constant because when all 3 options are provided, even when the Edit field is updated the UI will not reflect the changes until the page is refreshed. I added this constant to the two Edit components that fetch and place into editable fields.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/kafbat/kafka-ui/assets/63433735/7c2cee6b-625b-497c-806f-af7aa61d1dba)

