### PR TITLE
Infra: Exclude Springboot dependencies from the `other-dependencies` dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,9 @@ updates:
         - "patch"
         - "minor"
     other-dependencies:
+      exclude-patterns:
+        - "org.springframework.boot:*"
+        - "io.spring.dependency-management"
       patterns:
         - "*"
       update-types:


### PR DESCRIPTION
It looks like Dependabot doesn’t handle this by default. With the current configuration, it still assigns the Spring dependencies to the default group instead of the dedicated Spring Boot group.

See https://github.com/kafbat/kafka-ui/pull/1271 for an example


**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**

This a follow up for https://github.com/kafbat/kafka-ui/pull/1181


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to

<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**

![zorro-e1649086718471-1024x503](https://github.com/user-attachments/assets/45033aa2-d46e-4d27-8def-987ba26a58b3)
