### PR TITLE
Infra: Remove `io.modelcontextprotocol.sdk:mcp-spring-webflux` from the Spring boot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,6 @@ updates:
       patterns:
         - "org.springframework.boot:*"
         - "io.spring.dependency-management"
-        - "io.modelcontextprotocol.sdk:mcp-spring-webflux"
         # We defined this dependency explicitly because Spring uses an older version
         - "com.nimbusds:nimbus-jose-jwt"
     testing:


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

In [https://github.com/kafbat/kafka-ui/pull/1542](https://github.com/kafbat/kafka-ui/pull/1542), we chose to include the `io.modelcontextprotocol.sdk:mcp-spring-webflux` dependency under the Spring Boot group, since it depends on Spring Boot and it is reasonable to test and upgrade them together.

One challenge with this dependency is that it introduces breaking changes in minor releases, which can unexpectedly break minor and patch-level Spring Boot dependency upgrades (for example, https://github.com/kafbat/kafka-ui/pull/1591
).

While it is permitted to create breaking changes under semantic versioning rules for 0.x versions, Dependabot does not differentiate this case and treats such updates as regular patch releases.

To avoid breaking our group and not getting the full benefit of Dependabot, we'll handle this dependency separately for now until it reaches 1.0.0

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
- [x] No need to


**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**

<img width="612" height="407" alt="image" src="https://github.com/user-attachments/assets/663506a1-dc09-4586-a070-548ea77d2f12" />
