### PR TITLE
BE: Extend config sanitizer patterns

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/KafkaConfigSanitizer.java
+++ b/api/src/main/java/io/kafbat/ui/service/KafkaConfigSanitizer.java
@@ -29,7 +29,7 @@ class KafkaConfigSanitizer {
       .addAll(kafkaConfigKeysToSanitize())
       .add(
           "basic.auth.user.info",  /* For Schema Registry credentials */
-          "password", "secret", "token", "key", ".*credentials.*",   /* General credential patterns */
+          "password", "secret", "token", "key", ".*credentials.*", "passphrase",   /* General credential patterns */
           "aws.access.*", "aws.secret.*", "aws.session.*",   /* AWS-related credential patterns */
           "connection.uri" /* mongo credential patterns */
       )

--- a/api/src/test/java/io/kafbat/ui/service/KafkaConfigSanitizerTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/KafkaConfigSanitizerTest.java
@@ -27,6 +27,7 @@ class KafkaConfigSanitizerTest {
     assertThat(sanitizer.sanitize("main.consumer.sasl.jaas.config", "secret")).isEqualTo("******");
     assertThat(sanitizer.sanitize("database.password", "secret")).isEqualTo("******");
     assertThat(sanitizer.sanitize("basic.auth.user.info", "secret")).isEqualTo("******");
+    assertThat(sanitizer.sanitize("private.key.passphrase", "secret")).isEqualTo("******");
 
     //AWS var sanitizing
     assertThat(sanitizer.sanitize("aws.access.key.id", "secret")).isEqualTo("******");


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** Add "passphrase" as a default pattern to sanitize in the configs.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
