### PR TITLE
UX: Messages: Use "Newest" as default mode

### DIFF
--- a/frontend/src/lib/hooks/filterUtils.ts
+++ b/frontend/src/lib/hooks/filterUtils.ts
@@ -1,8 +1,8 @@
 import { PollingMode } from 'generated-sources';
 
 export const ModeOptions = [
-  { value: PollingMode.EARLIEST, label: 'Oldest' },
   { value: PollingMode.LATEST, label: 'Newest' },
+  { value: PollingMode.EARLIEST, label: 'Oldest' },
   { value: PollingMode.TAILING, label: 'Live' },
   { value: PollingMode.FROM_OFFSET, label: 'From offset' },
   { value: PollingMode.TO_OFFSET, label: 'To offset' },


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Simply chaned the default filter mode.

**Is there anything you'd like reviewers to focus on?**
Hi, I’ve noticed that other users have also expressed a need for this change, and some of our Kafka users specifically mentioned it. I believe it’s a great idea to modify the default mode, as it aligns better with Kafka's real-time streaming nature.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![gamer cat](https://github.com/user-attachments/assets/4e92a60e-3079-4e5e-8362-32301b8f13b0)
