### PR TITLE
FE: CG: Fix names display overflow issue

### DIFF
--- a/frontend/src/components/common/NewTable/Table.styled.ts
+++ b/frontend/src/components/common/NewTable/Table.styled.ts
@@ -154,7 +154,6 @@ export const Table = styled.table(
     word-wrap: break-word;
 
     &:first-of-type {
-      max-width: 530px;
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/frontend/src/components/common/NewTable/Table.styled.ts
+++ b/frontend/src/components/common/NewTable/Table.styled.ts
@@ -153,24 +153,30 @@ export const Table = styled.table(
     vertical-align: middle;
     word-wrap: break-word;
 
-    & a {
-      color: ${table.td.color.normal};
-      font-weight: 500;
-      max-width: 450px;
-      white-space: nowrap;
+    &:first-of-type {
+      max-width: 530px;
       overflow: hidden;
       text-overflow: ellipsis;
-      display: block;
+      white-space: nowrap;
 
-      &:hover {
+      & a {
+        color: ${table.td.color.normal};
+        font-weight: 500;
+        max-width: 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+
+        &:hover {
         color: ${table.link.color.hover};
-      }
+        }
 
-      &:active {
+        &:active {
+          color: ${table.link.color.active};
+        }
+        &:button {
         color: ${table.link.color.active};
-      }
-      &:button {
-      color: ${table.link.color.active};
+        }
       }
 
     }

--- a/frontend/src/components/common/NewTable/Table.styled.ts
+++ b/frontend/src/components/common/NewTable/Table.styled.ts
@@ -157,6 +157,7 @@ export const Table = styled.table(
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      max-width: 150ch;
 
       & a {
         color: ${table.td.color.normal};

--- a/frontend/src/components/common/NewTable/Table.styled.ts
+++ b/frontend/src/components/common/NewTable/Table.styled.ts
@@ -153,32 +153,43 @@ export const Table = styled.table(
     vertical-align: middle;
     word-wrap: break-word;
 
-    &:first-of-type {
+    & a {
+      color: ${table.td.color.normal};
+      font-weight: 500;
+      max-width: 150ch;
+      white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
-      white-space: nowrap;
-      max-width: 150ch;
+      display: block;
 
-      & a {
-        color: ${table.td.color.normal};
-        font-weight: 500;
-        max-width: 100%;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-
-        &:hover {
+      &:hover {
         color: ${table.link.color.hover};
-        }
-
-        &:active {
-          color: ${table.link.color.active};
-        }
-        &:button {
-        color: ${table.link.color.active};
-        }
       }
 
+      &:active {
+        color: ${table.link.color.active};
+      }
+      &:button {
+      color: ${table.link.color.active};
+      }
+    }
+
+    @media (max-width: 1500px) {
+      & a {
+        max-width: 70ch;
+      }
+    }
+
+    @media (max-width: 1024px) {
+      & a {
+        max-width: 50ch;
+      }
+    }
+
+    @media (max-width: 768px) {
+      & a {
+        max-width: 40ch;
+      }
     }
   }
 `


### PR DESCRIPTION
**What changes did you make?**

This pull request addresses a bug in Kafka UI where consumer group IDs sometimes appear truncated due to insufficient space for display. The issue affects the readability of consumer group names on the consumer groups page.

**Changes Include:**
- Improved the layout of consumer group IDs to ensure they are displayed correctly based on the available space.

**Is there anything you'd like reviewers to focus on?**

Please review the changes to confirm:
- Consumer group names are fully visible and properly formatted according to the available space.

Fixes #528 