### PR TITLE
FE: Fix display of ACLs with leading/trailing spaces in table

### DIFF
--- a/frontend/src/components/common/NewTable/Table.styled.ts
+++ b/frontend/src/components/common/NewTable/Table.styled.ts
@@ -152,6 +152,7 @@ export const Table = styled.table(
     color: ${table.td.color.normal};
     vertical-align: middle;
     word-wrap: break-word;
+    white-space: pre;
 
     & a {
       color: ${table.td.color.normal};


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
I added the CSS rule `white-space: pre;` to the table cell styling to ensure that ACLs with leading or trailing spaces are displayed correctly. This ensures that spaces are preserved in the UI, reflecting the actual data stored in Kafka.

**Is there anything you'd like reviewers to focus on?**

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
