### PR TITLE
Added search filters for kafka connect

### DIFF
--- a/frontend/src/components/Connect/List/List.tsx
+++ b/frontend/src/components/Connect/List/List.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 import useAppParams from 'lib/hooks/useAppParams';
 import { clusterConnectConnectorPath, ClusterNameRoute } from 'lib/paths';
 import Table, { TagCell } from 'components/common/NewTable';
-import { FullConnectorInfo } from 'generated-sources';
+import {
+  ConnectorState,
+  ConnectorType,
+  FullConnectorInfo,
+} from 'generated-sources';
 import { useConnectors } from 'lib/hooks/api/kafkaConnect';
 import { ColumnDef } from '@tanstack/react-table';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 import ActionsCell from './ActionsCell';
 import TopicsCell from './TopicsCell';
@@ -14,11 +18,7 @@ import RunningTasksCell from './RunningTasksCell';
 const List: React.FC = () => {
   const navigate = useNavigate();
   const { clusterName } = useAppParams<ClusterNameRoute>();
-  const [searchParams] = useSearchParams();
-  const { data: connectors } = useConnectors(
-    clusterName,
-    searchParams.get('q') || ''
-  );
+  const { data: connectors } = useConnectors(clusterName);
 
   const columns = React.useMemo<ColumnDef<FullConnectorInfo>[]>(
     () => [
@@ -34,6 +34,63 @@ const List: React.FC = () => {
     []
   );
 
+  const connectorTypeOptions = Object.values(ConnectorType).map((state) => ({
+    label: state,
+    value: state,
+  }));
+
+  const connectorStateOptions = Object.values(ConnectorState).map((state) => ({
+    label: state,
+    value: state,
+  }));
+
+  const columnSearchPlaceholders: {
+    id: string;
+    columnName: string;
+    placeholder: string;
+    type: string;
+    options?: { label: string; value: string }[];
+  }[] = [
+    {
+      id: 'name',
+      columnName: 'name',
+      placeholder: 'Search by Name',
+      type: 'input',
+    },
+    {
+      id: 'connect',
+      columnName: 'connect',
+      placeholder: 'Search by Connect',
+      type: 'input',
+    },
+    {
+      id: 'type',
+      columnName: 'type',
+      placeholder: 'Select Type',
+      type: 'autocomplete',
+      options: connectorTypeOptions,
+    },
+    {
+      id: 'connectorClass',
+      columnName: 'connectorClass',
+      placeholder: 'Search by Plugin',
+      type: 'input',
+    },
+    {
+      id: 'Topics',
+      columnName: 'topics',
+      placeholder: 'Search by Topics',
+      type: 'multiInput',
+    },
+    {
+      id: 'status_state',
+      columnName: 'status',
+      placeholder: 'Select Status',
+      type: 'autocomplete',
+      options: connectorStateOptions,
+    },
+  ];
+
   return (
     <Table
       data={connectors || []}
@@ -44,6 +101,8 @@ const List: React.FC = () => {
       }
       emptyMessage="No connectors found"
       setRowId={(originalRow) => `${originalRow.name}-${originalRow.connect}`}
+      enableColumnSearch
+      columnSearchPlaceholders={columnSearchPlaceholders}
     />
   );
 };

--- a/frontend/src/components/Connect/List/ListPage.tsx
+++ b/frontend/src/components/Connect/List/ListPage.tsx
@@ -2,11 +2,9 @@ import React, { Suspense } from 'react';
 import useAppParams from 'lib/hooks/useAppParams';
 import { ClusterNameRoute, clusterConnectorNewRelativePath } from 'lib/paths';
 import ClusterContext from 'components/contexts/ClusterContext';
-import Search from 'components/common/Search/Search';
 import * as Metrics from 'components/common/Metrics';
 import PageHeading from 'components/common/PageHeading/PageHeading';
 import Tooltip from 'components/common/Tooltip/Tooltip';
-import { ControlPanelWrapper } from 'components/common/ControlPanel/ControlPanel.styled';
 import PageLoader from 'components/common/PageLoader/PageLoader';
 import { ConnectorState, Action, ResourceType } from 'generated-sources';
 import { useConnectors, useConnects } from 'lib/hooks/api/kafkaConnect';
@@ -81,9 +79,6 @@ const ListPage: React.FC = () => {
           </Metrics.Indicator>
         </Metrics.Section>
       </Metrics.Wrapper>
-      <ControlPanelWrapper hasInput>
-        <Search placeholder="Search by Connect Name, Status or Type" />
-      </ControlPanelWrapper>
       <Suspense fallback={<PageLoader />}>
         <List />
       </Suspense>

--- a/frontend/src/components/common/Input/Input.styled.ts
+++ b/frontend/src/components/common/Input/Input.styled.ts
@@ -13,6 +13,7 @@ const INPUT_SIZES = {
 
 export const Wrapper = styled.div`
   position: relative;
+  min-width: 200px;
   &:hover {
     svg:first-child {
       fill: ${({ theme }) => theme.input.icon.hover};
@@ -52,6 +53,7 @@ export const Input = styled.input<InputProps>(
       : '40px'};
     width: 100%;
     padding-left: ${search ? '36px' : '12px'};
+    padding-right: 30px;
     font-size: 14px;
 
     &::placeholder {

--- a/frontend/src/components/common/MultiSearch/MultiSearch.styled.ts
+++ b/frontend/src/components/common/MultiSearch/MultiSearch.styled.ts
@@ -1,0 +1,130 @@
+import styled, { css } from 'styled-components';
+import { ComponentProps } from 'react';
+
+export interface InputProps extends ComponentProps<'input'> {
+  values?: string[];
+  inputSize?: 'S' | 'M' | 'L';
+  searchIcon?: boolean;
+  isFocused?: boolean;
+}
+
+const INPUT_SIZES = {
+  S: 18,
+  M: 32,
+  L: 40,
+};
+
+export const Wrapper = styled.div<InputProps>(
+  ({ theme: { input } }) => css`
+    position: relative;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 8px;
+    border: 1px solid ${input.borderColor.normal};
+    padding: 6px 32px 6px 12px;
+    border-radius: 4px;
+    min-width: 250px;
+    background-color: ${input.backgroundColor.normal};
+
+    &::placeholder {
+      color: ${input.color.placeholder.normal};
+      font-size: 14px;
+    }
+
+    &:hover {
+      border-color: ${input.borderColor.hover};
+    }
+
+    &:focus {
+      outline: none;
+      border-color: ${input.borderColor.focus};
+      &::placeholder {
+        color: transparent;
+      }
+    }
+  `
+);
+
+export const ValuesContainer = styled.div<InputProps>(
+  ({ isFocused }) => css`
+    display: flex;
+    align-items: center;
+    flex-wrap: ${isFocused ? 'nowrap' : 'wrap'};
+    gap: 8px;
+    flex-grow: 1;
+  `
+);
+
+export const Tag = styled.div`
+  display: flex;
+  align-items: center;
+  background-color: ${({ theme }) => theme.tag.backgroundColor.blue};
+  color: ${({ theme }) => theme.tag.color};
+  border-radius: 12px;
+  padding: 2px 0 2px 8px;
+  font-size: 12px;
+`;
+
+export const RemoveButton = styled.button`
+  background: none;
+  border: none;
+  margin-left: 2px;
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  color: ${({ theme }) => theme.tag.color};
+
+  &:hover {
+    color: ${({ theme }) => theme.tag.backgroundColor};
+  }
+`;
+
+export const Input = styled.input<InputProps>(
+  ({ theme: { input }, inputSize, values }) => css`
+    flex-grow: 1;
+    background-color: ${input.backgroundColor.normal};
+    border: none;
+    color: ${input.color.normal};
+    height: ${inputSize ? `${INPUT_SIZES[inputSize]}px` : '32px'};
+    font-size: 14px;
+    box-sizing: border-box;
+    width: ${values ? `15px` : '32px'};
+
+    &::placeholder {
+      color: ${input.color.placeholder.normal};
+      font-size: 14px;
+    }
+
+    &:focus {
+      outline: none;
+      &::placeholder {
+        color: transparent;
+      }
+    }
+  `
+);
+
+export const IconButtonWrapper = styled.span.attrs(() => ({
+  role: 'button',
+  tabIndex: 0,
+}))`
+  position: absolute;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  &:hover {
+    cursor: pointer;
+  }
+`;
+
+export const RemainingTagCount = styled.span`
+  font-size: 14px;
+  color: ${({ theme }) => theme.input.color.normal};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;

--- a/frontend/src/components/common/MultiSearch/MultiSearch.tsx
+++ b/frontend/src/components/common/MultiSearch/MultiSearch.tsx
@@ -61,6 +61,7 @@ const MultiSearch: React.FC<MultiSearchProps> = ({
   };
 
   const clearAll = () => {
+    setInputValue('');
     if (onChange) {
       onChange('', []);
     }

--- a/frontend/src/components/common/MultiSearch/MultiSearch.tsx
+++ b/frontend/src/components/common/MultiSearch/MultiSearch.tsx
@@ -1,0 +1,115 @@
+import React, { useRef, useState } from 'react';
+import useClickOutside from 'lib/hooks/useClickOutside';
+import CloseCircleIcon from 'components/common/Icons/CloseCircleIcon';
+import SearchIcon from 'components/common/Icons/SearchIcon';
+
+import * as S from './MultiSearch.styled';
+
+export interface MultiSearchProps extends Omit<S.InputProps, 'onChange'> {
+  name: string;
+  value?: string;
+  values?: string[];
+  onChange?: (value: string, values: string[]) => void;
+  inputSize?: 'S' | 'M' | 'L';
+  placeholder?: string;
+  searchIcon?: boolean;
+}
+
+const MAX_VISIBLE_TAGS = 1;
+
+const MultiSearch: React.FC<MultiSearchProps> = ({
+  name,
+  value = '',
+  values = [],
+  onChange,
+  inputSize = 'S',
+  placeholder = '',
+  searchIcon = true,
+  ...rest
+}) => {
+  const [inputValue, setInputValue] = useState(value);
+  const [showAllTags, setShowAllTags] = useState(false);
+
+  const selectContainerRef = useRef(null);
+
+  const handleKeyEnter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && inputValue.trim()) {
+      const trimmedValue = inputValue.trim();
+      if (!values.includes(trimmedValue)) {
+        const newValues = [...values, trimmedValue];
+        if (onChange) {
+          onChange('', newValues);
+        }
+      }
+      setInputValue('');
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setInputValue(newValue);
+    if (onChange) {
+      onChange(newValue, values);
+    }
+  };
+
+  const handleRemove = (valueToRemove: string) => {
+    const newValues = values.filter((tagValue) => tagValue !== valueToRemove);
+    if (onChange) {
+      onChange(inputValue, newValues);
+    }
+  };
+
+  const clearAll = () => {
+    if (onChange) {
+      onChange('', []);
+    }
+  };
+
+  const handleFocus = () => {
+    setShowAllTags(true);
+  };
+
+  const clickOutsideHandler = () => {
+    setShowAllTags(false);
+  };
+  useClickOutside(selectContainerRef, clickOutsideHandler);
+
+  const visibleTags = showAllTags ? values : values.slice(0, MAX_VISIBLE_TAGS);
+  const remainingTagsCount = values.length - MAX_VISIBLE_TAGS;
+
+  return (
+    <S.Wrapper ref={selectContainerRef}>
+      {searchIcon && <SearchIcon />}
+      <S.ValuesContainer>
+        {visibleTags.map((tagValue) => (
+          <S.Tag key={tagValue}>
+            {tagValue}
+            <S.RemoveButton onClick={() => handleRemove(tagValue)}>
+              <CloseCircleIcon />
+            </S.RemoveButton>
+          </S.Tag>
+        ))}
+        {!showAllTags && remainingTagsCount > 0 && (
+          <S.RemainingTagCount>+{remainingTagsCount}</S.RemainingTagCount>
+        )}
+        <S.Input
+          {...rest}
+          value={inputValue}
+          values={values}
+          placeholder={values.length <= MAX_VISIBLE_TAGS ? placeholder : name}
+          inputSize={inputSize}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyEnter}
+          onFocus={handleFocus}
+          isFocused={showAllTags}
+        />
+      </S.ValuesContainer>
+      <S.IconButtonWrapper onClick={clearAll}>
+        <CloseCircleIcon />
+      </S.IconButtonWrapper>
+    </S.Wrapper>
+  );
+};
+
+export default MultiSearch;

--- a/frontend/src/components/common/Search/Search.tsx
+++ b/frontend/src/components/common/Search/Search.tsx
@@ -10,6 +10,7 @@ interface SearchProps {
   disabled?: boolean;
   onChange?: (value: string) => void;
   value?: string;
+  searchIcon?: boolean;
 }
 
 const IconButtonWrapper = styled.span.attrs(() => ({
@@ -27,6 +28,7 @@ const Search: React.FC<SearchProps> = ({
   disabled = false,
   value,
   onChange,
+  searchIcon = true,
 }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const ref = useRef<ComponentRef<'input'>>(null);
@@ -70,7 +72,7 @@ const Search: React.FC<SearchProps> = ({
       inputSize="M"
       disabled={disabled}
       ref={ref}
-      search
+      search={searchIcon}
       clearIcon={
         <IconButtonWrapper onClick={clearSearchValue}>
           <CloseCircleIcon />

--- a/frontend/src/components/common/SearchAutocomplete/SearchAutocomplete.styled.ts
+++ b/frontend/src/components/common/SearchAutocomplete/SearchAutocomplete.styled.ts
@@ -1,0 +1,141 @@
+import styled, { css } from 'styled-components';
+import { ComponentProps } from 'react';
+
+export interface InputProps extends ComponentProps<'input'> {
+  inputSize?: 'S' | 'M' | 'L';
+  searchIcon?: boolean;
+}
+
+const INPUT_SIZES = {
+  S: 24,
+  M: 32,
+  L: 40,
+};
+
+interface OptionProps {
+  disabled?: boolean;
+  isHighlighted?: boolean;
+}
+
+export const Wrapper = styled.div`
+  position: relative;
+  min-width: 200px;
+  &:hover {
+    svg:first-child {
+      fill: ${({ theme }) => theme.input.icon.hover};
+    }
+  }
+  svg:first-child {
+    position: absolute;
+    top: 8px;
+    line-height: 0;
+    z-index: 1;
+    left: 12px;
+    right: unset;
+    height: 16px;
+    width: 16px;
+    fill: ${({ theme }) => theme.input.icon.color};
+  }
+  svg:last-child {
+    position: absolute;
+    top: 8px;
+    line-height: 0;
+    z-index: 1;
+    left: unset;
+    right: 12px;
+    height: 16px;
+    width: 16px;
+  }
+`;
+
+export const Input = styled.input<InputProps>(
+  ({ theme: { input }, inputSize, searchIcon }) => css`
+    background-color: ${input.backgroundColor.normal};
+    border: 1px ${input.borderColor.normal} solid;
+    border-radius: 4px;
+    color: ${input.color.normal};
+    height: ${inputSize ? `${INPUT_SIZES[inputSize]}px` : '32px'};
+    width: 100%;
+    padding-left: ${searchIcon ? '36px' : '12px'};
+    padding-right: 30px;
+    font-size: 14px;
+    box-sizing: border-box;
+
+    &::placeholder {
+      color: ${input.color.placeholder.normal};
+      font-size: 14px;
+    }
+    &:hover {
+      border-color: ${input.borderColor.hover};
+    }
+    &:focus {
+      outline: none;
+      border-color: ${input.borderColor.focus};
+      &::placeholder {
+        color: transparent;
+      }
+    }
+    &:read-only {
+      color: ${input.color.readOnly};
+      border: none;
+      background-color: ${input.backgroundColor.readOnly};
+      cursor: not-allowed;
+    }
+  `
+);
+
+export type StyledInputProps = ComponentProps<typeof Input>;
+
+export const OptionList = styled.ul`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  max-height: 228px;
+  margin-top: 4px;
+  background-color: ${({ theme }) => theme.select.backgroundColor.normal};
+  border: 1px ${({ theme }) => theme.select.borderColor.normal} solid;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 18px;
+  color: ${({ theme }) => theme.select.color.normal};
+  overflow-y: auto;
+  z-index: 10;
+  max-width: 100%;
+  min-width: 100%;
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+`;
+
+export const Option = styled.li<OptionProps>`
+  display: flex;
+  align-items: center;
+  list-style: none;
+  padding: 10px 12px;
+  transition: all 0.2s ease-in-out;
+  cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  gap: 5px;
+  color: ${({ theme, disabled }) =>
+    theme.select.color[disabled ? 'disabled' : 'normal']};
+  background-color: ${({ isHighlighted, theme }) =>
+    isHighlighted ? theme.select.backgroundColor.hover : 'transparent'};
+
+  &:hover {
+    background-color: ${({ theme, disabled }) =>
+      disabled ? 'transparent' : theme.select.backgroundColor.hover};
+  }
+
+  &:active {
+    background-color: ${({ theme }) => theme.select.backgroundColor.active};
+  }
+`;
+
+export const IconButtonWrapper = styled.span.attrs(() => ({
+  role: 'button',
+  tabIndex: 0,
+}))`
+  display: inline-block;
+  &:hover {
+    cursor: pointer;
+  }
+`;

--- a/frontend/src/components/common/SearchAutocomplete/SearchAutocomplete.tsx
+++ b/frontend/src/components/common/SearchAutocomplete/SearchAutocomplete.tsx
@@ -1,0 +1,156 @@
+import React, { useRef, useEffect, useState } from 'react';
+import useClickOutside from 'lib/hooks/useClickOutside';
+import { SelectOption } from 'components/common/Select/Select';
+import CloseCircleIcon from 'components/common/Icons/CloseCircleIcon';
+import SearchIcon from 'components/common/Icons/SearchIcon';
+
+import * as S from './SearchAutocomplete.styled';
+
+export interface SearchAutocompleteProps
+  extends Omit<S.StyledInputProps, 'onChange'> {
+  options: SelectOption<string>[];
+  value?: string;
+  onChange?: (option: string) => void;
+  inputSize?: 'S' | 'M' | 'L';
+  minWidth?: string;
+  placeholder?: string;
+  searchIcon?: boolean;
+}
+
+const SearchAutocomplete: React.FC<SearchAutocompleteProps> = ({
+  options = [],
+  value = '',
+  onChange,
+  inputSize = 'M',
+  placeholder = '',
+  minWidth,
+  searchIcon = true,
+  ...rest
+}) => {
+  const [inputValue, setInputValue] = useState(value);
+  const [showOptions, setShowOptions] = useState(false);
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(0);
+
+  const selectContainerRef = useRef(null);
+  const optionListRef = useRef<HTMLUListElement>(null);
+
+  const clickOutsideHandler = () => {
+    const isDisabledOption = (optionText: string) =>
+      options.some((option) => option.value === optionText && option.disabled);
+
+    if (!isDisabledOption(value) && showOptions) {
+      onChange?.(inputValue);
+    }
+
+    setShowOptions(false);
+    setHighlightedIndex(0);
+  };
+  useClickOutside(selectContainerRef, clickOutsideHandler);
+
+  const filteredOptions = options.filter((option) =>
+    option?.label?.toString().toLowerCase().includes(inputValue.toLowerCase())
+  );
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputValue(e.target.value);
+    setShowOptions(true);
+    if (onChange) {
+      onChange(e.target.value);
+    }
+  };
+
+  const handleOptionClick = (option: SelectOption<string>, index: number) => {
+    setInputValue(option?.value);
+    setShowOptions(false);
+    if (onChange) {
+      onChange(option.value);
+    }
+    setHighlightedIndex(index);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setHighlightedIndex((prev) =>
+        Math.min(prev + 1, filteredOptions.length - 1)
+      );
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (highlightedIndex >= 0 && highlightedIndex < filteredOptions.length) {
+        handleOptionClick(filteredOptions[highlightedIndex], highlightedIndex);
+      }
+    }
+  };
+
+  useEffect(() => {
+    if (optionListRef.current && highlightedIndex >= 0) {
+      const option = optionListRef.current.children[
+        highlightedIndex
+      ] as HTMLElement;
+      if (option) {
+        const optionRect = option.getBoundingClientRect();
+        const listRect = optionListRef.current.getBoundingClientRect();
+        if (optionRect.bottom > listRect.bottom) {
+          optionListRef.current.scrollTop +=
+            optionRect.bottom - listRect.bottom;
+        } else if (optionRect.top < listRect.top) {
+          optionListRef.current.scrollTop -= listRect.top - optionRect.top;
+        }
+      }
+    }
+  }, [highlightedIndex]);
+
+  const clearSearchValue = () => {
+    setInputValue('');
+    setShowOptions(false);
+    setHighlightedIndex(0);
+    if (onChange) {
+      onChange('');
+    }
+  };
+
+  return (
+    <S.Wrapper ref={selectContainerRef}>
+      {searchIcon && <SearchIcon />}
+      <S.Input
+        {...rest}
+        role="listitem"
+        value={inputValue}
+        onFocus={() => setShowOptions(true)}
+        autoComplete="off"
+        placeholder={placeholder}
+        inputSize={inputSize}
+        onChange={handleInputChange}
+        onKeyDown={handleKeyDown}
+      />
+      {showOptions && (
+        <S.OptionList role="listbox" ref={optionListRef}>
+          {filteredOptions.length > 0 ? (
+            filteredOptions.map((option, index) => (
+              <S.Option
+                role="option"
+                key={option.value}
+                disabled={option.disabled}
+                isHighlighted={index === highlightedIndex}
+                onClick={() => handleOptionClick(option, index)}
+              >
+                {option.label}
+              </S.Option>
+            ))
+          ) : (
+            <S.Option disabled>No results</S.Option>
+          )}
+        </S.OptionList>
+      )}
+
+      <S.IconButtonWrapper onClick={clearSearchValue}>
+        <CloseCircleIcon />
+      </S.IconButtonWrapper>
+    </S.Wrapper>
+  );
+};
+
+export default SearchAutocomplete;


### PR DESCRIPTION
**What changes did you make?**

Implemented a new filtering mechanism for the connectors grid in Kafka UI. Instead of a single search field, users can now filter by individual fields: Name, Connect, Type, Plugin, Topics, and Status. The filtering logic applies a logical "AND" across these fields.

**Is there anything you'd like reviewers to focus on?**

Please review the filtering functionality to ensure that each field is correctly applied.
