### PR TITLE
Infra: FE: limit pnpm and node version enforcement to the major versions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -103,8 +103,8 @@
     "whatwg-fetch": "3.6.20"
   },
   "engines": {
-    "node": "^22.12.0",
-    "pnpm": "^9.15.0"
+    "node": "^22",
+    "pnpm": "^9"
   },
   "pnpm": {
     "overrides": {


### PR DESCRIPTION
This change is a follow up for https://github.com/kafbat/kafka-ui/pull/747 to only enforce the major versions. 

Minor and feature revision enforcement is not necessary and adds little value.  

A sample situations where this can hurt us include Dependabot and other tools. 


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->

- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->



**A picture of a cute animal (not mandatory but encouraged)**

![8f6f8607d5dc31abd4c457261dff626b](https://github.com/user-attachments/assets/226d68b6-a093-4e67-aa72-bb8b5e816af1)
