### PR TITLE
Brokers: Improve accessibility for r/o clusters

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/ReadOnlyModeFilter.java
+++ b/api/src/main/java/io/kafbat/ui/config/ReadOnlyModeFilter.java
@@ -25,7 +25,7 @@ public class ReadOnlyModeFilter implements WebFilter {
       Pattern.compile("/api/clusters/(?<clusterName>[^/]++)");
 
   private static final Set<Pattern> SAFE_ENDPOINTS = Set.of(
-      Pattern.compile("/api/clusters/[^/]+/topics/[^/]+/(smartfilters)$")
+      Pattern.compile("/api/clusters/[^/]+/topics/[^/]+/(smartfilters|analysis)$")
   );
 
   private final ClustersStorage clustersStorage;

--- a/api/src/main/java/io/kafbat/ui/model/InternalBrokerConfig.java
+++ b/api/src/main/java/io/kafbat/ui/model/InternalBrokerConfig.java
@@ -16,12 +16,12 @@ public class InternalBrokerConfig {
   private final boolean isReadOnly;
   private final List<ConfigEntry.ConfigSynonym> synonyms;
 
-  public static InternalBrokerConfig from(ConfigEntry configEntry) {
+  public static InternalBrokerConfig from(ConfigEntry configEntry, boolean readOnlyCluster) {
     InternalBrokerConfig.InternalBrokerConfigBuilder builder = InternalBrokerConfig.builder()
         .name(configEntry.name())
         .value(configEntry.value())
         .source(configEntry.source())
-        .isReadOnly(configEntry.isReadOnly())
+        .isReadOnly(readOnlyCluster || configEntry.isReadOnly())
         .isSensitive(configEntry.isSensitive())
         .synonyms(configEntry.synonyms());
     return builder.build();

--- a/api/src/main/java/io/kafbat/ui/service/BrokerService.java
+++ b/api/src/main/java/io/kafbat/ui/service/BrokerService.java
@@ -59,7 +59,7 @@ public class BrokerService {
     }
     return loadBrokersConfig(cluster, brokerId)
         .map(list -> list.stream()
-            .map(InternalBrokerConfig::from)
+            .map(configEntry -> InternalBrokerConfig.from(configEntry, cluster.isReadOnly()))
             .collect(Collectors.toList()))
         .flatMapMany(Flux::fromIterable);
   }

--- a/frontend/src/components/Brokers/Broker/Configs/TableComponents/InputCell/InputCellViewMode.tsx
+++ b/frontend/src/components/Brokers/Broker/Configs/TableComponents/InputCell/InputCellViewMode.tsx
@@ -31,8 +31,8 @@ const InputCellViewMode: FC<InputCellViewModeProps> = ({
   );
 
   return (
-    <S.ValueWrapper $isDynamic={isDynamic}>
-      <S.Value title={title}>{displayValue}</S.Value>
+    <S.ValueWrapper>
+      <S.Value $isDynamic={isDynamic} title={title}>{displayValue}</S.Value>
       <Tooltip
         value={
           <Button

--- a/frontend/src/components/Brokers/Broker/Configs/TableComponents/InputCell/InputCellViewMode.tsx
+++ b/frontend/src/components/Brokers/Broker/Configs/TableComponents/InputCell/InputCellViewMode.tsx
@@ -32,7 +32,9 @@ const InputCellViewMode: FC<InputCellViewModeProps> = ({
 
   return (
     <S.ValueWrapper>
-      <S.Value $isDynamic={isDynamic} title={title}>{displayValue}</S.Value>
+      <S.Value $isDynamic={isDynamic} title={title}>
+        {displayValue}
+      </S.Value>
       <Tooltip
         value={
           <Button

--- a/frontend/src/components/Brokers/Broker/Configs/TableComponents/InputCell/styled.ts
+++ b/frontend/src/components/Brokers/Broker/Configs/TableComponents/InputCell/styled.ts
@@ -1,22 +1,23 @@
 import styled from 'styled-components';
 
-export const ValueWrapper = styled.div<{ $isDynamic?: boolean }>`
+export const ValueWrapper = styled.div`
   display: flex;
   justify-content: space-between;
-  font-weight: ${({ $isDynamic }) => ($isDynamic ? 600 : 400)};
+  font-weight: 400;
 
   button {
     margin: 0 10px;
   }
 `;
 
-export const Value = styled.span`
+export const Value = styled.span<{ $isDynamic?: boolean }>`
   line-height: 24px;
   margin-right: 10px;
   text-overflow: ellipsis;
   max-width: 400px;
   overflow: hidden;
   white-space: nowrap;
+  font-weight: ${({ $isDynamic }) => ($isDynamic ? 600 : 400)};
 `;
 
 export const ButtonsWrapper = styled.div`


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?**


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
There are some inconsistencies between the backend and frontend in the case of read-only clusters.
This results in enabled buttons which if you click them, get 405 error.
This PR tries to make them consistent.

* Make all configs of brokers read-only for read-only clusters
* Allow "analyze topic" for read-only clusters (https://github.com/provectus/kafka-ui/issues/1967), which seems to do no write-level action on the real data

There may be still some inconsistencies in the ACL page.
I can not check or fix them now, because I have no running kafka cluster with authentication/ACL enabled.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
-  No need to
- [X] Manually (please, describe, if necessary)
- Unit checks
- Integration checks
- Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [X] My changes generate no new warnings (e.g. Sonar is happy)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
