### PR TITLE
Infra: Run dependabot daily for gradle, npm and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
 - package-ecosystem: gradle
   directory: "/"
   schedule:
-    interval: weekly
+    interval: daily
     time: "10:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
@@ -41,7 +41,7 @@ updates:
 - package-ecosystem: docker
   directory: "/api"
   schedule:
-    interval: weekly
+    interval: daily
     time: "10:00"
     timezone: Europe/London
   open-pull-requests-limit: 10
@@ -55,7 +55,7 @@ updates:
 - package-ecosystem: npm
   directory: "/frontend"
   schedule:
-    interval: weekly
+    interval: daily
     time: "10:00"
     timezone: Europe/London
   open-pull-requests-limit: 10


### PR DESCRIPTION
**Is there anything you'd like reviewers to focus on?**

Dependencies such as Spring are highly susceptible to CVEs, so it’s important to promptly receive and merge fixes when vulnerabilities are identified. For example https://github.com/kafbat/kafka-ui/pull/1354 needed manual intervention due to this same Dependabot timing

Theoretically, Dependabot Security updates(if enabled) should be able to handle security upgrades off-the schedule. However, that heavily depends on a vetted CVE and the corresponding Dependabot alert. For new CVEs where the alert does not exist yet, this may add 2-3 days of latency

Currently, the number of Dependabot pull requests is low because of our grouping configuration, so increasing its run frequency should not create extra noise for maintainers.

I excluded GitHub actions because weekly should be fine for that ecosystem given that the CVE pressure there is low

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**

<img width="1024" height="535" alt="image" src="https://github.com/user-attachments/assets/a3f03df8-5a73-4efd-b791-50eb3e414f85" />
