### PR TITLE
Infra: Create more targeted groups for gradle and group all the action upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,7 +34,6 @@ updates:
         - "org.testcontainers:*"
         - "org.junit.jupiter:*"
         - "org.assertj:*"
-        - "com.gorylenko.gradle-git-properties"
         - "com.bmuschko.docker-remote-api"
         - "org.mockito:*"
         # Bouncy Castle is only used for testing purposes


### PR DESCRIPTION
**What changes did you make?** 

Updated the Dependabot configuration to define more targeted groups. 

The intent is to increase the number of Dependabot pull requests that successfully merge into `main`, as the current grouping is too ambitious and frequently breaks the build (see #1520) causing us to simply ignore the updates and not get the main benefit of Dependabot

The action group was created because it’s generally safer to bundle these updates together. Depending on how things progress, we may need to apply a similar adjustment to it as well. 

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Manually (please, describe, if necessary)

I tested the groups in my fork: https://github.com/yeikel/kafka-ui/pulls

<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged


**A picture of a cute animal (not mandatory but encouraged)**

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/06b9bf08-76f3-45aa-91d8-b10125ae7fe5" />
