### PR TITLE
feat: Add support for custom root certificates in Java keystore

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,15 +11,7 @@ RUN apk add --no-cache \
 RUN addgroup -S kafkaui && adduser -S kafkaui -G kafkaui
 
 # creating folder for dynamic config usage (certificates uploads, etc)
-RUN mkdir -p /etc/kafkaui/certs
-RUN if ls /etc/kafkaui/certs/*.crt 1> /dev/null 2>&1; then \
-        for cert in /etc/kafkaui/certs/*.crt; do \
-            keytool -import -noprompt -trustcacerts -alias $(basename $cert .crt) -file $cert -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit; \
-        done \
-    else \
-        echo "No certificates found in /etc/kafkaui/certs/"; \
-    fi
-
+RUN mkdir /etc/kafkaui/
 RUN chown kafkaui /etc/kafkaui
 
 USER kafkaui

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -11,7 +11,10 @@ RUN apk add --no-cache \
 RUN addgroup -S kafkaui && adduser -S kafkaui -G kafkaui
 
 # creating folder for dynamic config usage (certificates uploads, etc)
-RUN mkdir /etc/kafkaui/
+RUN mkdir -p /etc/kafkaui/certs
+COPY ./import-certs.sh /usr/local/bin/import-certs.sh
+RUN chmod +x /usr/local/bin/import-certs.sh
+
 RUN chown kafkaui /etc/kafkaui
 
 USER kafkaui
@@ -24,4 +27,4 @@ ENV JAVA_OPTS=
 EXPOSE 8080
 
 # see JmxSslSocketFactory docs to understand why add-opens is needed
-CMD java --add-opens java.rmi/javax.rmi.ssl=ALL-UNNAMED  $JAVA_OPTS -jar api.jar
+CMD ["sh", "-c", "/usr/local/bin/import-certs.sh && java --add-opens java.rmi/javax.rmi.ssl=ALL-UNNAMED $JAVA_OPTS -jar api.jar"]

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-# The tag is ignored when a sha is included but the reason to add it are:  
+# The tag is ignored when a sha is included but the reason to add it are:
 # 1. Self Documentation: It is difficult to find out what the expected tag is given a sha alone
 # 2. Helps dependabot during discovery of upgrades
 FROM azul/zulu-openjdk-alpine:17-jre-headless-latest@sha256:af4df00adaec356d092651af50d9e80fd179f96722d267e79acb564aede10fda
@@ -9,6 +9,12 @@ RUN apk add --no-cache \
     # configuring timezones
     tzdata
 RUN addgroup -S kafkaui && adduser -S kafkaui -G kafkaui
+
+RUN mkdir /etc/kafkaui/certs
+
+RUN for cert in /etc/kafkaui/certs/*.crt; do \
+        keytool -import -noprompt -trustcacerts -alias $(basename $cert .crt) -file $cert -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit; \
+    done
 
 # creating folder for dynamic config usage (certificates uploads, etc)
 RUN mkdir /etc/kafkaui/

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,9 +12,13 @@ RUN addgroup -S kafkaui && adduser -S kafkaui -G kafkaui
 
 # creating folder for dynamic config usage (certificates uploads, etc)
 RUN mkdir -p /etc/kafkaui/certs
-RUN for cert in /etc/kafkaui/certs/*.crt; do \
-        keytool -import -noprompt -trustcacerts -alias $(basename $cert .crt) -file $cert -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit; \
-    done
+RUN if ls /etc/kafkaui/certs/*.crt 1> /dev/null 2>&1; then \
+        for cert in /etc/kafkaui/certs/*.crt; do \
+            keytool -import -noprompt -trustcacerts -alias $(basename $cert .crt) -file $cert -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit; \
+        done \
+    else \
+        echo "No certificates found in /etc/kafkaui/certs/"; \
+    fi
 
 RUN chown kafkaui /etc/kafkaui
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --no-cache \
     tzdata
 RUN addgroup -S kafkaui && adduser -S kafkaui -G kafkaui
 
-RUN mkdir /etc/kafkaui/certs
+RUN mkdir -p /etc/kafkaui/certs
 
 RUN for cert in /etc/kafkaui/certs/*.crt; do \
         keytool -import -noprompt -trustcacerts -alias $(basename $cert .crt) -file $cert -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit; \

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -10,14 +10,12 @@ RUN apk add --no-cache \
     tzdata
 RUN addgroup -S kafkaui && adduser -S kafkaui -G kafkaui
 
+# creating folder for dynamic config usage (certificates uploads, etc)
 RUN mkdir -p /etc/kafkaui/certs
-
 RUN for cert in /etc/kafkaui/certs/*.crt; do \
         keytool -import -noprompt -trustcacerts -alias $(basename $cert .crt) -file $cert -keystore $JAVA_HOME/lib/security/cacerts -storepass changeit; \
     done
 
-# creating folder for dynamic config usage (certificates uploads, etc)
-RUN mkdir /etc/kafkaui/
 RUN chown kafkaui /etc/kafkaui
 
 USER kafkaui

--- a/api/import-certs.sh
+++ b/api/import-certs.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+CERT_DIR="/etc/kafkaui/certs"
+KEYSTORE="$JAVA_HOME/lib/security/cacerts"
+STOREPASS="changeit"
+
+if [ -d "$CERT_DIR" ]; then
+    for cert in $CERT_DIR/*.crt; do
+        if [ -f "$cert" ]; then
+            alias=$(basename "$cert" .crt)
+            echo "Importing $cert with alias $alias"
+            keytool -import -noprompt -trustcacerts -alias "$alias" -file "$cert" -keystore "$KEYSTORE" -storepass "$STOREPASS"
+        fi
+    done
+else
+    echo "No certificates directory found at $CERT_DIR"
+fi
+


### PR DESCRIPTION
<!-- ignore-task-list-start -->
## Feature: Custom Root Certificates in Java Keystore

### Description
This pull request introduces support for importing custom root certificates into the Java keystore during the Docker image build process. This enhancement allows the application to trust additional certificates, which is particularly useful for environments where custom certificates are required.

### Changes
- **Dockerfile**:
  - Added a step to create a directory for certificates (`/etc/kafkaui/certs`).
  - Added a loop to import any `.crt` files found in the `/etc/kafkaui/certs` directory into the Java keystore using `keytool`.

Please review and provide feedback.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
