### PR TITLE
fix: Fix word of values view in statics partition

### DIFF
--- a/frontend/src/components/Topics/Topic/Statistics/PartitionInfoRow.tsx
+++ b/frontend/src/components/Topics/Topic/Statistics/PartitionInfoRow.tsx
@@ -74,13 +74,13 @@ const PartitionInfoRow: React.FC<{ row: Row<TopicAnalysisStats> }> = ({
       <div>
         <Heading level={4}>Values sizes</Heading>
         <List>
-          <Label>Total key size</Label>
+          <Label>Total value size</Label>
           <BytesFormatted value={valueSize?.sum} />
-          <Label>Min key size</Label>
+          <Label>Min value size</Label>
           <BytesFormatted value={valueSize?.min} />
-          <Label>Max key size</Label>
+          <Label>Max value size</Label>
           <BytesFormatted value={valueSize?.max} />
-          <Label>Avg key size</Label>
+          <Label>Avg value size</Label>
           <BytesFormatted value={valueSize?.avg} />
           <Label>Percentile 50</Label>
           <BytesFormatted value={valueSize?.prctl50} />


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Very simple changed.

I have seen 'key' word at Values sizes area.

This change does not affect functionality and is intended solely to improve clarity and accuracy in the wording.

as-is
<img width="1660" height="469" alt="스크린샷 2025-07-21 오전 8 35 52" src="https://github.com/user-attachments/assets/c68aeb42-e409-459d-a168-2b48a160f229" />

to-be
<img width="1664" height="430" alt="image" src="https://github.com/user-attachments/assets/e29e0e72-effb-4cce-96b5-58241ee74768" />


**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to
- [ ] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
