### PR TITLE
FE: Add whitespace after readonly cluster name tag

### DIFF
--- a/frontend/src/components/Dashboard/ClusterName.tsx
+++ b/frontend/src/components/Dashboard/ClusterName.tsx
@@ -10,10 +10,9 @@ const ClusterName: React.FC<ClusterNameProps> = ({ row }) => {
   return (
     <div style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
       {readOnly && (
-        <>
-          <Tag color="blue">readonly</Tag>
-          &nbsp;
-        </>
+        <Tag color="blue" style={{ marginRight: '0.75em' }}>
+          readonly
+        </Tag>
       )}
       {name}
     </div>

--- a/frontend/src/components/Topics/List/TopicTitleCell.tsx
+++ b/frontend/src/components/Topics/List/TopicTitleCell.tsx
@@ -15,10 +15,9 @@ export const TopicTitleCell: React.FC<CellContext<Topic, unknown>> = ({
       style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}
     >
       {internal && (
-        <>
-          <Tag color="gray">IN</Tag>
-          &nbsp;
-        </>
+        <Tag color="gray" style={{ marginRight: '0.75em' }}>
+          IN
+        </Tag>
       )}
       {name}
     </NavLink>


### PR DESCRIPTION
**What changes did you make?** (Give an overview)
Add whitespace after the readonly tag next to the cluster name in the dashboard. Follows the approach taken for the internal tag on topics: https://github.com/kafbat/kafka-ui/blob/3c1fd1f456ae77ab8ab409fb3bb57fd9a4351b9d/frontend/src/components/Topics/List/TopicTitleCell.tsx#L20

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Before:
<img width="556" height="321" alt="Screenshot 2025-10-31 at 13 22 12" src="https://github.com/user-attachments/assets/71125373-aa46-43dd-8ae8-4b697fad36c1" />

After:
<img width="596" height="315" alt="Screenshot 2025-11-08 at 10 22 41" src="https://github.com/user-attachments/assets/f2caad77-bf24-4c4d-8b61-d21166a28e35" />

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
