### PR TITLE
FE: Hide internal topics by default (closes #1073)

### DIFF
--- a/frontend/src/components/Topics/List/ListPage.tsx
+++ b/frontend/src/components/Topics/List/ListPage.tsx
@@ -31,7 +31,7 @@ const ListPage: React.FC = () => {
       if (stored === null) localStorage.setItem('hideInternalTopics', 'true');
     } else {
       // sync localStorage if URL has it set
-      const raw =  searchParams.get('hideInternal');
+      const raw = searchParams.get('hideInternal');
       const norm = raw === 'true' || raw === 'false' ? raw : 'true'; // default to true if malformed
       localStorage.setItem('hideInternalTopics', norm);
       if (norm !== raw) searchParams.set('hideInternal', norm); // sync URL if malformed

--- a/frontend/src/components/Topics/List/ListPage.tsx
+++ b/frontend/src/components/Topics/List/ListPage.tsx
@@ -22,19 +22,27 @@ const ListPage: React.FC = () => {
     if (!searchParams.has('perPage')) {
       searchParams.set('perPage', String(PER_PAGE));
     }
-    if (
-      !!localStorage.getItem('hideInternalTopics') &&
-      !searchParams.has('hideInternal')
-    ) {
-      searchParams.set('hideInternal', 'true');
+    // If URL doesn't specify it, derive from localStorage (default = true when missing)
+    if (!searchParams.has('hideInternal')) {
+      const stored = localStorage.getItem('hideInternalTopics');
+      const shouldHide = stored === null ? true : stored === 'true';
+      searchParams.set('hideInternal', String(shouldHide));
+      // persist the default so it sticks across pages
+      if (stored === null) localStorage.setItem('hideInternalTopics', 'true');
+    } else {
+      // sync localStorage if URL has it set
+      const raw =  searchParams.get('hideInternal');
+      const norm = raw === 'true' || raw === 'false' ? raw : 'true'; // default to true if malformed
+      localStorage.setItem('hideInternalTopics', norm);
+      if (norm !== raw) searchParams.set('hideInternal', norm); // sync URL if malformed
     }
     setSearchParams(searchParams);
   }, []);
 
   const handleSwitch = () => {
-    if (searchParams.has('hideInternal')) {
-      localStorage.removeItem('hideInternalTopics');
-      searchParams.delete('hideInternal');
+    if (searchParams.get('hideInternal') === 'true') {
+      localStorage.setItem('hideInternalTopics', 'false');
+      searchParams.set('hideInternal', 'false');
     } else {
       localStorage.setItem('hideInternalTopics', 'true');
       searchParams.set('hideInternal', 'true');
@@ -66,7 +74,7 @@ const ListPage: React.FC = () => {
         <label>
           <Switch
             name="ShowInternalTopics"
-            checked={!searchParams.has('hideInternal')}
+            checked={searchParams.get('hideInternal') === 'false'}
             onChange={handleSwitch}
           />
           Show Internal Topics

--- a/frontend/src/components/Topics/List/__tests__/ListPage.spec.tsx
+++ b/frontend/src/components/Topics/List/__tests__/ListPage.spec.tsx
@@ -36,11 +36,11 @@ describe('ListPage Component', () => {
       const switchInput = screen.getByLabelText('Show Internal Topics');
       expect(switchInput).toBeInTheDocument();
 
-      expect(global.localStorage.getItem('hideInternalTopics')).toBeNull();
-      await userEvent.click(switchInput);
       expect(global.localStorage.getItem('hideInternalTopics')).toBeTruthy();
       await userEvent.click(switchInput);
-      expect(global.localStorage.getItem('hideInternalTopics')).toBeNull();
+      expect(global.localStorage.getItem('hideInternalTopics')).toBeFalsy();
+      await userEvent.click(switchInput);
+      expect(global.localStorage.getItem('hideInternalTopics')).toBeTruthy();
     });
 
     it('renders the TopicsTable', () => {


### PR DESCRIPTION

<!-- ignore-task-list-start -->

* [ ] **Breaking change?**
  **No.** Defaults only apply when the URL lacks `hideInternal` and no prior preference exists in `localStorage`. Existing explicit URL values and saved preferences continue to work as before.

<!-- ignore-task-list-end -->

**What changes did you make?** (Give an overview)

* Frontend (Topics → `ListPage.tsx`): When the URL has no `hideInternal` param, derive the value from `localStorage('hideInternalTopics')`, **defaulting to `true` if missing**.
* Respect explicit URL values (`?hideInternal=true/false`).
* Parse the stored value as a real boolean (`'true'`/`'false'`) instead of truthy/falsy.
* Avoid mutating the existing `URLSearchParams` instance (create a new one before calling `setSearchParams`).

Closes #1073.

**Is there anything you'd like reviewers to focus on?**

* URL precedence over localStorage (explicit URL should win).
* Whether we should **persist** the default (`'true'`) back to `localStorage` on first run (current change does, for consistency across sessions).
* Any preference on naming/placement if you’d like this logic factored into a small helper.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)

<!-- ignore-task-list-start -->

* [ ] No need to
* [x] Manually (IST):

  * Clear `localStorage`; open Topics → `?hideInternal=true` gets appended.
  * Toggle to show internal; reload persists as expected.
  * Visit with `?hideInternal=false` in URL; list shows internals; reload preserves via URL/localStorage.
* [ ] Unit checks
* [ ] Integration checks
* [ ] Covered by existing automation

<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)

* [ ] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**) — *note: UI behavior now defaults to hiding internal topics; added a short note to docs if required*
* [ ] My changes generate no new warnings (e.g. Sonar is happy)
* [ ] I have added tests that prove my fix is effective or that my feature works (if applicable)
* [ ] New and existing unit tests pass locally with my changes
* [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
![cute-bush-baby](https://imgs.search.brave.com/BkVfdJnP6GS7f_sB-_VUmX21WSVSFfddZhnS9r6XEIE/rs:fit:500:0:1:0/g:ce/aHR0cHM6Ly9vdXRm/b3JpYS5jb20vd3At/Y29udGVudC91cGxv/YWRzLzIwMjMvMDQv/Y3V0ZS1hbmltYWxz/LTE2MS0wNDA0MjAy/My5qcGc)