### PR TITLE
FE: Support `awsRoleArn` when using IAM Auth

### DIFF
--- a/frontend/src/widgets/ClusterConfigForm/Sections/Authentication/AuthenticationMethods.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/Authentication/AuthenticationMethods.tsx
@@ -76,12 +76,32 @@ const AuthenticationMethods: React.FC<{ method: string }> = ({ method }) => {
       );
     case 'SASL/AWS IAM':
       return (
-        <Input
-          label="AWS Profile Name"
-          type="text"
-          name="auth.props.awsProfileName"
-          withError
-        />
+        <>
+          <Input
+            label="AWS Profile Name"
+            type="text"
+            name="auth.props.awsProfileName"
+            withError
+          />
+          <Input
+            label="AWS Role Arn"
+            type="text"
+            name="auth.props.awsRoleArn"
+            withError
+          />
+          <Input
+            label="AWS Role Session Name"
+            type="text"
+            name="auth.props.awsRoleSessionName"
+            withError
+          />
+          <Input
+            label="AWS STS Region"
+            type="text"
+            name="auth.props.awsStsRegion"
+            withError
+          />
+        </>
       );
     case 'mTLS':
       return <SSLForm prefix="auth.keystore" title="Keystore" />;

--- a/frontend/src/widgets/ClusterConfigForm/schema.ts
+++ b/frontend/src/widgets/ClusterConfigForm/schema.ts
@@ -141,7 +141,10 @@ const authPropsSchema = lazy((_, { parent }) => {
       });
     case 'SASL/AWS IAM':
       return object({
-        awsProfileName: string(),
+        awsProfileName: string().notRequired(),
+        awsRoleArn: string().notRequired(),
+        awsRoleSessionName: string().notRequired(),
+        awsStsRegion: string().notRequired(),
       });
     case 'SASL/Azure Entra':
     case 'SASL/GCP IAM':

--- a/frontend/src/widgets/ClusterConfigForm/schema.ts
+++ b/frontend/src/widgets/ClusterConfigForm/schema.ts
@@ -141,10 +141,10 @@ const authPropsSchema = lazy((_, { parent }) => {
       });
     case 'SASL/AWS IAM':
       return object({
-        awsProfileName: string().notRequired(),
-        awsRoleArn: string().notRequired(),
-        awsRoleSessionName: string().notRequired(),
-        awsStsRegion: string().notRequired(),
+        awsProfileName: string(),
+        awsRoleArn: string(),
+        awsRoleSessionName: string(),
+        awsStsRegion: string(),
       });
     case 'SASL/Azure Entra':
     case 'SASL/GCP IAM':

--- a/frontend/src/widgets/ClusterConfigForm/utils/transformFormDataToPayload.ts
+++ b/frontend/src/widgets/ClusterConfigForm/utils/transformFormDataToPayload.ts
@@ -260,6 +260,9 @@ export const transformFormDataToPayload = (data: ClusterConfigFormValues) => {
             'software.amazon.msk.auth.iam.IAMClientCallbackHandler',
           'sasl.jaas.config': getJaasConfig('SASL/AWS IAM', {
             awsProfileName: props.awsProfileName,
+            awsRoleArn: props.awsRoleArn,
+            awsRoleSessionName: props.awsRoleSessionName,
+            awsStsRegion: props.awsStsRegion
           }),
         };
         break;

--- a/frontend/src/widgets/ClusterConfigForm/utils/transformFormDataToPayload.ts
+++ b/frontend/src/widgets/ClusterConfigForm/utils/transformFormDataToPayload.ts
@@ -262,7 +262,7 @@ export const transformFormDataToPayload = (data: ClusterConfigFormValues) => {
             awsProfileName: props.awsProfileName,
             awsRoleArn: props.awsRoleArn,
             awsRoleSessionName: props.awsRoleSessionName,
-            awsStsRegion: props.awsStsRegion
+            awsStsRegion: props.awsStsRegion,
           }),
         };
         break;


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Added support for the optional `awsRoleArn` configuration when using IAM authentication.

**Is there anything you'd like reviewers to focus on?**
In addition to `awsRoleArn`, I have also added `awsRoleSessionName` & `awsStsRegion` as defined here in [MSK IAM Auth Library](https://github.com/aws/aws-msk-iam-auth?tab=readme-ov-file#specifying-an-aws-iam-role-for-a-client).

```
sasl.jaas.config=software.amazon.msk.auth.iam.IAMLoginModule required awsRoleArn="arn:aws:iam::123456789012:role/msk_client_role" awsRoleSessionName="producer"  awsStsRegion="us-west-2";
```

Docs PR: https://github.com/kafbat/ui-docs/pull/61

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
