### PR TITLE
Infra: Fix typespec generation on Windows

### DIFF
--- a/contract-typespec/build.gradle
+++ b/contract-typespec/build.gradle
@@ -32,7 +32,9 @@ def typeSpecs = ["api"]
 
 typeSpecs.each { spec ->
 
-    def tspPath = "\\tsp --output-dir=${project.layout.buildDirectory.get()}/tsp/${spec} compile .\\"
+    def buildDir = project.layout.buildDirectory.get().asFile
+    def outputDir = new File(buildDir, "tsp${File.separator}${spec}")
+    def tspPath = "tsp --output-dir=\"${outputDir}\" compile ."
 
     tasks.register("installDependencies_${spec}", NpmTask) {
         group = 'build'


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Improve the generation of the typespec so that it is portable and works on Windows as well

**Is there anything you'd like reviewers to focus on?**

Running the build in Windows fails because the format of the command is not correct 

> > Task :contract-typespec:generateOpenApi_api FAILED
> '\tsp' is not recognized as an internal or external command,
> operable program or batch file.
> 
> [Incubating] Problems report is available at: file:///D:/dev/kafka-ui/build/reports/problems/problems-report.html
> 
> FAILURE: Build failed with an exception.
> 
> * What went wrong:
> Execution failed for task ':contract-typespec:generateOpenApi_api'.
> > Process 'command 'D:\dev\kafka-ui\contract-typespec\.gradle\nodejs\node-v22.12.0-win-x64\npm.cmd'' finished with non-zero exit value 1


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Manually (please, describe, if necessary)

 `gradlew.bat clean build ` works now on Windows

- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/f5080e18-5520-4138-99ae-05a153b4a55c" />
