### PR TITLE
BE: Chore: Bump Spring Boot to 3.5.3

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -53,7 +53,7 @@ dependencies {
         exclude group: 'io.projectreactor.ipc', module: 'reactor-netty'
     }
 
-    runtimeOnly(libs.micrometer.registry.prometheus){
+    runtimeOnly(libs.micrometer.registry.prometheus) {
         exclude group: 'com.google.protobuf', module: 'protobuf-java' because("Micrometer uses protobuf-java 4.x, which is incompatible with protobuf-java 3.x used by various dependencies of this project. See https://github.com/prometheus/client_java/issues/1431")
     }
 

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -53,15 +53,13 @@ dependencies {
         exclude group: 'io.projectreactor.ipc', module: 'reactor-netty'
     }
 
-    runtimeOnly libs.micrometer.registry.prometheus
+    runtimeOnly(libs.micrometer.registry.prometheus){
+        exclude group: 'com.google.protobuf', module: 'protobuf-java' because("Micrometer uses protobuf-java 4.x, which is incompatible with protobuf-java 3.x used by various dependencies of this project. See https://github.com/prometheus/client_java/issues/1431")
+    }
 
     // CVE Fixes
     implementation libs.apache.commons.compress
     implementation libs.okhttp3.logging.intercepter
-    implementation libs.json.smart
-    implementation libs.netty.common
-    implementation libs.netty.handler
-    implementation libs.spring.context
 
     implementation libs.modelcontextprotocol.spring.webflux
     implementation libs.victools.jsonschema.generator

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-spring-boot = '3.4.5'
+spring-boot = '3.5.3'
 
 aws-msk-auth = '2.3.0'
 azure-identity = '1.15.4'
@@ -21,7 +21,9 @@ lombok = '1.18.34'
 odd-oddrn-generator = '0.1.17'
 odd-oddrn-client = '0.1.41'
 cel = '0.3.0'
-junit = '5.11.2'
+# This version should be compatible with the version used by spring-boot-starter-test to avoid conflicts
+# See https://github.com/spring-projects/spring-boot/blob/b6b570ebebb6ea233e00af5e554adcf40256f224/gradle.properties#L16C21-L16C27
+junit = '5.13.1'
 mockito = '5.16.0'
 okhttp3 = '4.12.0'
 testcontainers = '1.20.6'
@@ -125,12 +127,6 @@ testng = { module = 'org.testng:testng', version.ref = 'testng' }
 aspectj = { module = 'org.aspectj:aspectjweaver', version.ref = 'aspectj' }
 bonigarcia-webdrivermanager = { module = 'io.github.bonigarcia:webdrivermanager', version.ref = 'bonigarcia-webdrivermanager' }
 netty-resolver-dns-native = { module = 'io.netty:netty-resolver-dns-native-macos' }
-
-# CVE fixes
-json-smart = { module = 'net.minidev:json-smart', version = '2.5.2' }
-netty-common = { module = 'io.netty:netty-common', version.ref = 'netty' }
-netty-handler = { module = 'io.netty:netty-handler', version.ref = 'netty' }
-spring-context = { module = 'org.springframework:spring-context', version = '6.2.7' }
 
 # test scope
 bouncycastle-bcpkix = { module = 'org.bouncycastle:bcpkix-jdk18on', version = '1.80' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ odd-oddrn-client = '0.1.41'
 cel = '0.3.0'
 # This version should be compatible with the version used by spring-boot-starter-test to avoid conflicts
 # See https://github.com/spring-projects/spring-boot/blob/b6b570ebebb6ea233e00af5e554adcf40256f224/gradle.properties#L16C21-L16C27
-junit = '5.13.1'
+junit = '5.12.2'
 mockito = '5.16.0'
 okhttp3 = '4.12.0'
 testcontainers = '1.20.6'


### PR DESCRIPTION
**What changes did you make? (Give an overview)**

- Upgraded Spring Boot to the latest version (`3.5.3`) to fetch the latest bug fixes and features as well as fixing CVE-2025-41234 
- Removed several dependency overrides that are no longer necessary since they were upgraded by Spring
- Removed the explicit inclusion of `Junit5` , as it is provided transitively by `spring-boot-starter-test`. Keeping it explicitly declared leads to version conflicts, which goes against the [JUnit project's recommendations for Spring Boot](https://docs.junit.org/snapshot/user-guide/#running-tests-build-spring-boot).


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**

![image](https://github.com/user-attachments/assets/d9ed7914-a875-480b-b424-613e711ef5de)
