### PR TITLE
FE: Wizard: Fix sections collapsing

### DIFF
--- a/frontend/src/widgets/ClusterConfigForm/Sections/Authentication/Authentication.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/Authentication/Authentication.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { AUTH_OPTIONS, SECURITY_PROTOCOL_OPTIONS } from 'lib/constants';
 import ControlledSelect from 'components/common/Select/ControlledSelect';

--- a/frontend/src/widgets/ClusterConfigForm/Sections/Authentication/Authentication.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/Authentication/Authentication.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import { useFormContext } from 'react-hook-form';
 import { AUTH_OPTIONS, SECURITY_PROTOCOL_OPTIONS } from 'lib/constants';
 import ControlledSelect from 'components/common/Select/ControlledSelect';
@@ -10,25 +10,28 @@ const Authentication: React.FC = () => {
   const { watch, setValue } = useFormContext();
   const hasAuth = !!watch('auth');
   const authMethod = watch('auth.method');
+  const [configOpen, setConfigOpen] = useState(false);
   const hasSecurityProtocolField =
     authMethod && !['Delegation tokens', 'mTLS'].includes(authMethod);
 
-  const toggle = () =>
-    setValue('auth', hasAuth ? undefined : {}, {
+  const toggle = () => {
+    setConfigOpen((prevConfigOpen) => !prevConfigOpen);
+    setValue('auth', hasAuth ? { isActive: false } : { isActive: true }, {
       shouldValidate: true,
       shouldDirty: true,
       shouldTouch: true,
     });
+  };
 
   return (
     <>
       <SectionHeader
         title="Authentication"
-        adding={!hasAuth}
+        adding={!configOpen}
         addButtonText="Configure Authentication"
         onClick={toggle}
       />
-      {hasAuth && (
+      {configOpen && (
         <>
           <ControlledSelect
             name="auth.method"

--- a/frontend/src/widgets/ClusterConfigForm/Sections/KSQL.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/KSQL.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import Input from 'components/common/Input/Input';
 import { useFormContext } from 'react-hook-form';
 import SectionHeader from 'widgets/ClusterConfigForm/common/SectionHeader';
@@ -8,7 +8,9 @@ import Credentials from 'widgets/ClusterConfigForm/common/Credentials';
 const KSQL = () => {
   const { setValue, watch } = useFormContext();
   const ksql = watch('ksql');
+  const [configOpen, setConfigOpen] = useState(false);
   const toggleConfig = () => {
+    setConfigOpen((prevConfigOpen) => !prevConfigOpen);
     setValue('ksql', ksql ? undefined : { url: '', isAuth: false }, {
       shouldValidate: true,
       shouldDirty: true,
@@ -19,11 +21,11 @@ const KSQL = () => {
     <>
       <SectionHeader
         title="KSQL DB"
-        adding={!ksql}
+        adding={!configOpen}
         addButtonText="Configure KSQL DB"
         onClick={toggleConfig}
       />
-      {ksql && (
+      {configOpen && (
         <>
           <Input
             label="URL *"

--- a/frontend/src/widgets/ClusterConfigForm/Sections/KSQL.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/KSQL.tsx
@@ -11,11 +11,12 @@ const KSQL = () => {
   const [configOpen, setConfigOpen] = useState(false);
   const toggleConfig = () => {
     setConfigOpen((prevConfigOpen) => !prevConfigOpen);
-    setValue('ksql', ksql ? undefined : { url: '', isAuth: false }, {
-      shouldValidate: true,
-      shouldDirty: true,
-      shouldTouch: true,
-    });
+    setValue('ksql', ksql ? { isActive: false } : { isActive: false, url: '', isAuth: false }, {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+      }
+    );
   };
   return (
     <>

--- a/frontend/src/widgets/ClusterConfigForm/Sections/KSQL.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/KSQL.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import Input from 'components/common/Input/Input';
 import { useFormContext } from 'react-hook-form';
 import SectionHeader from 'widgets/ClusterConfigForm/common/SectionHeader';

--- a/frontend/src/widgets/ClusterConfigForm/Sections/KSQL.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/KSQL.tsx
@@ -11,7 +11,10 @@ const KSQL = () => {
   const [configOpen, setConfigOpen] = useState(false);
   const toggleConfig = () => {
     setConfigOpen((prevConfigOpen) => !prevConfigOpen);
-    setValue('ksql', ksql ? { isActive: false } : { isActive: false, url: '', isAuth: false }, {
+    setValue(
+      'ksql',
+      ksql ? { isActive: false } : { isActive: false, url: '', isAuth: false },
+      {
         shouldValidate: true,
         shouldDirty: true,
         shouldTouch: true,

--- a/frontend/src/widgets/ClusterConfigForm/Sections/KafkaCluster.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/KafkaCluster.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import Input from 'components/common/Input/Input';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { FormError, InputHint } from 'components/common/Input/Input.styled';

--- a/frontend/src/widgets/ClusterConfigForm/Sections/KafkaCluster.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/KafkaCluster.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import Input from 'components/common/Input/Input';
 import { useFieldArray, useFormContext } from 'react-hook-form';
 import { FormError, InputHint } from 'components/common/Input/Input.styled';
@@ -21,19 +21,22 @@ const KafkaCluster: React.FC = () => {
     name: 'bootstrapServers',
   });
 
-  const hasTrustStore = !!watch('truststore');
+  const [hasTrustStore, setHasTrustStore] = useState(false);
 
-  const toggleSection = (section: string) => () =>
+  const toggleSection = (section: string) => () => {
+    setHasTrustStore((prevConfigOpen) => !prevConfigOpen);
     setValue(
       section,
       watch(section)
-        ? undefined
+        ? { isActive: false }
         : {
+            isActive: true,
             location: '',
             password: '',
           },
       { shouldValidate: true, shouldDirty: true, shouldTouch: true }
     );
+  };
 
   return (
     <>

--- a/frontend/src/widgets/ClusterConfigForm/Sections/Metrics.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/Metrics.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useState} from 'react';
 import Input from 'components/common/Input/Input';
 import { useFormContext } from 'react-hook-form';
 import ControlledSelect from 'components/common/Select/ControlledSelect';
@@ -11,28 +11,32 @@ import Credentials from 'widgets/ClusterConfigForm/common/Credentials';
 const Metrics = () => {
   const { setValue, watch } = useFormContext();
   const visibleMetrics = !!watch('metrics');
-  const toggleMetrics = () =>
+  const [configOpen, setConfigOpen] = useState(false);
+  const toggleMetrics = () => {
+    setConfigOpen((prevConfigOpen) => !prevConfigOpen);
     setValue(
       'metrics',
       visibleMetrics
-        ? undefined
+        ? { isActive: false }
         : {
+            isActive: true,
             type: '',
             port: 0,
             isAuth: false,
           },
       { shouldValidate: true, shouldDirty: true, shouldTouch: true }
     );
+  };
 
   return (
     <>
       <SectionHeader
         title="Metrics"
-        adding={!visibleMetrics}
+        adding={!configOpen}
         addButtonText="Configure Metrics"
         onClick={toggleMetrics}
       />
-      {visibleMetrics && (
+      {configOpen && (
         <>
           <ControlledSelect
             name="metrics.type"

--- a/frontend/src/widgets/ClusterConfigForm/Sections/Metrics.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/Metrics.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import Input from 'components/common/Input/Input';
 import { useFormContext } from 'react-hook-form';
 import ControlledSelect from 'components/common/Select/ControlledSelect';

--- a/frontend/src/widgets/ClusterConfigForm/Sections/SchemaRegistry.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/SchemaRegistry.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import Input from 'components/common/Input/Input';
 import { useFormContext } from 'react-hook-form';
 import SectionHeader from 'widgets/ClusterConfigForm/common/SectionHeader';
@@ -12,7 +11,12 @@ const SchemaRegistry = () => {
   const [configOpen, setConfigOpen] = useState(false);
   const toggleConfig = () => {
     setConfigOpen((prevConfigOpen) => !prevConfigOpen);
-    setValue('schemaRegistry', schemaRegistry ? { isActive: false }: { isActive: true, url: '', isAuth: false }, {
+    setValue(
+      'schemaRegistry',
+      schemaRegistry
+        ? { isActive: false }
+        : { isActive: true, url: '', isAuth: false },
+      {
         shouldValidate: true,
         shouldDirty: true,
         shouldTouch: true,

--- a/frontend/src/widgets/ClusterConfigForm/Sections/SchemaRegistry.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/SchemaRegistry.tsx
@@ -12,11 +12,12 @@ const SchemaRegistry = () => {
   const [configOpen, setConfigOpen] = useState(false);
   const toggleConfig = () => {
     setConfigOpen((prevConfigOpen) => !prevConfigOpen);
-    setValue('schemaRegistry', schemaRegistry ? undefined : { url: '', isAuth: false }, {
+    setValue('schemaRegistry', schemaRegistry ? { isActive: false }: { isActive: true, url: '', isAuth: false }, {
         shouldValidate: true,
         shouldDirty: true,
         shouldTouch: true,
-    });
+      }
+    );
   };
   return (
     <>

--- a/frontend/src/widgets/ClusterConfigForm/Sections/SchemaRegistry.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/SchemaRegistry.tsx
@@ -7,11 +7,16 @@ import SSLForm from 'widgets/ClusterConfigForm/common/SSLForm';
 import Credentials from 'widgets/ClusterConfigForm/common/Credentials';
 
 const SchemaRegistry = () => {
-  const { setValue } = useFormContext();
+  const { setValue, watch } = useFormContext();
+  const schemaRegistry = watch('schemaRegistry');
   const [configOpen, setConfigOpen] = useState(false);
   const toggleConfig = () => {
     setConfigOpen((prevConfigOpen) => !prevConfigOpen);
-    setValue('schemaRegistry', { url: '', isAuth: false });
+    setValue('schemaRegistry', schemaRegistry ? undefined : { url: '', isAuth: false }, {
+        shouldValidate: true,
+        shouldDirty: true,
+        shouldTouch: true,
+    });
   };
   return (
     <>

--- a/frontend/src/widgets/ClusterConfigForm/Sections/SchemaRegistry.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/SchemaRegistry.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useState } from 'react';
 import Input from 'components/common/Input/Input';
 import { useFormContext } from 'react-hook-form';
 import SectionHeader from 'widgets/ClusterConfigForm/common/SectionHeader';
@@ -6,24 +7,21 @@ import SSLForm from 'widgets/ClusterConfigForm/common/SSLForm';
 import Credentials from 'widgets/ClusterConfigForm/common/Credentials';
 
 const SchemaRegistry = () => {
-  const { setValue, watch } = useFormContext();
-  const schemaRegistry = watch('schemaRegistry');
+  const { setValue } = useFormContext();
+  const [configOpen, setConfigOpen] = useState(false);
   const toggleConfig = () => {
-    setValue(
-      'schemaRegistry',
-      schemaRegistry ? undefined : { url: '', isAuth: false },
-      { shouldValidate: true, shouldDirty: true, shouldTouch: true }
-    );
+    setConfigOpen((prevConfigOpen) => !prevConfigOpen);
+    setValue('schemaRegistry', { url: '', isAuth: false });
   };
   return (
     <>
       <SectionHeader
         title="Schema Registry"
-        adding={!schemaRegistry}
+        adding={!configOpen}
         addButtonText="Configure Schema Registry"
         onClick={toggleConfig}
       />
-      {schemaRegistry && (
+      {configOpen && (
         <>
           <Input
             label="URL *"

--- a/frontend/src/widgets/ClusterConfigForm/types.ts
+++ b/frontend/src/widgets/ClusterConfigForm/types.ts
@@ -20,6 +20,7 @@ type WithAuth = {
 type URLWithAuth = WithAuth &
   WithKeystore & {
     url?: string;
+    isActive?: string;
   };
 
 type KafkaConnect = WithAuth &
@@ -30,6 +31,7 @@ type KafkaConnect = WithAuth &
 
 type Metrics = WithAuth &
   WithKeystore & {
+    isActive?: string;
     type: string;
     port: string;
   };
@@ -43,6 +45,7 @@ export type ClusterConfigFormValues = {
     password: string;
   };
   auth?: WithKeystore & {
+    isActive?: string;
     method: string;
     securityProtocol: SecurityProtocol;
     props: Record<string, string>;

--- a/frontend/src/widgets/ClusterConfigForm/utils/transformFormDataToPayload.ts
+++ b/frontend/src/widgets/ClusterConfigForm/utils/transformFormDataToPayload.ts
@@ -52,7 +52,7 @@ export const transformFormDataToPayload = (data: ClusterConfigFormValues) => {
   }
 
   // Schema Registry
-  if (data.schemaRegistry) {
+  if (data.schemaRegistry?.isActive) {
     config.schemaRegistry = data.schemaRegistry.url;
     config.schemaRegistryAuth = transformToCredentials(
       data.schemaRegistry.isAuth,
@@ -65,7 +65,7 @@ export const transformFormDataToPayload = (data: ClusterConfigFormValues) => {
   }
 
   // KSQL
-  if (data.ksql) {
+  if (data.ksql?.isActive) {
     config.ksqldbServer = data.ksql.url;
     config.ksqldbServerAuth = transformToCredentials(
       data.ksql.isAuth,
@@ -88,7 +88,7 @@ export const transformFormDataToPayload = (data: ClusterConfigFormValues) => {
   }
 
   // Metrics
-  if (data.metrics) {
+  if (data.metrics?.isActive) {
     config.metrics = {
       type: data.metrics.type,
       port: Number(data.metrics.port),
@@ -106,7 +106,7 @@ export const transformFormDataToPayload = (data: ClusterConfigFormValues) => {
   };
 
   // Authentication
-  if (data.auth) {
+  if (data.auth?.isActive) {
     const { method, props, securityProtocol, keystore } = data.auth;
     switch (method) {
       case 'SASL/JAAS':


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
I update the configure cluster sections to open and close properly. Prior to this change they would open, but not close consistently. I added a configOpen variable to manage this. Rather than passing undefined when the form is closed it now sets it to an {isActive: false}. Then the data is reset in transformFormDataToPayload based on that actual flag rather than null checking.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

<img width="1510" alt="Screenshot 2024-05-17 at 12 07 05 PM" src="https://github.com/kafbat/kafka-ui/assets/63433735/b8d4fe04-8173-486a-815c-522c016b39a7">

