### PR TITLE
BE: Chore: standarize Protobuf import paths

### DIFF
--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
@@ -435,6 +435,7 @@ public class ProtobufFileSerde implements BuiltInSerde {
      * to Linux/Unix-style forward slashes (`/`) when the application is running on a Windows OS.
      * On other operating systems, the input path is returned unchanged.</p>
      * This is needed because imports in Protobuf use forward slashes (`/`) for the imports
+     * which causes a conflict with Windows paths. Ie: `language/language.proto` is converted to `language\language.proto`
      *
      * @param path the file path to standardize; must not be {@code null}.
      * @return the standardized file path with forward slashes if running on Windows, or the original path otherwise.

--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
@@ -434,8 +434,9 @@ public class ProtobufFileSerde implements BuiltInSerde {
      * <p>This method is designed to standardize file paths by converting Windows-style backslashes (`\`)
      * to Linux/Unix-style forward slashes (`/`) when the application is running on a Windows OS.
      * On other operating systems, the input path is returned unchanged.</p>
-     * This is needed because imports in Protobuf use forward slashes (`/`) for the imports
-     * which causes a conflict with Windows paths. Ie: `language/language.proto` is converted to `language\language.proto`
+     *
+     * <p>This is needed because imports in Protobuf use forward slashes (`/`) for the imports
+     * which causes a conflict with Windows paths. Ie: `language/language.proto` is converted to `language\language.proto`</p>
      *
      * @param path the file path to standardize; must not be {@code null}.
      * @return the standardized file path with forward slashes if running on Windows, or the original path otherwise.

--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
@@ -64,6 +64,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.SystemUtils;
 import org.jetbrains.annotations.NotNull;
 
 @Slf4j
@@ -416,7 +417,7 @@ public class ProtobufFileSerde implements BuiltInSerde {
         files.filter(p -> !Files.isDirectory(p) && p.toString().endsWith(".proto"))
             .forEach(path -> {
               // relative path will be used as "import" statement
-              String relativePath = baseLocation.relativize(path).toString();
+              String relativePath = removeBackSlashes(baseLocation.relativize(path).toString());
               var protoFileElement = ProtoParser.Companion.parse(
                   Location.get(baseLocation.toString(), relativePath),
                   readFileAsString(path)
@@ -425,6 +426,24 @@ public class ProtobufFileSerde implements BuiltInSerde {
             });
       }
       return filesByLocations;
+    }
+
+    /**
+     * Replaces backslashes in the given file path with forward slashes if the operating system is Windows.
+     *
+     * <p>This method is designed to standardize file paths by converting Windows-style backslashes (`\`)
+     * to Linux/Unix-style forward slashes (`/`) when the application is running on a Windows OS.
+     * On other operating systems, the input path is returned unchanged.</p>
+     * This is needed because imports in Protobuf use forward slashes (`/`) for the imports
+     *
+     * @param path the file path to standardize; must not be {@code null}.
+     * @return the standardized file path with forward slashes if running on Windows, or the original path otherwise.
+     */
+    private @NotNull String removeBackSlashes(@NotNull final String path) {
+      if (SystemUtils.IS_OS_WINDOWS) {
+        return path.replace("\\", "/");
+      }
+      return path;
     }
   }
 

--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
@@ -435,8 +435,9 @@ public class ProtobufFileSerde implements BuiltInSerde {
      * to Linux/Unix-style forward slashes (`/`) when the application is running on a Windows OS.
      * On other operating systems, the input path is returned unchanged.</p>
      *
-     * <p>This is needed because imports in Protobuf use forward slashes (`/`) for the imports
-     * which causes a conflict with Windows paths. Ie: `language/language.proto` is converted to `language\language.proto`</p>
+     * <p>This is needed because imports in Protobuf use forward slashes (`/`)
+     * which causes a conflict with Windows paths. For example,`language/language.proto`
+     * would be converted to `language\language.proto` in Windows causing a resolution exception</p>
      *
      * @param path the file path to standardize; must not be {@code null}.
      * @return the standardized file path with forward slashes if running on Windows, or the original path otherwise.


### PR DESCRIPTION
<!-- ignore-task-list-start -->

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Before this change, the `SchemaRegistryServiceTests` tests were failing in Windows with the following exception: 

![image](https://github.com/user-attachments/assets/f90311e3-8308-405c-92a1-8d7622cf3c65)

```java
	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:782)
	... 55 more
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [io.kafbat.ui.service.DeserializationService]: Constructor threw exception
	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:221)
	at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:117)
	at org.springframework.beans.factory.support.ConstructorResolver.instantiate(ConstructorResolver.java:315)
	... 69 more
Caused by: java.lang.NullPointerException: ProtoFile not found for import 'language/language.proto'
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:1011)
	at io.kafbat.ui.serdes.builtin.ProtobufFileSerde$ProtoSchemaLoader$1.load(ProtobufFileSerde.java:403)
	at com.squareup.wire.schema.Linker.getFileLinker$wire_schema(Linker.kt:95)

```

With this change, we are standardizing the import statements to remove backlashes in Windows which fixes the tests : 

![image](https://github.com/user-attachments/assets/6660ce1e-a33d-4c44-92a8-98f5f9987f7f)

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**
![istockphoto-1243410279-612x612](https://github.com/user-attachments/assets/eb188652-bb96-4c42-92f1-9bb8a9de5afb)

