### PR TITLE
FE: Messages: Format JSON arrays

### DIFF
--- a/frontend/src/components/Topics/Topic/Messages/MessageContent/MessageContent.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/MessageContent/MessageContent.tsx
@@ -59,7 +59,9 @@ const MessageContent: React.FC<MessageContentProps> = ({
   };
 
   const contentType =
-    messageContent && messageContent.trim().startsWith('{')
+    messageContent &&
+    (messageContent.trim().startsWith('{') ||
+      messageContent.trim().startsWith('['))
       ? SchemaType.JSON
       : SchemaType.PROTOBUF;
 


### PR DESCRIPTION
We currently only format JSON objects, but we can detect and format JSON arrays as well, which will improve the user experience when messages contain arrays of JSON objects.

Before:

![image](https://github.com/user-attachments/assets/5ffc25f9-2bd9-4275-9d5b-88403e6d8916)

After:

![image](https://github.com/user-attachments/assets/45ba794f-c401-417d-849a-8624aa8dc51b)

**What changes did you make?**

Changed JSON message detection to include messages starting with `[`, not only `{`.

**Is there anything you'd like reviewers to focus on?**

No.

**How Has This Been Tested?**
<!-- ignore-task-list-start -->
- [X] Manually: Created a message containing an unformatted JSON array and made sure its preview is formatted.
<!-- ignore-task-list-end -->

**Checklist**
- [X] I have performed a self-review of my own code
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged


**A picture of a cute animal**
![image](https://github.com/user-attachments/assets/1e5620a2-b696-47af-bf9e-cc2edc66714a)
