### PR TITLE
BE: Chore: Bump Spring Boot to 3.4.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-spring-boot = '3.4.4'
+spring-boot = '3.4.5'
 
 aws-msk-auth = '2.3.0'
 azure-identity = '1.15.4'


### PR DESCRIPTION
Fixes CVE-2025-22235

- [x] Covered by existing automation


**A picture of a cute animal (not mandatory but encouraged)**
