### PR TITLE
fix(rbac): show connect cluster when user has connector permissions

### DIFF
--- a/api/src/main/java/io/kafbat/ui/controller/KafkaConnectController.java
+++ b/api/src/main/java/io/kafbat/ui/controller/KafkaConnectController.java
@@ -154,7 +154,7 @@ public class KafkaConnectController extends AbstractController implements KafkaC
         : maybeComparator.map(Comparator::reversed);
 
     Flux<FullConnectorInfoDTO> connectors = kafkaConnectService.getAllConnectors(getCluster(clusterName), search, fts)
-        .filterWhen(dto -> accessControlService.isConnectAccessible(dto.getConnect(), clusterName));
+        .filterWhen(dto -> accessControlService.isConnectorAccessible(dto.getConnect(), dto.getName(), clusterName));
 
     Flux<FullConnectorInfoDTO> sorted = comparator.map(connectors::sort).orElse(connectors);
 


### PR DESCRIPTION
Fixes #1612 

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

 Users with only connector-level VIEW permissions (e.g., "kafka-connect/dev-*") could not see the connect cluster in the sidebar because isConnectAccessible only checked for direct connect VIEW permission. Also checks if user has any connector VIEW permission for the connect, using proper regex matching to support all pattern variations.

**Is there anything you'd like reviewers to focus on?**
We compile a regex every time this check runs. That's fine here since it only happens when loading the page, not constantly. Alternative is to precompile the patterns once when the app starts (or when permissions are loaded), then reuse them instead of compiling every time.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Manually (please, describe, if necessary)
  - ran locally with keycloak
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
🦊