### PR TITLE
FE: Align resource filter behaviour

### DIFF
--- a/frontend/src/components/ACLPage/List/List.tsx
+++ b/frontend/src/components/ACLPage/List/List.tsx
@@ -35,9 +35,12 @@ import * as S from './List.styled';
 const ACList: React.FC = () => {
   const { clusterName } = useAppParams<{ clusterName: ClusterName }>();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [search, setSearch] = useState(searchParams.get('q') || '');
   const { isFtsEnabled } = useFts('acl');
-  const { data: aclList } = useAcls({ clusterName, search, fts: isFtsEnabled });
+  const { data: aclList } = useAcls({
+    clusterName,
+    search: searchParams.get('q') ?? '',
+    fts: isFtsEnabled,
+  });
   const { deleteResource } = useDeleteAcl(clusterName);
   const { isReadOnly } = React.useContext(ClusterContext);
   const modal = useConfirm(true);
@@ -51,14 +54,13 @@ const ACList: React.FC = () => {
 
   useEffect(() => {
     const params = new URLSearchParams(searchParams);
-    if (search) {
-      params.set('q', search);
+    if (searchParams.get('q')) {
       params.set('page', '1'); // reset to first page on new search
     } else {
       params.delete('q');
     }
     setSearchParams(params, { replace: true });
-  }, [search]);
+  }, [searchParams.get('q')]);
 
   const handleDeleteClick = (acl: KafkaAcl | null) => {
     if (acl) {
@@ -214,9 +216,8 @@ const ACList: React.FC = () => {
       </ResourcePageHeading>
       <ControlPanelWrapper hasInput>
         <Search
+          key={clusterName}
           placeholder="Search by Principal Name"
-          value={search}
-          onChange={setSearch}
           extraActions={<Fts resourceName="acl" />}
         />
       </ControlPanelWrapper>

--- a/frontend/src/components/ACLPage/List/List.tsx
+++ b/frontend/src/components/ACLPage/List/List.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { ColumnDef, Row } from '@tanstack/react-table';
 import Table from 'components/common/NewTable';

--- a/frontend/src/components/Connect/List/ListPage.tsx
+++ b/frontend/src/components/Connect/List/ListPage.tsx
@@ -31,6 +31,7 @@ const ListPage: React.FC = () => {
       <ConnectorsStatistics isLoading={isLoading} />
       <S.Search hasInput>
         <Search
+          key={clusterName}
           placeholder="Search by Connect Name, Status or Type"
           extraActions={<Fts resourceName="connects" />}
         />

--- a/frontend/src/components/ConsumerGroups/List.tsx
+++ b/frontend/src/components/ConsumerGroups/List.tsx
@@ -133,6 +133,7 @@ const List = () => {
       </ResourcePageHeading>
       <ControlPanelWrapper hasInput>
         <Search
+          key={clusterName}
           placeholder="Search by Consumer Group ID"
           extraActions={<Fts resourceName="consumer_groups" />}
         />

--- a/frontend/src/components/Schemas/List/List.tsx
+++ b/frontend/src/components/Schemas/List/List.tsx
@@ -116,6 +116,7 @@ const List: React.FC = () => {
       </ResourcePageHeading>
       <ControlPanelWrapper hasInput>
         <Search
+          key={clusterName}
           placeholder="Search by Schema Name"
           extraActions={<Fts resourceName="schemas" />}
         />

--- a/frontend/src/components/Topics/List/ListPage.tsx
+++ b/frontend/src/components/Topics/List/ListPage.tsx
@@ -99,6 +99,7 @@ const ListPage: React.FC = () => {
       </ResourcePageHeading>
       <ControlPanelWrapper hasInput>
         <Search
+          key={clusterName}
           placeholder="Search by Topic Name"
           extraActions={<Fts resourceName="topics" />}
         />


### PR DESCRIPTION
Resource filters now correctly clear when users navigate between clusters.

This ensures filters reset properly on cluster changes, preventing unintended behaviour.

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**



Closes #1372
