### PR TITLE
FE: Use theme color definition for warning icon

### DIFF
--- a/frontend/src/components/common/Icons/WarningIcon.tsx
+++ b/frontend/src/components/common/Icons/WarningIcon.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 const WarningIconContainer = styled.span`
   align-items: center;
@@ -10,6 +10,7 @@ const WarningIconContainer = styled.span`
 `;
 
 const WarningIcon: React.FC = () => {
+  const theme = useTheme();
   return (
     <WarningIconContainer>
       <svg
@@ -24,7 +25,7 @@ const WarningIcon: React.FC = () => {
           fillRule="evenodd"
           clipRule="evenodd"
           d="M8.09265 1.06679C7.60703 0.250524 6.39297 0.250524 5.90735 1.06679L0.170916 10.7089C-0.314707 11.5252 0.292322 12.5455 1.26357 12.5455H12.7364C13.7077 12.5455 14.3147 11.5252 13.8291 10.7089L8.09265 1.06679ZM6 5.00006C6 4.44778 6.44772 4.00006 7 4.00006C7.55228 4.00006 8 4.44778 8 5.00006V7.00006C8 7.55235 7.55228 8.00006 7 8.00006C6.44772 8.00006 6 7.55235 6 7.00006V5.00006ZM6 10.0001C6 9.44778 6.44772 9.00006 7 9.00006C7.55228 9.00006 8 9.44778 8 10.0001C8 10.5523 7.55228 11.0001 7 11.0001C6.44772 11.0001 6 10.5523 6 10.0001Z"
-          fill="#F2C94C"
+          fill={theme.icons.warningIcon}
         />
       </svg>
     </WarningIconContainer>

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -68,6 +68,7 @@ const Colors = {
   yellow: {
     '10': '#FFEECC',
     '20': '#FFDD57',
+    '30': '#FFD439',
   },
   blue: {
     '10': '#e3f2fd',
@@ -270,7 +271,7 @@ const baseTheme = {
     infoIcon: Colors.neutral[30],
     closeCircleIcon: Colors.neutral[30],
     deleteIcon: Colors.red[20],
-    warningIcon: Colors.yellow[20],
+    warningIcon: Colors.yellow[30],
     warningRedIcon: {
       rectFill: Colors.red[10],
       pathFill: Colors.red[50],


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

We already have a color definition `warningIcon` in our theme which is close to the hard-coded yellow color in the actual template `<WarningIcon>`. Use it for consistency and allow theming here.

The original theme color `yellow[20]` changes the icon from #F2C94C to #FFDD57 which is close, but drops the contrast ratio on white background from 1.58:1 to 1.33:1.
Introduce a darker version `yellow[30]` with #FFD439, so we get at least up to 1.42:1. See screenshots below for comparison.

Stumbled across this during #1108

**Is there anything you'd like reviewers to focus on?**

AFAIK the warning icon is only used in the header for outdated versions (see screenshot at the bottom of the attached image)


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

<img width="1536" height="789" alt="44a45bc9-76ad-42fd-b4bd-9b142be39d0b" src="https://github.com/user-attachments/assets/fc8ef6b0-ea2e-49fb-95fa-2a51fe3851f7" />
