### PR TITLE
issues/239: max content width for Menu. Closes #239

### DIFF
--- a/frontend/src/components/Nav/Menu/styled.ts
+++ b/frontend/src/components/Nav/Menu/styled.ts
@@ -45,7 +45,7 @@ export const ContentWrapper = styled.div`
 
 export const Title = styled.div`
   white-space: nowrap;
-  max-width: 110px;
+  max-width: max-content;
   overflow: hidden;
   text-overflow: ellipsis;
 `;

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -139,7 +139,7 @@ const baseTheme = {
   },
   layout: {
     minWidth: '1200px',
-    navBarWidth: '240px',
+    navBarWidth: '280px',
     navBarHeight: '51px',
     rightSidebarWidth: '70vw',
     filtersSidebarWidth: '300px',


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?**
I added the quick fix recommended in #239; allowing `max-content` for width and capping it at 280px.

It allows for long Kafka cluster names but won't ruin the UI in the case of a very long name.

**Is there anything you'd like reviewers to focus on?**
This feels good enough to close #239 while still allowing room for #528. Check out the picture to see how it looks.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

![image](https://github.com/user-attachments/assets/b0fea983-c18e-481d-bc99-1394ff8e04f8)
