### PR TITLE
fix(oauth2): add delegating auth manager to manage oidc and oauth2

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
@@ -19,10 +19,12 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.security.authentication.DelegatingReactiveAuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.oauth2.client.authentication.OAuth2LoginReactiveAuthenticationManager;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
 import org.springframework.security.oauth2.client.endpoint.ReactiveOAuth2AccessTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.WebClientReactiveAuthorizationCodeTokenResponseClient;
@@ -75,6 +77,7 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
       OAuthLogoutSuccessHandler logoutHandler,
       ReactiveOAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> tokenResponseClient,
       ReactiveOAuth2UserService<OidcUserRequest, OidcUser> oidcUserService,
+      ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService,
       @Qualifier("oauthWebClient") WebClient webClient
   ) {
     log.info("Configuring OAUTH2 authentication.");
@@ -82,13 +85,19 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
     var oidcAuthManager =
         new OidcAuthorizationCodeReactiveAuthenticationManager(tokenResponseClient, oidcUserService);
 
+    var oauth2AuthManager =
+        new OAuth2LoginReactiveAuthenticationManager(tokenResponseClient, oauth2UserService);
+
+    var delegatingAuthManager =
+        new DelegatingReactiveAuthenticationManager(oidcAuthManager, oauth2AuthManager);
+
     var builder = http.authorizeExchange(spec -> spec
             .pathMatchers(AUTH_WHITELIST)
             .permitAll()
             .anyExchange()
             .authenticated()
         )
-        .oauth2Login(oauth2 -> oauth2.authenticationManager(oidcAuthManager))
+        .oauth2Login(oauth2 -> oauth2.authenticationManager(delegatingAuthManager))
         .logout(spec -> spec.logoutSuccessHandler(logoutHandler))
         .csrf(ServerHttpSecurity.CsrfSpec::disable);
 

--- a/api/src/test/java/io/kafbat/ui/config/auth/OAuthTestSupport.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/OAuthTestSupport.java
@@ -163,6 +163,24 @@ public final class OAuthTestSupport {
         .build();
   }
 
+  /**
+   * Creates a GitHub-style client registration WITHOUT "openid" scope.
+   * This tests the non-OIDC OAuth2 flow where no ID token is returned.
+   */
+  public static ClientRegistration githubStyleClientRegistration() {
+    return ClientRegistration.withRegistrationId("github")
+        .clientId(CLIENT_ID)
+        .clientSecret(CLIENT_SECRET)
+        .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+        .redirectUri("{baseUrl}/login/oauth2/code/{registrationId}")
+        .scope("read:user")  // No "openid" scope - this is key for non-OIDC
+        .authorizationUri(oauthBaseUrl() + AUTHORIZE_PATH)
+        .tokenUri(oauthBaseUrl() + TOKEN_PATH)
+        .userInfoUri(oauthBaseUrl() + USERINFO_PATH)
+        .userNameAttributeName("login")
+        .build();
+  }
+
   public static OAuthProperties createOAuthProperties() {
     OAuthProperties props = mock(OAuthProperties.class);
     OAuthProperties.OAuth2Provider provider = mock(OAuthProperties.OAuth2Provider.class);


### PR DESCRIPTION
Fixes #1633

<!-- ignore-task-list-start -->

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Fixed GitHub OAuth authentication broken by commit 19fe273. The previous commit configured oauth2Login to use only OidcAuthorizationCodeReactiveAuthenticationManager, which doesn't support non-OIDC OAuth2 providers like GitHub (GitHub doesn't return ID tokens).

**Is there anything you'd like reviewers to focus on?**

The DelegatingReactiveAuthenticationManager tries OIDC first, then falls back to OAuth2. The OIDC manager returns Mono.empty() when no "openid" scope is present, allowing the delegation to work correctly.


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Manually (please, describe, if necessary)
  - Ran with Okta, GitHub, and keycloak locally to validate everything works as expected.
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

  ╱|、
(˚ˎ 。7  
 |、˜〵          
じしˍ,)ノ 