### PR TITLE
FE: KC: prevent TypeError when config is undefined on Connect Config page

### DIFF
--- a/frontend/src/components/Connect/Details/Config/Config.tsx
+++ b/frontend/src/components/Connect/Details/Config/Config.tsx
@@ -60,9 +60,8 @@ const Config: React.FC = () => {
     }
   };
 
-  const hasCredentials = JSON.stringify(config, null, '\t').includes(
-    '"******"'
-  );
+  const hasCredentials =
+    config && JSON.stringify(config, null, '\t').includes('"******"');
   return (
     <ConnectEditWrapperStyled>
       {hasCredentials && (


### PR DESCRIPTION
Fixes #1648 

When loading the connector config page, the config data may briefly be undefined before the API response arrives. The hasCredentials check was calling JSON.stringify(config).includes() without guarding against undefined, causing a TypeError that triggered the ErrorBoundary redirect to /404.

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Added a guard in Config.tsx to check that config is defined before calling JSON.stringify(config).includes('"******"'). The previous code would crash when config was undefined during the loading state, because JSON.stringify(undefined) returns the value undefined (not a string), and calling .includes() on undefined throws a TypeError.

**Is there anything you'd like reviewers to focus on?**
The fix is a one-liner. 

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Manually (please, describe, if necessary)
  - Ran locally end-to-end with docker and validated it works as expected
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⡀⠤⠄⠒⠒⠒⠒⠢⠤⣀⠀⠀⠀⠀⠀⠀⠀
⠀⠀⢀⡠⢤⡀⢀⡀⠤⢀⣀⠶⢅⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠑⢤⠀⠀⠀⠀⠀
⠀⠀⡎⠀⠠⠊⠁⠀⢀⠔⠁⠀⠀⠈⢣⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢳⠀⠀⠀⠀
⠀⡼⠀⢠⠀⠀⠀⡀⢸⠀⠀⠀⠀⠀⠈⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠈⣇⡀⠀⠀
⠸⡀⠀⠄⠀⠀⣶⣦⠀⠳⣄⠀⠀⠀⡄⡇⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡗⡌⢆⠀
⠀⠣⢴⠀⠀⠀⠉⠀⠀⠀⠈⡆⠀⢈⡜⠁⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⠘⢨⠀
⠀⠀⢸⠀⠀⢀⡠⡲⠀⢀⡖⠈⠒⠋⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⡇⢠⠘⡄
⠀⠀⠘⡄⣠⡃⠓⠉⠛⢯⡀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣠⠔⠒⠀⠀⠀⡇⠈⢴⡇
⠀⠀⠀⢣⠀⢧⠀⠀⠀⡆⠉⠉⠆⠀⠀⠑⢶⠒⠂⠹⡀⠳⡤⠤⠀⠀⠹⡄⠈⠀
⠀⠀⠀⠘⡆⣈⡳⠀⠀⡝⠒⠀⢇⡀⠀⠀⢸⠀⠀⠀⣇⣀⢘⠆⠀⠀⠀⢇⠀⠀
⠀⠀⠀⠀⠉⠀⠀⠀⣞⠠⢄⠀⣇⠀⠀⠀⠈⡆⠀⠀⠓⠦⢼⣒⣖⣄⡠⠎⠀⠀
⠀⠀⠀⠀⠀⠀⠀⠀⠈⠉⠉⠙⠢⠯⠥⠤⠔⠃⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀