### PR TITLE
Update CVE checks workflow to trigger on changes in 'infra/' directory

### DIFF
--- a/.github/workflows/cve_checks.yml
+++ b/.github/workflows/cve_checks.yml
@@ -1,9 +1,14 @@
 name: "Infra: CVE checks"
+
 on:
   pull_request:
     types: [ "opened", "reopened", "synchronize" ]
+    paths:
+      - 'infra/**'  # Run only when files in 'infra/' change
   push:
     branches: [ "main" ]
+    paths:
+      - 'infra/**'
   workflow_dispatch:
   schedule:
     # * is a special character in YAML so you have to quote this string
@@ -76,7 +81,7 @@ jobs:
 
   notify:
     needs: check-cves
-    if: ${{ always() && needs.build-and-test.result == 'failure' && github.event_name == 'schedule' }}
+    if: ${{ always() && needs.check-cves.result == 'failure' && github.event_name == 'schedule' }}
     uses: ./.github/workflows/infra_discord_hook.yml
     with:
       message: "Attention! CVE checks run failed! Please fix them CVEs :("


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

fixes #958 

CVE checks will now run only when infrastructure files change. The workflow won't trigger for unrelated application code changes. Notifications will work correctly for scheduled runs if CVE checks fail.

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
