### PR TITLE
FE: UX: Update TopicsCell styling in connectors

### DIFF
--- a/frontend/src/components/Connect/List/ConnectorsTable/connectorsColumns/cells/TopicsCell.styled.ts
+++ b/frontend/src/components/Connect/List/ConnectorsTable/connectorsColumns/cells/TopicsCell.styled.ts
@@ -1,19 +1,21 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+import { MultiLineTag } from 'components/common/Tag/Tag.styled';
 
 export const TagsWrapper = styled.div`
-  display: flex;
-  flex-wrap: wrap;
-  word-break: break-word;
-  white-space: pre-wrap;
+  ${({ theme }) => css`
+    display: flex;
+    flex-wrap: wrap;
+    word-break: break-word;
+    white-space: pre-wrap;
 
-  div {
-    a {
-      color: rgb(76, 76, 255) !important;
-      text-decoration: none;
+    ${MultiLineTag} {
+      background-color: ${theme.chips.backgroundColor.normal};
+      color: ${theme.chips.color.normal};
 
       &:hover {
-        color: rgb(23, 23, 207) !important;
+        background-color: ${theme.chips.backgroundColor.hover};
+        color: ${theme.chips.color.hover};
       }
     }
-  }
+  `}
 `;


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

### AS-IS


https://github.com/user-attachments/assets/006504b3-8978-4964-86c6-58a1c34cdabc

### TO-BE


https://github.com/user-attachments/assets/489b49a4-3f43-4dc3-b85b-498066767c01



Currently, it's difficult to see the name of the topic in the table of `Kafka Connect > connectors` page with dark theme because of the text color.

It seems that the current css styling is not applied as expected. So I fixed the css.

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

![IMG_2427](https://github.com/user-attachments/assets/52499772-f53d-4cc0-b2d0-b147acd32b15)
