### PR TITLE
Change mock json to use alwaysFakeOptionals=false

### DIFF
--- a/frontend/src/components/Topics/Topic/SendMessage/utils.ts
+++ b/frontend/src/components/Topics/Topic/SendMessage/utils.ts
@@ -12,7 +12,7 @@ import AjvDraft4 from 'ajv-draft-04';
 import addFormats from 'ajv-formats';
 
 jsf.option('fillProperties', false);
-jsf.option('alwaysFakeOptionals', true);
+jsf.option('alwaysFakeOptionals', false);
 jsf.option('failOnInvalidFormat', false);
 
 const generateValueFromSchema = (preferred?: SerdeDescription) => {


### PR DESCRIPTION
Why: For some complex schemas, the mock library hangs because of this option is true.

This is possibly because of a bug leading to an infinite loop, or because the nature of the schema leading to exponential amount of optional fields to be generated

Setting alwaysFakeOptionals to false fixes this issue for the schema that caused the error

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Set alwaysFakeOptionals=false

**Is there anything you'd like reviewers to focus on?**
I understand there is a tradeoff here, but it completely breaks some of our topic, so it would be great if it could be merged.

Also note that the schema mocker for some reason runs on the main topic page load (not just by clicking on produce)
So it stops the topic completely from being accessed.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [X] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->
Tested the schema locally with the schema mock library, tried with and without this option, where without the schema generated fine

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [X] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
🦭