### PR TITLE
Cut off less text in left-hand nav menu

### DIFF
--- a/frontend/src/components/Nav/Menu/styled.ts
+++ b/frontend/src/components/Nav/Menu/styled.ts
@@ -45,7 +45,7 @@ export const ContentWrapper = styled.div`
 
 export const Title = styled.div`
   white-space: nowrap;
-  max-width: 110px;
+  max-width: 160px;
   overflow: hidden;
   text-overflow: ellipsis;
 `;


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?**

Currently the maximum width of 110px in the left-hand menu is really conservative, dropping way more text than it needs:

![image](https://github.com/user-attachments/assets/5ee8f532-60e6-4a2e-bf68-0fae599414df)

160px seems like a much better choice:

![image](https://github.com/user-attachments/assets/2d356ec5-4273-406e-9cbb-a1648d70c692)

Much more text is shown now, but it still cuts off appropriately before the drop-down icon.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
