### PR TITLE
Infra: Update dependabot to adjust exclude patterns for the spring-boot-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,9 +25,6 @@ updates:
       update-types:
         - "patch"
         - "minor"
-      exclude-patterns:
-          - "org.springframework.boot:*"
-          - "io.spring.dependency-management"
     other-dependencies:
       exclude-patterns:
         - "org.springframework.boot:*"


### PR DESCRIPTION

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Removed excluded patterns for direct dependencies as the current configuration blocks Dependabot from sending Spring Boot upgrades 

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] No need to
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged


