### PR TITLE
Infra: Ignore Netty updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,11 @@ updates:
   labels:
     - "type/dependencies"
     - "scope/backend"
+  ignore:
+    # Disable dependabot pull request for Netty
+    # In general, our  Netty references are temporary overrides, usually applied to address transitive Spring vulnerabilities, and should be configured with caution
+    # In general, having conflicting Netty versions in the classpath is not recommended
+    - dependency-name: "io.netty:*"
   groups:
     spring-boot-dependencies:
       patterns:
@@ -23,16 +28,10 @@ updates:
       exclude-patterns:
           - "org.springframework.boot:*"
           - "io.spring.dependency-management"
-          # All netty references are temporary overwrites that must be set carefully
-          # We do not need dependabot to send pull requests
-          - "io.netty:*"    
     other-dependencies:
       exclude-patterns:
         - "org.springframework.boot:*"
         - "io.spring.dependency-management"
-        # All netty references are temporary overwrites that must be set carefully
-        # We do not need dependabot to send pull requests
-        - "io.netty:*"
       patterns:
         - "*"
       update-types:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,8 @@ updates:
     - "type/dependencies"
     - "scope/backend"
   ignore:
-    # Disable dependabot pull request for Netty
-    # In general, our  Netty references are temporary overrides, usually applied to address transitive Spring vulnerabilities, and should be configured with caution
+    # Disable dependabot pull requests for Netty
+    # In general, our Netty references are temporary overrides, usually applied to address transitive Spring vulnerabilities, and should be configured with caution
     # In general, having conflicting Netty versions in the classpath is not recommended
     - dependency-name: "io.netty:*"
   groups:


### PR DESCRIPTION
Follow up for https://github.com/kafbat/kafka-ui/pull/1323

**Is there anything you'd like reviewers to focus on?**

Although the previous configuration was technically accurate regarding the groups, it resulted in Netty upgrades being processed individually rather than grouped. This update ensures Netty upgrades are fully ignored, as originally intended.

Closes https://github.com/kafbat/kafka-ui/pull/1326

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to


**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged


**A picture of a cute animal (not mandatory but encouraged)**
