### PR TITLE
FE: Fix white dot on the "Key Serde" dropdown

### DIFF
--- a/frontend/src/components/common/Select/Select.styled.ts
+++ b/frontend/src/components/common/Select/Select.styled.ts
@@ -81,7 +81,7 @@ export const OptionList = styled.ul`
   line-height: 18px;
   color: ${({ theme }) => theme.select.color.normal};
   overflow-y: auto;
-  z-index: 10;
+  z-index: 12;
   max-width: 300px;
   min-width: 100%;
   align-items: center;


### PR DESCRIPTION
<!-- ignore-task-list-end -->
Increased `z-index` of select's dropdown element. Closes #394. Tested manually.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged



**A picture of a cute animal (not mandatory but encouraged)**
![image](https://github.com/kafbat/kafka-ui/assets/22551739/153b0eab-ad70-481e-b6c2-01d4e936bf53)

