### PR TITLE
Infra: Replace usage of Dependabot's reviewers with CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,7 @@
 
 
 # BACKEND
+gradle/libs.versions.toml   @kafbat/backend
 /build.gradle               @kafbat/backend
 /gradle.properties          @kafbat/backend
 /settings.gradle            @kafbat/backend

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,6 @@ updates:
     interval: weekly
     time: "10:00"
     timezone: Europe/London
-  reviewers:
-    - "kafbat/backend"
   open-pull-requests-limit: 10
   labels:
     - "type/dependencies"
@@ -27,8 +25,6 @@ updates:
     interval: weekly
     time: "10:00"
     timezone: Europe/London
-  reviewers:
-    - "kafbat/backend"
   open-pull-requests-limit: 10
   ignore:
   - dependency-name: "azul/zulu-openjdk-alpine"
@@ -43,8 +39,6 @@ updates:
     interval: weekly
     time: "10:00"
     timezone: Europe/London
-  reviewers:
-    - "kafbat/frontend"
   open-pull-requests-limit: 10
   versioning-strategy: increase-if-necessary
   labels:
@@ -64,8 +58,6 @@ updates:
     interval: weekly
     time: "10:00"
     timezone: Europe/London
-  reviewers:
-    - "kafbat/devops"
   open-pull-requests-limit: 10
   labels:
     - "type/dependencies"


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

The `reviewers` field in the `dependabot.yml` file will be removed soon. For more information, see [this blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/).

This pull request removes the usage of the `reviewers` field and creates a `CODEWNERS` file instead


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to

<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**

