### PR TITLE
Add all changes to connect with GCP Schema Registries

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
@@ -70,6 +70,9 @@ public class ClustersProperties {
     List<@Valid Masking> masking;
 
     AuditProperties audit;
+
+    boolean gcpSchemaRegistry = false;
+
   }
 
   @Data

--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/MessageFormatter.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/MessageFormatter.java
@@ -11,6 +11,7 @@ import io.confluent.kafka.serializers.KafkaAvroDeserializerConfig;
 import io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
 import io.kafbat.ui.util.jsonschema.JsonAvroConversion;
+import java.util.HashMap;
 import java.util.Map;
 import lombok.SneakyThrows;
 
@@ -18,9 +19,10 @@ interface MessageFormatter {
 
   String format(String topic, byte[] value);
 
-  static Map<SchemaType, MessageFormatter> createMap(SchemaRegistryClient schemaRegistryClient) {
+  static Map<SchemaType, MessageFormatter> createMap(SchemaRegistryClient schemaRegistryClient,
+                                                     boolean gcpSchemaRegistry) {
     return Map.of(
-        SchemaType.AVRO, new AvroMessageFormatter(schemaRegistryClient),
+        SchemaType.AVRO, new AvroMessageFormatter(schemaRegistryClient, gcpSchemaRegistry),
         SchemaType.JSON, new JsonSchemaMessageFormatter(schemaRegistryClient),
         SchemaType.PROTOBUF, new ProtobufMessageFormatter(schemaRegistryClient)
     );
@@ -29,17 +31,23 @@ interface MessageFormatter {
   class AvroMessageFormatter implements MessageFormatter {
     private final KafkaAvroDeserializer avroDeserializer;
 
-    AvroMessageFormatter(SchemaRegistryClient client) {
+    AvroMessageFormatter(SchemaRegistryClient client, boolean gcpSchemaRegistry) {
       this.avroDeserializer = new KafkaAvroDeserializer(client);
-      this.avroDeserializer.configure(
-          Map.of(
-              AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "wontbeused",
-              KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false,
-              KafkaAvroDeserializerConfig.SCHEMA_REFLECTION_CONFIG, false,
-              KafkaAvroDeserializerConfig.AVRO_USE_LOGICAL_TYPE_CONVERTERS_CONFIG, true
-          ),
-          false
-      );
+
+      final Map<String, Object> avroProps = new HashMap<>();
+      avroProps.put(AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, "wontbeused");
+      avroProps.put(KafkaAvroDeserializerConfig.SPECIFIC_AVRO_READER_CONFIG, false);
+      avroProps.put(KafkaAvroDeserializerConfig.SCHEMA_REFLECTION_CONFIG, false);
+      avroProps.put(KafkaAvroDeserializerConfig.AVRO_USE_LOGICAL_TYPE_CONVERTERS_CONFIG, true);
+
+      if (gcpSchemaRegistry) {
+        avroProps.put(KafkaAvroDeserializerConfig.BEARER_AUTH_CREDENTIALS_SOURCE, "CUSTOM");
+        avroProps.put(KafkaAvroDeserializerConfig.BEARER_AUTH_CUSTOM_PROVIDER_CLASS,
+            "class com.google.cloud.hosted.kafka.auth.GcpBearerAuthCredentialProvider");
+      }
+
+      this.avroDeserializer.configure(avroProps, false);
+
     }
 
     @Override

--- a/api/src/main/java/io/kafbat/ui/service/KafkaClusterFactory.java
+++ b/api/src/main/java/io/kafbat/ui/service/KafkaClusterFactory.java
@@ -167,11 +167,13 @@ public class KafkaClusterFactory {
   }
 
   private ReactiveFailover<KafkaSrClientApi> schemaRegistryClient(ClustersProperties.Cluster clusterProperties) {
+
     var auth = Optional.ofNullable(clusterProperties.getSchemaRegistryAuth())
         .orElse(new ClustersProperties.SchemaRegistryAuth());
     WebClient webClient = new WebClientConfigurator()
         .configureSsl(clusterProperties.getSsl(), clusterProperties.getSchemaRegistrySsl())
         .configureBasicAuth(auth.getUsername(), auth.getPassword())
+        .configureGcpBearerAuth(clusterProperties.isGcpSchemaRegistry())
         .configureBufferSize(webClientMaxBuffSize)
         .build();
     return ReactiveFailover.create(

--- a/api/src/main/java/io/kafbat/ui/service/SchemaRegistryService.java
+++ b/api/src/main/java/io/kafbat/ui/service/SchemaRegistryService.java
@@ -148,14 +148,21 @@ public class SchemaRegistryService {
                                                          String schemaName) {
     return api(cluster)
         .mono(c -> c.getSubjectCompatibilityLevel(schemaName, true))
-        .map(CompatibilityConfig::getCompatibilityLevel)
+        .map(compatibilityConfig ->
+            cluster.getOriginalProperties().isGcpSchemaRegistry()
+                ? compatibilityConfig.getCompatibility()
+                : compatibilityConfig.getCompatibilityLevel())
         .onErrorResume(error -> Mono.empty());
   }
 
   public Mono<Compatibility> getGlobalSchemaCompatibilityLevel(KafkaCluster cluster) {
     return api(cluster)
         .mono(KafkaSrClientApi::getGlobalCompatibilityLevel)
-        .map(CompatibilityConfig::getCompatibilityLevel);
+        .map(compatibilityConfig ->
+            cluster.getOriginalProperties().isGcpSchemaRegistry()
+                ? compatibilityConfig.getCompatibility()
+                : compatibilityConfig.getCompatibilityLevel()
+        );
   }
 
   private Mono<Compatibility> getSchemaCompatibilityInfoOrGlobal(KafkaCluster cluster,

--- a/api/src/test/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerdeTest.java
+++ b/api/src/test/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerdeTest.java
@@ -35,7 +35,7 @@ class SchemaRegistrySerdeTest {
   @BeforeEach
   void init() {
     serde = new SchemaRegistrySerde();
-    serde.configure(List.of("wontbeused"), registryClient, "%s-key", "%s-value", true);
+    serde.configure(List.of("wontbeused"), registryClient, false, "%s-key", "%s-value", true);
   }
 
   @ParameterizedTest
@@ -135,7 +135,7 @@ class SchemaRegistrySerdeTest {
 
     @BeforeEach
     void init() {
-      serde.configure(List.of("wontbeused"), registryClient, "%s-key", "%s-value", false);
+      serde.configure(List.of("wontbeused"), registryClient, false, "%s-key", "%s-value", false);
     }
 
     @Test
@@ -151,7 +151,7 @@ class SchemaRegistrySerdeTest {
 
     @BeforeEach
     void init() {
-      serde.configure(List.of("wontbeused"), registryClient, "%s-key", "%s-value", true);
+      serde.configure(List.of("wontbeused"), registryClient, false, "%s-key", "%s-value", true);
     }
 
     @Test

--- a/contract/src/main/resources/swagger/kafbat-ui-api.yaml
+++ b/contract/src/main/resources/swagger/kafbat-ui-api.yaml
@@ -4341,6 +4341,8 @@ components:
                             type: string
                           keystorePassword:
                             type: string
+                      gcpSchemaRegistry:
+                        type: boolean
                       ksqldbServer:
                         type: string
                       ksqldbServerSsl:

--- a/contract/src/main/resources/swagger/kafka-sr-api.yaml
+++ b/contract/src/main/resources/swagger/kafka-sr-api.yaml
@@ -381,8 +381,13 @@ components:
             properties:
                 compatibilityLevel:
                     $ref: '#/components/schemas/Compatibility'
-            required:
-                - compatibilityLevel
+                # GCP Managed Kafka Schema registries specific fields
+                alias:
+                    type: string
+                compatibility:
+                    $ref: '#/components/schemas/Compatibility'
+                normalize:
+                    type: boolean
 
         CompatibilityLevelChange:
             type: object


### PR DESCRIPTION
<!-- ignore-task-list-start -->
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Added new cluster property "gcpSchemaRegistry" to enable compatibility with new [GCP Schema Registries](https://cloud.google.com/managed-service-for-apache-kafka/docs/schema-registry/schema-registry-overview).
This property can be used in config.yaml file like this:

```yaml
kafka:
  clusters:
    - name: local  # Unique name identifier for the Kafka cluster
      bootstrap-servers: kafka1:9092,kafka2:9092  # List of Kafka broker addresses

      schemaRegistry: https://managedkafka.googleapis.com/v1/projects/PROJECT_ID/locations/REGION/schemaRegistries/REGISTRY_ID
      gcpSchemaRegistry: true # false by default
```

Or can be enabled with the env variable: `KAFKA_CLUSTERS_0_GCPSCHAMAREGISTRY=true`

Important changes in code are:

- Add bearer token generation for auth with GCP Schema Registry in WebClientConfigurator
- Add custom bearer token provider in SchemaRegistrySerde
- Add the new `gcpSchemaRegistry` config property in kafbat-ui-api
- Add new schema fields kafka-sr-api for compatibility level as GCP Schema Registry return different format.
- Add condition to use compatibility or compatibliityLevel field based on gcpSchemaRegistry enabled or not in
  SchemaRegistryService

It's needed to use `gcloud auth application-default login` to get the credentials to connect to GCP Schema 
Registries or run kafka-ui in a compute engine instance or GKE with a service account with the needed permissions.

Note: This functionality only works now with Avro schema types as these are the ones I work with.
It could work with Protobuf schemas, but not with JSON ones as GCP Schema Registries don't 
support them.



**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Manually (please, describe, if necessary)
  
  Changes tested connecting to GCP and Confluent Schema Registries to check:
  
  - All Schemas registered are shown in Schema Registry dashboard 
  - Topic events are deserialized correctly in the topics dashboards.
  
  It was impossible to pass unit tests even before adding any change :'(
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

