### PR TITLE
BE: Auth: Support LDAPS for AD

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -212,6 +212,19 @@
             <version>${okhttp3.mockwebserver.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>${confluent.version}-ccs</version>
+            <classifier>test</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.80</version>
+            <scope>test</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/api/src/main/java/io/kafbat/ui/util/CustomSslSocketFactory.java
+++ b/api/src/main/java/io/kafbat/ui/util/CustomSslSocketFactory.java
@@ -1,0 +1,90 @@
+package io.kafbat.ui.util;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+import javax.net.SocketFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+public class CustomSslSocketFactory extends SSLSocketFactory {
+  private final SSLSocketFactory socketFactory;
+
+  public CustomSslSocketFactory() {
+    try {
+      SSLContext ctx = SSLContext.getInstance("TLS");
+      ctx.init(null, new TrustManager[] { new DisabledX509TrustManager() }, new SecureRandom());
+      socketFactory = ctx.getSocketFactory();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static SocketFactory getDefault() {
+    return new CustomSslSocketFactory();
+  }
+
+  @Override
+  public String[] getDefaultCipherSuites() {
+    return socketFactory.getDefaultCipherSuites();
+  }
+
+  @Override
+  public String[] getSupportedCipherSuites() {
+    return socketFactory.getSupportedCipherSuites();
+  }
+
+  @Override
+  public Socket createSocket(Socket socket, String string, int i, boolean bln) throws IOException {
+    return socketFactory.createSocket(socket, string, i, bln);
+  }
+
+  @Override
+  public Socket createSocket(String string, int i) throws IOException {
+    return socketFactory.createSocket(string, i);
+  }
+
+  @Override
+  public Socket createSocket(String string, int i, InetAddress ia, int i1) throws IOException {
+    return socketFactory.createSocket(string, i, ia, i1);
+  }
+
+  @Override
+  public Socket createSocket(InetAddress ia, int i) throws IOException {
+    return socketFactory.createSocket(ia, i);
+  }
+
+  @Override
+  public Socket createSocket(InetAddress ia, int i, InetAddress ia1, int i1) throws IOException {
+    return socketFactory.createSocket(ia, i, ia1, i1);
+  }
+
+  @Override
+  public Socket createSocket() throws IOException {
+    return socketFactory.createSocket();
+  }
+
+  private static class DisabledX509TrustManager implements X509TrustManager {
+    /** Empty certificate array. */
+    private static final X509Certificate[] CERTS = new X509Certificate[0];
+
+    @Override
+    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
+      // No-op, all clients are trusted.
+    }
+
+    @Override
+    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
+      // No-op, all servers are trusted.
+    }
+
+    @Override
+    public X509Certificate[] getAcceptedIssuers() {
+      return CERTS;
+    }
+  }
+}

--- a/api/src/main/java/io/kafbat/ui/util/CustomSslSocketFactory.java
+++ b/api/src/main/java/io/kafbat/ui/util/CustomSslSocketFactory.java
@@ -1,24 +1,23 @@
 package io.kafbat.ui.util;
 
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.security.SecureRandom;
-import java.security.cert.X509Certificate;
 import javax.net.SocketFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
 
 public class CustomSslSocketFactory extends SSLSocketFactory {
   private final SSLSocketFactory socketFactory;
 
   public CustomSslSocketFactory() {
     try {
-      SSLContext ctx = SSLContext.getInstance("TLS");
-      ctx.init(null, new TrustManager[] { new DisabledX509TrustManager() }, new SecureRandom());
-      socketFactory = ctx.getSocketFactory();
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, InsecureTrustManagerFactory.INSTANCE.getTrustManagers(), new SecureRandom());
+
+      socketFactory = sslContext.getSocketFactory();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -66,25 +65,5 @@ public class CustomSslSocketFactory extends SSLSocketFactory {
   @Override
   public Socket createSocket() throws IOException {
     return socketFactory.createSocket();
-  }
-
-  private static class DisabledX509TrustManager implements X509TrustManager {
-    /** Empty certificate array. */
-    private static final X509Certificate[] CERTS = new X509Certificate[0];
-
-    @Override
-    public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
-      // No-op, all clients are trusted.
-    }
-
-    @Override
-    public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
-      // No-op, all servers are trusted.
-    }
-
-    @Override
-    public X509Certificate[] getAcceptedIssuers() {
-      return CERTS;
-    }
   }
 }

--- a/api/src/test/java/io/kafbat/ui/AbstractActiveDirectoryIntegrationTest.java
+++ b/api/src/test/java/io/kafbat/ui/AbstractActiveDirectoryIntegrationTest.java
@@ -1,7 +1,6 @@
 package io.kafbat.ui;
 
 import static io.kafbat.ui.AbstractIntegrationTest.LOCAL;
-import static io.kafbat.ui.container.ActiveDirectoryContainer.DOMAIN;
 import static io.kafbat.ui.container.ActiveDirectoryContainer.EMPTY_PERMISSIONS_USER;
 import static io.kafbat.ui.container.ActiveDirectoryContainer.FIRST_USER_WITH_GROUP;
 import static io.kafbat.ui.container.ActiveDirectoryContainer.PASSWORD;
@@ -12,48 +11,28 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import io.kafbat.ui.container.ActiveDirectoryContainer;
 import io.kafbat.ui.model.AuthenticationInfoDTO;
 import io.kafbat.ui.model.ResourceTypeDTO;
 import io.kafbat.ui.model.UserPermissionDTO;
 import java.util.List;
 import java.util.Objects;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.ApplicationContextInitializer;
-import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.BodyInserters;
 
 @SpringBootTest
 @ActiveProfiles("rbac-ad")
 @AutoConfigureWebTestClient(timeout = "60000")
-@ContextConfiguration(initializers = {ActiveDirectoryIntegrationTest.Initializer.class})
-public class ActiveDirectoryIntegrationTest {
+public abstract class AbstractActiveDirectoryIntegrationTest {
   private static final String SESSION = "SESSION";
-
-  private static final ActiveDirectoryContainer ACTIVE_DIRECTORY = new ActiveDirectoryContainer();
 
   @Autowired
   private WebTestClient webTestClient;
-
-  @BeforeAll
-  public static void setup() {
-    ACTIVE_DIRECTORY.start();
-  }
-
-  @AfterAll
-  public static void shutdown() {
-    ACTIVE_DIRECTORY.stop();
-  }
 
   @Test
   public void testUserPermissions() {
@@ -107,14 +86,5 @@ public class ActiveDirectoryIntegrationTest {
         .returnResult(AuthenticationInfoDTO.class)
         .getResponseBody()
         .blockFirst();
-  }
-
-  public static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
-    @Override
-    public void initialize(@NotNull ConfigurableApplicationContext context) {
-      System.setProperty("spring.ldap.urls", ACTIVE_DIRECTORY.getLdapUrl());
-      System.setProperty("oauth2.ldap.activeDirectory", "true");
-      System.setProperty("oauth2.ldap.activeDirectory.domain", DOMAIN);
-    }
   }
 }

--- a/api/src/test/java/io/kafbat/ui/ActiveDirectoryLdapTest.java
+++ b/api/src/test/java/io/kafbat/ui/ActiveDirectoryLdapTest.java
@@ -1,0 +1,35 @@
+package io.kafbat.ui;
+
+import static io.kafbat.ui.container.ActiveDirectoryContainer.DOMAIN;
+
+import io.kafbat.ui.container.ActiveDirectoryContainer;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+
+@ContextConfiguration(initializers = {ActiveDirectoryLdapTest.Initializer.class})
+public class ActiveDirectoryLdapTest extends AbstractActiveDirectoryIntegrationTest {
+  private static final ActiveDirectoryContainer ACTIVE_DIRECTORY = new ActiveDirectoryContainer(false);
+
+  @BeforeAll
+  public static void setup() {
+    ACTIVE_DIRECTORY.start();
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    ACTIVE_DIRECTORY.stop();
+  }
+
+  public static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    @Override
+    public void initialize(@NotNull ConfigurableApplicationContext context) {
+      System.setProperty("spring.ldap.urls", ACTIVE_DIRECTORY.getLdapUrl());
+      System.setProperty("oauth2.ldap.activeDirectory", "true");
+      System.setProperty("oauth2.ldap.activeDirectory.domain", DOMAIN);
+    }
+  }
+}

--- a/api/src/test/java/io/kafbat/ui/ActiveDirectoryLdapTest.java
+++ b/api/src/test/java/io/kafbat/ui/ActiveDirectoryLdapTest.java
@@ -6,13 +6,19 @@ import io.kafbat.ui.container.ActiveDirectoryContainer;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.reactive.server.WebTestClient;
 
 @ContextConfiguration(initializers = {ActiveDirectoryLdapTest.Initializer.class})
 public class ActiveDirectoryLdapTest extends AbstractActiveDirectoryIntegrationTest {
   private static final ActiveDirectoryContainer ACTIVE_DIRECTORY = new ActiveDirectoryContainer(false);
+
+  @Autowired
+  private WebTestClient webTestClient;
 
   @BeforeAll
   public static void setup() {
@@ -22,6 +28,16 @@ public class ActiveDirectoryLdapTest extends AbstractActiveDirectoryIntegrationT
   @AfterAll
   public static void shutdown() {
     ACTIVE_DIRECTORY.stop();
+  }
+
+  @Test
+  public void testUserPermissions() {
+    checkUserPermissions(webTestClient);
+  }
+
+  @Test
+  public void testEmptyPermissions() {
+    checkEmptyPermissions(webTestClient);
   }
 
   public static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {

--- a/api/src/test/java/io/kafbat/ui/ActiveDirectoryLdapsTest.java
+++ b/api/src/test/java/io/kafbat/ui/ActiveDirectoryLdapsTest.java
@@ -33,15 +33,15 @@ import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemWriter;
 public class ActiveDirectoryLdapsTest extends AbstractActiveDirectoryIntegrationTest {
   private static final ActiveDirectoryContainer ACTIVE_DIRECTORY = new ActiveDirectoryContainer(true);
 
-  private static File CERT_PEM = null;
-  private static File PRIVATE_KEY_PEM = null;
+  private static File certPem = null;
+  private static File privateKeyPem = null;
 
   @BeforeAll
   public static void setup() throws Exception {
     generateCerts();
 
-    ACTIVE_DIRECTORY.withCopyFileToContainer(forHostPath(CERT_PEM.getAbsolutePath()), CONTAINER_CERT_PATH);
-    ACTIVE_DIRECTORY.withCopyFileToContainer(forHostPath(PRIVATE_KEY_PEM.getAbsolutePath()), CONTAINER_KEY_PATH);
+    ACTIVE_DIRECTORY.withCopyFileToContainer(forHostPath(certPem.getAbsolutePath()), CONTAINER_CERT_PATH);
+    ACTIVE_DIRECTORY.withCopyFileToContainer(forHostPath(privateKeyPem.getAbsolutePath()), CONTAINER_KEY_PATH);
 
     ACTIVE_DIRECTORY.start();
   }
@@ -66,13 +66,13 @@ public class ActiveDirectoryLdapsTest extends AbstractActiveDirectoryIntegration
 
     TestSslUtils.createTrustStore(truststore.getPath(), new Password(PASSWORD), Map.of("client", clientCert));
 
-    CERT_PEM = File.createTempFile("cert", ".pem");
-    try (FileWriter fw = new FileWriter(CERT_PEM)) {
+    certPem = File.createTempFile("cert", ".pem");
+    try (FileWriter fw = new FileWriter(certPem)) {
       fw.write(certOrKeyToString(clientCert));
     }
 
-    PRIVATE_KEY_PEM = File.createTempFile("key", ".pem");
-    try (FileWriter fw = new FileWriter(PRIVATE_KEY_PEM)) {
+    privateKeyPem = File.createTempFile("key", ".pem");
+    try (FileWriter fw = new FileWriter(privateKeyPem)) {
       fw.write(certOrKeyToString(clientKeyPair.getPrivate()));
     }
   }

--- a/api/src/test/java/io/kafbat/ui/ActiveDirectoryLdapsTest.java
+++ b/api/src/test/java/io/kafbat/ui/ActiveDirectoryLdapsTest.java
@@ -1,0 +1,100 @@
+package io.kafbat.ui;
+
+import static io.kafbat.ui.container.ActiveDirectoryContainer.CONTAINER_CERT_PATH;
+import static io.kafbat.ui.container.ActiveDirectoryContainer.CONTAINER_KEY_PATH;
+import static io.kafbat.ui.container.ActiveDirectoryContainer.DOMAIN;
+import static io.kafbat.ui.container.ActiveDirectoryContainer.PASSWORD;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+import io.kafbat.ui.container.ActiveDirectoryContainer;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.OutputStreamWriter;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.cert.X509Certificate;
+import java.util.Map;
+import org.apache.kafka.common.config.types.Password;
+import org.apache.kafka.test.TestSslUtils;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.testcontainers.shaded.org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator;
+import org.testcontainers.shaded.org.bouncycastle.openssl.jcajce.JcaPKCS8Generator;
+import org.testcontainers.shaded.org.bouncycastle.util.io.pem.PemWriter;
+
+@ContextConfiguration(initializers = {ActiveDirectoryLdapsTest.Initializer.class})
+public class ActiveDirectoryLdapsTest extends AbstractActiveDirectoryIntegrationTest {
+  private static final ActiveDirectoryContainer ACTIVE_DIRECTORY = new ActiveDirectoryContainer(true);
+
+  private static File CERT_PEM = null;
+  private static File PRIVATE_KEY_PEM = null;
+
+  @BeforeAll
+  public static void setup() throws Exception {
+    generateCerts();
+
+    ACTIVE_DIRECTORY.withCopyFileToContainer(forHostPath(CERT_PEM.getAbsolutePath()), CONTAINER_CERT_PATH);
+    ACTIVE_DIRECTORY.withCopyFileToContainer(forHostPath(PRIVATE_KEY_PEM.getAbsolutePath()), CONTAINER_KEY_PATH);
+
+    ACTIVE_DIRECTORY.start();
+  }
+
+  @AfterAll
+  public static void shutdown() {
+    ACTIVE_DIRECTORY.stop();
+  }
+
+  private static void generateCerts() throws Exception {
+    File truststore = File.createTempFile("truststore", ".jks");
+
+    truststore.deleteOnExit();
+
+    String host = "localhost";
+    KeyPair clientKeyPair = TestSslUtils.generateKeyPair("RSA");
+
+    X509Certificate clientCert = new TestSslUtils.CertificateBuilder(365, "SHA256withRSA")
+        .sanDnsNames(host)
+        .sanIpAddress(InetAddress.getByName(host))
+        .generate("O=Samba Administration, OU=Samba, CN=" + host, clientKeyPair);
+
+    TestSslUtils.createTrustStore(truststore.getPath(), new Password(PASSWORD), Map.of("client", clientCert));
+
+    CERT_PEM = File.createTempFile("cert", ".pem");
+    try (FileWriter fw = new FileWriter(CERT_PEM)) {
+      fw.write(certOrKeyToString(clientCert));
+    }
+
+    PRIVATE_KEY_PEM = File.createTempFile("key", ".pem");
+    try (FileWriter fw = new FileWriter(PRIVATE_KEY_PEM)) {
+      fw.write(certOrKeyToString(clientKeyPair.getPrivate()));
+    }
+  }
+
+  private static String certOrKeyToString(Object certOrKey) throws Exception {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try (PemWriter pemWriter = new PemWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8))) {
+      if (certOrKey instanceof X509Certificate) {
+        pemWriter.writeObject(new JcaMiscPEMGenerator(certOrKey));
+      } else {
+        pemWriter.writeObject(new JcaPKCS8Generator((PrivateKey) certOrKey, null));
+      }
+    }
+    return out.toString(StandardCharsets.UTF_8);
+  }
+
+  public static class Initializer implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    @Override
+    public void initialize(@NotNull ConfigurableApplicationContext context) {
+      System.setProperty("spring.ldap.urls", ACTIVE_DIRECTORY.getLdapUrl());
+      System.setProperty("oauth2.ldap.activeDirectory", "true");
+      System.setProperty("oauth2.ldap.activeDirectory.domain", DOMAIN);
+    }
+  }
+}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
In this PR I added `CustomSslSocketFactory` that trusts all certificates by default. 
This allows you to use LDAPS to connect to an AD server without further specifying the path to the truststore/password.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [ ] Unit checks
- [x] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
