### PR TITLE
FE: Messages: Fix stack overflow for large messages

### DIFF
--- a/e2e-tests/src/main/java/io/kafbat/ui/settings/BaseSource.java
+++ b/e2e-tests/src/main/java/io/kafbat/ui/settings/BaseSource.java
@@ -7,11 +7,12 @@ import static org.apache.commons.lang3.BooleanUtils.TRUE;
 public abstract class BaseSource {
 
   public static final boolean HEADLESS = parseBoolean(getOptionalString(TRUE, System.getProperty("headless")));
+  public static final boolean SELENOID = parseBoolean(getOptionalString(TRUE, System.getProperty("selenoid")));
   public static final String CLUSTER_NAME = "local";
   public static final String CONNECT_NAME = "first";
   private static final String LOCAL_HOST = "localhost";
   public static final String REMOTE_URL = String.format("http://%s:4444/wd/hub", LOCAL_HOST);
   public static final String BASE_API_URL = String.format("http://%s:8080", LOCAL_HOST);
-  public static final String BASE_HOST = "host.docker.internal";
+  public static final String BASE_HOST = SELENOID ? "host.docker.internal" : LOCAL_HOST;
   public static final String BASE_UI_URL = String.format("http://%s:8080", BASE_HOST);
 }

--- a/e2e-tests/src/main/java/io/kafbat/ui/settings/BaseSource.java
+++ b/e2e-tests/src/main/java/io/kafbat/ui/settings/BaseSource.java
@@ -7,12 +7,11 @@ import static org.apache.commons.lang3.BooleanUtils.TRUE;
 public abstract class BaseSource {
 
   public static final boolean HEADLESS = parseBoolean(getOptionalString(TRUE, System.getProperty("headless")));
-  public static final boolean SELENOID = parseBoolean(getOptionalString(TRUE, System.getProperty("selenoid")));
   public static final String CLUSTER_NAME = "local";
   public static final String CONNECT_NAME = "first";
   private static final String LOCAL_HOST = "localhost";
   public static final String REMOTE_URL = String.format("http://%s:4444/wd/hub", LOCAL_HOST);
   public static final String BASE_API_URL = String.format("http://%s:8080", LOCAL_HOST);
-  public static final String BASE_HOST = SELENOID ? "host.docker.internal" : LOCAL_HOST;
+  public static final String BASE_HOST = "host.docker.internal";
   public static final String BASE_UI_URL = String.format("http://%s:8080", BASE_HOST);
 }

--- a/frontend/src/components/common/Editor/Editor.tsx
+++ b/frontend/src/components/common/Editor/Editor.tsx
@@ -31,7 +31,7 @@ const Editor = React.forwardRef<AceEditor | null, EditorProps>((props, ref) => {
           ? `${(props.value?.split('\n').length || 32) * 19}px`
           : '372px'
       }
-      wrapEnabled
+      wrapEnabled={false}
       {...rest}
     />
   );


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/24ca3979-034e-4b66-abe9-fa2ebb6c48c0)
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
When viewing large messages in AceEditor I was getting: _RangeError: Maximum call stack size exceeded_
After some googling, it looks like setting wraperEnabled to false fixes the issue
Additionally, I had to set example:
spring.codec.max-in-memory-size: 15MB -- in config.yml
and 
max.request.size: 15000000 on cluster preferences when I wanted to be able to produce large messages

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
