### PR TITLE
Chore: add run configurations to improve the dev experience locally

### DIFF
--- a/.run/KafkaUiApplication.run.xml
+++ b/.run/KafkaUiApplication.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="KafkaUiApplication" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot" nameIsGenerated="true">
+    <option name="ALTERNATIVE_JRE_PATH" value="openjdk-21" />
+    <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
+    <option name="FRAME_DEACTIVATION_UPDATE_POLICY" value="UpdateClassesAndResources" />
+    <module name="api" />
+    <selectedOptions>
+      <option name="environmentVariables" />
+    </selectedOptions>
+    <option name="SPRING_BOOT_MAIN_CLASS" value="io.kafbat.ui.KafkaUiApplication" />
+    <option name="VM_PARAMETERS" value="--add-opens java.rmi/javax.rmi.ssl=ALL-UNNAMED" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Lauch E2E Dependencies.run.xml
+++ b/.run/Lauch E2E Dependencies.run.xml
@@ -3,6 +3,7 @@
     <deployment type="docker-compose.yml">
       <settings>
         <option name="envFilePath" value="" />
+        <option name="removeOrphansOnComposeDown" value="false" />
         <option name="sourceFilePath" value="documentation/compose/e2e-tests.yaml" />
       </settings>
     </deployment>

--- a/.run/Lauch E2E Dependencies.run.xml
+++ b/.run/Lauch E2E Dependencies.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Lauch E2E Dependencies" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="envFilePath" value="" />
+        <option name="sourceFilePath" value="documentation/compose/e2e-tests.yaml" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Template TestNG.run.xml
+++ b/.run/Template TestNG.run.xml
@@ -18,7 +18,7 @@
     <listeners />
     <method v="2">
       <option name="Make" enabled="true" />
-      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_Start Compose" />
+      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Lauch E2E Dependencies" run_configuration_type="docker-deploy" />
     </method>
   </configuration>
 </component>

--- a/.run/Template TestNG.run.xml
+++ b/.run/Template TestNG.run.xml
@@ -7,7 +7,7 @@
     <option name="MAIN_CLASS_NAME" value="" />
     <option name="GROUP_NAME" value="" />
     <option name="TEST_OBJECT" value="CLASS" />
-    <option name="VM_PARAMETERS" value="-ea -Dheadless=false -Dselenoid=false" />
+    <option name="VM_PARAMETERS" value="-Dheadless=false -Dselenoid=false" />
     <option name="PARAMETERS" value="" />
     <option name="OUTPUT_DIRECTORY" value="" />
     <option name="TEST_SEARCH_SCOPE">

--- a/.run/Template TestNG.run.xml
+++ b/.run/Template TestNG.run.xml
@@ -1,0 +1,23 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="true" type="TestNG">
+    <shortenClasspath name="NONE" />
+    <useClassPathOnly />
+    <option name="SUITE_NAME" value="" />
+    <option name="PACKAGE_NAME" value="" />
+    <option name="MAIN_CLASS_NAME" value="" />
+    <option name="GROUP_NAME" value="" />
+    <option name="TEST_OBJECT" value="CLASS" />
+    <option name="VM_PARAMETERS" value="-ea -Dheadless=false -Dselenoid=false" />
+    <option name="PARAMETERS" value="" />
+    <option name="OUTPUT_DIRECTORY" value="" />
+    <option name="TEST_SEARCH_SCOPE">
+      <value defaultName="moduleWithDependencies" />
+    </option>
+    <option name="PROPERTIES_FILE" value="" />
+    <properties />
+    <listeners />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Template TestNG.run.xml
+++ b/.run/Template TestNG.run.xml
@@ -18,6 +18,7 @@
     <listeners />
     <method v="2">
       <option name="Make" enabled="true" />
+      <option name="ToolBeforeRunTask" enabled="true" actionId="Tool_External Tools_Start Compose" />
     </method>
   </configuration>
 </component>

--- a/.run/Template TestNG.run.xml
+++ b/.run/Template TestNG.run.xml
@@ -18,7 +18,6 @@
     <listeners />
     <method v="2">
       <option name="Make" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="Lauch E2E Dependencies" run_configuration_type="docker-deploy" />
     </method>
   </configuration>
 </component>


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Configures a set of default [Run Configuration for IntelliJ IDEA ](https://www.jetbrains.com/help/idea/run-debug-configuration-java-application.html) to improve the development experience locally. Now, when a developer clones and runs the project, a set of default run configurations are included by default


1. A default run configuration for Spring with the VM arguments `--add-opens java.rmi/javax.rmi.ssl=ALL-UNNAMED` that are needed to launch the application 

https://github.com/kafbat/kafka-ui/blob/a9bc82ca6c626332508687d37462e7762cb8eb6a/api/Dockerfile#L27

2. `Lauch Dependencies` : Adds a Docker compose configuration to launch all the dependencies calling `docker compose up documentation/compose/e2e-tests.yaml`

3. Adds a TestNG template for IntelliJ to ensure that integration test execution include `-Dheadless=false -Dselenoid=false` automatically. This configuration avoids running Selenoid and running a real Chrome instance following the definition in https://github.com/kafbat/kafka-ui/blob/a9bc82ca6c626332508687d37462e7762cb8eb6a/e2e-tests/src/main/java/io/kafbat/ui/settings/BaseSource.java#L9-L10

Now, when we run any Smoke test in IntelliJ IDEA should add the ` -Dheadless=false -Dselenoid=false`  arguments automatically under VM Options

![image](https://github.com/user-attachments/assets/3a043db0-551c-4b68-bbf5-72dae1d48dd5)

In an ideal world, running this step should launch `E2E Dependencies` as well but sadly that's blocking due to the following issues: 

- https://youtrack.jetbrains.com/issue/IJPL-13136/Allow-Run-Debug-Configurations-to-not-wait-for-Before-launch-actions-to-complete

- https://youtrack.jetbrains.com/issue/IJPL-12121/Allow-External-Tools-to-run-in-the-background

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Manually (please, describe, if necessary)

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code

**A picture of a cute animal (not mandatory but encouraged)**

![Cuban-Trogon-800-Michael-Klotz-CC](https://github.com/user-attachments/assets/1a180b35-78b7-4c37-84d4-844730c8d32c)
