### PR TITLE
FE: Rename "max size on disk" to "Max partition size"

### DIFF
--- a/frontend/src/components/Topics/shared/Form/TopicForm.tsx
+++ b/frontend/src/components/Topics/shared/Form/TopicForm.tsx
@@ -206,7 +206,7 @@ const TopicForm: React.FC<Props> = ({
               id="topicFormRetentionBytesLabel"
               htmlFor="topicFormRetentionBytes"
             >
-              Max size on disk in GB
+              Max partition size in GB
             </InputLabel>
             <Controller
               control={control}

--- a/frontend/src/components/Topics/shared/Form/__tests__/TopicForm.spec.tsx
+++ b/frontend/src/components/Topics/shared/Form/__tests__/TopicForm.spec.tsx
@@ -52,7 +52,7 @@ describe('TopicForm', () => {
     expectByRoleAndNameToBeInDocument('button', '7 days');
     expectByRoleAndNameToBeInDocument('button', '4 weeks');
 
-    expectByRoleAndNameToBeInDocument('listbox', 'Max size on disk in GB');
+    expectByRoleAndNameToBeInDocument('listbox', 'Max partition size in GB');
     expectByRoleAndNameToBeInDocument(
       'spinbutton',
       'Maximum message size in bytes'


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Fixes [#86](https://github.com/kafbat/kafka-ui/issues/86)

I renamed input label "max size on disk" to "Max partition size"

**Is there anything you'd like reviewers to focus on?**

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)
