### PR TITLE
Closes #621

### DIFF
--- a/api/src/main/java/io/kafbat/ui/controller/AclsController.java
+++ b/api/src/main/java/io/kafbat/ui/controller/AclsController.java
@@ -67,6 +67,7 @@ public class AclsController extends AbstractController implements AclsApi {
                                                           KafkaAclResourceTypeDTO resourceTypeDto,
                                                           String resourceName,
                                                           KafkaAclNamePatternTypeDTO namePatternTypeDto,
+                                                          String search,
                                                           ServerWebExchange exchange) {
     AccessContext context = AccessContext.builder()
         .cluster(clusterName)
@@ -87,7 +88,7 @@ public class AclsController extends AbstractController implements AclsApi {
     return validateAccess(context).then(
         Mono.just(
             ResponseEntity.ok(
-                aclsService.listAcls(getCluster(clusterName), filter)
+                aclsService.listAcls(getCluster(clusterName), filter, search)
                     .map(ClusterMapper::toKafkaAclDto)))
     ).doOnEach(sig -> audit(context, sig));
   }

--- a/api/src/main/java/io/kafbat/ui/service/acl/AclsService.java
+++ b/api/src/main/java/io/kafbat/ui/service/acl/AclsService.java
@@ -68,10 +68,11 @@ public class AclsService {
         .doOnSuccess(v -> log.info("ACL DELETED: [{}]", aclString));
   }
 
-  public Flux<AclBinding> listAcls(KafkaCluster cluster, ResourcePatternFilter filter) {
+  public Flux<AclBinding> listAcls(KafkaCluster cluster, ResourcePatternFilter filter, String principalSearch) {
     return adminClientService.get(cluster)
         .flatMap(c -> c.listAcls(filter))
         .flatMapIterable(acls -> acls)
+        .filter(acl -> principalSearch == null || acl.entry().principal().contains(principalSearch))
         .sort(Comparator.comparing(AclBinding::toString));  //sorting to keep stable order on different calls
   }
 

--- a/contract/src/main/resources/swagger/kafbat-ui-api.yaml
+++ b/contract/src/main/resources/swagger/kafbat-ui-api.yaml
@@ -1943,6 +1943,11 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/KafkaAclNamePatternType'
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
       responses:
         200:
           description: OK

--- a/frontend/src/components/ACLPage/List/List.tsx
+++ b/frontend/src/components/ACLPage/List/List.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { ColumnDef, Row } from '@tanstack/react-table';
 import PageHeading from 'components/common/PageHeading/PageHeading';
 import Table from 'components/common/NewTable';
@@ -20,12 +21,16 @@ import { useTheme } from 'styled-components';
 import ACLFormContext from 'components/ACLPage/Form/AclFormContext';
 import PlusIcon from 'components/common/Icons/PlusIcon';
 import ActionButton from 'components/common/ActionComponent/ActionButton/ActionButton';
+import { ControlPanelWrapper } from 'components/common/ControlPanel/ControlPanel.styled';
+import Search from 'components/common/Search/Search';
 
 import * as S from './List.styled';
 
 const ACList: React.FC = () => {
   const { clusterName } = useAppParams<{ clusterName: ClusterName }>();
-  const { data: aclList } = useAcls(clusterName);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [search, setSearch] = useState(searchParams.get('q') || '');
+  const { data: aclList } = useAcls({ clusterName, search });
   const { deleteResource } = useDeleteAcl(clusterName);
   const modal = useConfirm(true);
   const theme = useTheme();
@@ -35,6 +40,11 @@ const ACList: React.FC = () => {
     setTrue: openFrom,
   } = useBoolean();
   const [rowId, setRowId] = React.useState('');
+
+  // Set the search params to the url based on the localStorage value
+  useEffect(() => {
+    setSearch(searchParams.get('q') || '');
+  }, [searchParams]);
 
   const handleDeleteClick = (acl: KafkaAcl | null) => {
     if (acl) {
@@ -162,6 +172,9 @@ const ACList: React.FC = () => {
           <PlusIcon /> Create ACL
         </ActionButton>
       </PageHeading>
+      <ControlPanelWrapper hasInput>
+        <Search placeholder="Search by Principle Name" />
+      </ControlPanelWrapper>
       <Table
         columns={columns}
         data={aclList ?? []}

--- a/frontend/src/lib/hooks/api/acl.ts
+++ b/frontend/src/lib/hooks/api/acl.ts
@@ -14,12 +14,19 @@ import {
   KafkaAcl,
 } from 'generated-sources';
 
-export function useAcls(clusterName: ClusterName) {
+export function useAcls({ clusterName, search }: { 
+  clusterName: ClusterName; 
+  search?: string; 
+}) {
   return useQuery(
-    ['clusters', clusterName, 'acls'],
-    () => api.listAcls({ clusterName }),
+    ['clusters', clusterName, 'acls', { search }],
+    () => api.listAcls({
+        clusterName,
+        search
+    }),
     {
-      suspense: false,
+        keepPreviousData: true,
+        suspense: false,
     }
   );
 }


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
No breaking changes.

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
This PR introduces a search functionality in Kafka UI that allows users to search ACLs by principal name. This feature was developed to improve the debugging process for users managing clusters with numerous ACLs, especially when clients encounter "authorization failed" errors. And in general this feature enables users to quickly locate specific ACL entries, saving time and making the debugging experience more efficient and user friendly.

**Is there anything you'd like reviewers to focus on?**
No. There are not many changes :)

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->
This feature has been tested and deployed on production clustres with many acls and it works great :)

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

A visualization of the new feature:
https://github.com/user-attachments/assets/4b591910-3f4c-401d-9809-fcf9b0b129a0