### PR TITLE
Infra: FE: Bump pnpm to 9.15.0

### DIFF
--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4.0.0
         with:
-          version: 9.11.0
+          version: 9.15.0
 
       - name: Install node
         uses: actions/setup-node@v4.0.2

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -103,8 +103,8 @@
     "whatwg-fetch": "3.6.20"
   },
   "engines": {
-    "node": "v18.17.1",
-    "pnpm": "v9.11.0"
+    "node": "18.17.1",
+    "pnpm": "9.15.0"
   },
   "pnpm": {
     "overrides": {

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
 
         <!-- Frontend dependency versions -->
         <node.version>v18.17.1</node.version>
-        <pnpm.version>v9.11.0</pnpm.version>
+        <pnpm.version>v9.15.0</pnpm.version>
 
         <!-- Plugin versions -->
         <fabric8-maven-plugin.version>0.45.1</fabric8-maven-plugin.version>


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Upgrades pnpm to the latest version(9.15.0)

Besides the expected upstream patches in pnpm , it also unblocks dependabot upgrades 

See https://github.com/dependabot/dependabot-core/issues/11124

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**

![cute-red-panda](https://github.com/user-attachments/assets/47429295-850b-4225-a807-6fcd8f587e25)
