### PR TITLE
FE: Enable sorting for Replication Factor (topics module)

### DIFF
--- a/frontend/src/components/Topics/List/TopicTable.tsx
+++ b/frontend/src/components/Topics/List/TopicTable.tsx
@@ -72,9 +72,9 @@ const TopicTable: React.FC = () => {
         },
       },
       {
+        id: TopicColumnsToSort.REPLICATION_FACTOR,
         header: 'Replication Factor',
         accessorKey: 'replicationFactor',
-        enableSorting: false,
         size: 148,
         maxSize: 148,
       },


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

<!-- ignore-task-list-end -->
**What changes did you make?**

Enabled sorting for the **Replication Factor** column in the topics table.  
Previously, sorting for this column was disabled (`enableSorting: false`). Now, the column has an `id` (`TopicColumnsToSort.REPLICATION_FACTOR`) that activates sorting.  
Backend-side support for sorting by replication factor already exists, so this change only enables it on the UI side.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (verified that sorting by replication factor now works as expected in the Topics list)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal**
<img width="457" height="606" alt="animals" src="https://github.com/user-attachments/assets/f7f2c3ac-cf4e-4731-842f-710dfb1304c8" />

