### PR TITLE
fix(messages): prevent infinite re-read loop when polling range is empty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target/
 .settings
 .springBeans
 .sts4-cache
+.pnpm-store
 
 ### IntelliJ IDEA ###
 .idea

--- a/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
@@ -110,6 +110,7 @@ public class ClustersProperties {
     Integer maxPageSize;
     Integer defaultPageSize;
     Integer responseTimeoutMs;
+    Integer maxMessagesToScanPerPoll;
   }
 
   @Data

--- a/api/src/main/java/io/kafbat/ui/emitter/AbstractEmitter.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/AbstractEmitter.java
@@ -16,10 +16,21 @@ abstract class AbstractEmitter implements java.util.function.Consumer<FluxSink<T
     this.pollingSettings = pollingSettings;
   }
 
+  protected PollingSettings getPollingSettings() {
+    return pollingSettings;
+  }
+
   protected PolledRecords poll(FluxSink<TopicMessageEventDTO> sink, EnhancedConsumer consumer) {
     var records = consumer.pollEnhanced(pollingSettings.getPollTimeout());
     sendConsuming(sink, records);
     return records;
+  }
+
+  /**
+   * Poll without sending CONSUMING stats. Used by range emitters to report in-range-only stats.
+   */
+  protected PolledRecords pollWithoutConsuming(EnhancedConsumer consumer) {
+    return consumer.pollEnhanced(pollingSettings.getPollTimeout());
   }
 
   protected boolean isSendLimitReached() {
@@ -38,6 +49,10 @@ abstract class AbstractEmitter implements java.util.function.Consumer<FluxSink<T
 
   protected void sendConsuming(FluxSink<TopicMessageEventDTO> sink, PolledRecords records) {
     messagesProcessing.sentConsumingInfo(sink, records);
+  }
+
+  protected void sendConsumingInRange(FluxSink<TopicMessageEventDTO> sink, int inRangeRecords, long inRangeBytes, long elapsedMs) {
+    messagesProcessing.sentConsumingInfo(sink, inRangeRecords, inRangeBytes, elapsedMs);
   }
 
   // cursor is null if target partitions were fully polled (no, need to do paging)

--- a/api/src/main/java/io/kafbat/ui/emitter/BackwardEmitter.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/BackwardEmitter.java
@@ -44,8 +44,11 @@ public class BackwardEmitter extends RangePollingEmitter {
       );
     }
 
-    int msgsToPollPerPartition = Math.max(1, (int) Math.ceil((double) messagesPerPage / readToOffsets.size()));
     TreeMap<TopicPartition, FromToOffset> result = new TreeMap<>(Comparator.comparingInt(TopicPartition::partition));
+    if (readToOffsets.isEmpty()) {
+      return result;
+    }
+    int msgsToPollPerPartition = nextChunkSizePerPartition(readToOffsets.size());
     readToOffsets.forEach((tp, toOffset) -> {
       long tpStartOffset = seekOperations.getBeginOffsets().get(tp);
       if (toOffset > tpStartOffset) {

--- a/api/src/main/java/io/kafbat/ui/emitter/BackwardEmitter.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/BackwardEmitter.java
@@ -44,7 +44,7 @@ public class BackwardEmitter extends RangePollingEmitter {
       );
     }
 
-    int msgsToPollPerPartition = (int) Math.ceil((double) messagesPerPage / readToOffsets.size());
+    int msgsToPollPerPartition = Math.max(1, (int) Math.ceil((double) messagesPerPage / readToOffsets.size()));
     TreeMap<TopicPartition, FromToOffset> result = new TreeMap<>(Comparator.comparingInt(TopicPartition::partition));
     readToOffsets.forEach((tp, toOffset) -> {
       long tpStartOffset = seekOperations.getBeginOffsets().get(tp);

--- a/api/src/main/java/io/kafbat/ui/emitter/ConsumingStats.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/ConsumingStats.java
@@ -24,6 +24,20 @@ class ConsumingStats {
     );
   }
 
+  /**
+   * Accumulate and emit CONSUMING event with in-range-only stats (for range emitters).
+   */
+  void sendConsumingEvt(FluxSink<TopicMessageEventDTO> sink, int inRangeRecords, long inRangeBytes, long elapsedMs) {
+    bytes += inRangeBytes;
+    records += inRangeRecords;
+    elapsed += elapsedMs;
+    sink.next(
+        new TopicMessageEventDTO()
+            .type(TopicMessageEventDTO.TypeEnum.CONSUMING)
+            .consuming(createConsumingStats())
+    );
+  }
+
   void incFilterApplyError() {
     filterApplyErrors++;
   }

--- a/api/src/main/java/io/kafbat/ui/emitter/ForwardEmitter.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/ForwardEmitter.java
@@ -44,8 +44,11 @@ public class ForwardEmitter extends RangePollingEmitter {
       );
     }
 
-    int msgsToPollPerPartition = Math.max(1, (int) Math.ceil((double) messagesPerPage / readFromOffsets.size()));
     TreeMap<TopicPartition, FromToOffset> result = new TreeMap<>(Comparator.comparingInt(TopicPartition::partition));
+    if (readFromOffsets.isEmpty()) {
+      return result;
+    }
+    int msgsToPollPerPartition = nextChunkSizePerPartition(readFromOffsets.size());
     readFromOffsets.forEach((tp, fromOffset) -> {
       long tpEndOffset = seekOperations.getEndOffsets().get(tp);
       if (fromOffset < tpEndOffset) {

--- a/api/src/main/java/io/kafbat/ui/emitter/ForwardEmitter.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/ForwardEmitter.java
@@ -44,7 +44,7 @@ public class ForwardEmitter extends RangePollingEmitter {
       );
     }
 
-    int msgsToPollPerPartition = (int) Math.ceil((double) messagesPerPage / readFromOffsets.size());
+    int msgsToPollPerPartition = Math.max(1, (int) Math.ceil((double) messagesPerPage / readFromOffsets.size()));
     TreeMap<TopicPartition, FromToOffset> result = new TreeMap<>(Comparator.comparingInt(TopicPartition::partition));
     readFromOffsets.forEach((tp, fromOffset) -> {
       long tpEndOffset = seekOperations.getEndOffsets().get(tp);

--- a/api/src/main/java/io/kafbat/ui/emitter/MessagesProcessing.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/MessagesProcessing.java
@@ -72,6 +72,15 @@ class MessagesProcessing {
     }
   }
 
+  /**
+   * Send consuming stats for in-range records only (used by range emitters).
+   */
+  void sentConsumingInfo(FluxSink<TopicMessageEventDTO> sink, int inRangeRecords, long inRangeBytes, long elapsedMs) {
+    if (!sink.isCancelled()) {
+      consumingStats.sendConsumingEvt(sink, inRangeRecords, inRangeBytes, elapsedMs);
+    }
+  }
+
   void sendFinishEvents(FluxSink<TopicMessageEventDTO> sink, @Nullable Cursor.Tracking cursor) {
     if (!sink.isCancelled()) {
       consumingStats.sendFinishEvent(sink, cursor);

--- a/api/src/main/java/io/kafbat/ui/emitter/PolledRecords.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/PolledRecords.java
@@ -38,7 +38,14 @@ public record PolledRecords(int count,
   }
 
   private static int calculatePolledRecSize(Iterable<ConsumerRecord<Bytes, Bytes>> recs) {
-    int polledBytes = 0;
+    return (int) bytesOf(recs);
+  }
+
+  /**
+   * Compute total serialized size (bytes) of the given records. Used for in-range stats.
+   */
+  static long bytesOf(Iterable<ConsumerRecord<Bytes, Bytes>> recs) {
+    long polledBytes = 0;
     for (ConsumerRecord<Bytes, Bytes> rec : recs) {
       for (Header header : rec.headers()) {
         polledBytes +=

--- a/api/src/main/java/io/kafbat/ui/emitter/RangePollingEmitter.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/RangePollingEmitter.java
@@ -49,16 +49,16 @@ abstract class RangePollingEmitter extends AbstractEmitter {
     if (activePartitions <= 0) {
       return 1;
     }
+    final int pollCap = getPollingSettings().getMaxMessagesToScanPerPoll();
     final int baseChunk = Math.max(1, (int) Math.ceil((double) messagesPerPage / activePartitions));
     final int minChunk = Math.max(1, Math.min(10, messagesPerPage));
     final int requestedChunk = Math.max(baseChunk, minChunk);
-    // Keep the total-request cap compatible with the per-partition floor.
-    final int maxTotalRequested = Math.max(
-        messagesPerPage * 3,
-        minChunk * activePartitions
-    );
+    // Align total requested with poll cap to reduce tiny range iterations (many partitions + small page).
+    final int maxTotalByPage = Math.max(messagesPerPage * 3, minChunk * activePartitions);
+    final int maxTotalRequested = Math.min(pollCap, maxTotalByPage);
     final int maxChunkByTotal = Math.max(1, (int) Math.ceil((double) maxTotalRequested / activePartitions));
-    return Math.min(requestedChunk, maxChunkByTotal);
+    // Prefer larger chunk up to maxChunkByTotal to fill poll cap and reduce iterations.
+    return Math.min(maxChunkByTotal, Math.max(requestedChunk, maxChunkByTotal));
   }
 
   @Override
@@ -104,11 +104,12 @@ abstract class RangePollingEmitter extends AbstractEmitter {
     List<ConsumerRecord<Bytes, Bytes>> result = new ArrayList<>();
     Set<TopicPartition> paused = new HashSet<>();
     while (!sink.isCancelled() && paused.size() < range.size()) {
-      var polledRecords = poll(sink, consumer);
+      var polledRecords = pollWithoutConsuming(consumer);
+      List<ConsumerRecord<Bytes, Bytes>> inRangeThisPoll = new ArrayList<>();
       range.forEach((tp, fromTo) -> {
         polledRecords.records(tp).stream()
             .filter(r -> r.offset() < fromTo.to)
-            .forEach(result::add);
+            .forEach(inRangeThisPoll::add);
 
         //next position is out of target range -> pausing partition
         if (!paused.contains(tp) && consumer.position(tp) >= fromTo.to) {
@@ -116,6 +117,9 @@ abstract class RangePollingEmitter extends AbstractEmitter {
           consumer.pause(List.of(tp));
         }
       });
+      result.addAll(inRangeThisPoll);
+      long inRangeBytes = PolledRecords.bytesOf(inRangeThisPoll);
+      sendConsumingInRange(sink, inRangeThisPoll.size(), inRangeBytes, polledRecords.elapsed().toMillis());
     }
     consumer.resume(paused);
     return result;

--- a/api/src/main/java/io/kafbat/ui/service/ConsumerGroupService.java
+++ b/api/src/main/java/io/kafbat/ui/service/ConsumerGroupService.java
@@ -455,6 +455,12 @@ public class ConsumerGroupService {
     return createConsumer(cluster, Map.of());
   }
 
+  public EnhancedConsumer createConsumer(KafkaCluster cluster, int requestedLimit) {
+    int pollCap = cluster.getPollingSettings().getMaxMessagesToScanPerPoll();
+    long maxPollRecords = Math.min((long) pollCap, Math.max(1L, (long) requestedLimit * 2L));
+    return createConsumer(cluster, Map.of(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, (int) maxPollRecords));
+  }
+
   public EnhancedConsumer createConsumer(KafkaCluster cluster,
                                          Map<String, Object> properties) {
     Properties props = new Properties();

--- a/api/src/main/java/io/kafbat/ui/service/MessagesService.java
+++ b/api/src/main/java/io/kafbat/ui/service/MessagesService.java
@@ -241,7 +241,7 @@ public class MessagesService {
         cursor.deserializer(),
         cursor.consumerPosition(),
         cursor.filter(),
-        cursor.limit()
+        fixPageSize(cursor.limit())
     );
   }
 

--- a/api/src/main/java/io/kafbat/ui/service/MessagesService.java
+++ b/api/src/main/java/io/kafbat/ui/service/MessagesService.java
@@ -264,7 +264,7 @@ public class MessagesService {
                                                       int limit) {
     var emitter = switch (consumerPosition.pollingMode()) {
       case TO_OFFSET, TO_TIMESTAMP, LATEST -> new BackwardEmitter(
-          () -> consumerGroupService.createConsumer(cluster),
+          () -> consumerGroupService.createConsumer(cluster, limit),
           consumerPosition,
           limit,
           deserializer,
@@ -273,7 +273,7 @@ public class MessagesService {
           cursorsStorage.createNewCursor(deserializer, consumerPosition, filter, limit)
       );
       case FROM_OFFSET, FROM_TIMESTAMP, EARLIEST -> new ForwardEmitter(
-          () -> consumerGroupService.createConsumer(cluster),
+          () -> consumerGroupService.createConsumer(cluster, limit),
           consumerPosition,
           limit,
           deserializer,

--- a/api/src/test/java/io/kafbat/ui/emitter/ConsumingStatsTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/ConsumingStatsTest.java
@@ -1,0 +1,58 @@
+package io.kafbat.ui.emitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import io.kafbat.ui.model.TopicMessageEventDTO;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.FluxSink;
+
+class ConsumingStatsTest {
+
+  FluxSink<TopicMessageEventDTO> sink;
+  ArgumentCaptor<TopicMessageEventDTO> eventCaptor;
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void setUp() {
+    sink = mock(FluxSink.class);
+    eventCaptor = ArgumentCaptor.forClass(TopicMessageEventDTO.class);
+  }
+
+  @Test
+  void sendConsumingEvtInRangeAccumulatesAndEmits() {
+    ConsumingStats stats = new ConsumingStats();
+    stats.sendConsumingEvt(sink, 5, 100L, 10L);
+    stats.sendConsumingEvt(sink, 3, 50L, 5L);
+
+    verify(sink, times(2)).next(eventCaptor.capture());
+    List<TopicMessageEventDTO> events = eventCaptor.getAllValues();
+    assertThat(events.get(0).getType()).isEqualTo(TopicMessageEventDTO.TypeEnum.CONSUMING);
+    assertThat(events.get(0).getConsuming().getMessagesConsumed()).isEqualTo(5);
+    assertThat(events.get(0).getConsuming().getBytesConsumed()).isEqualTo(100L);
+    assertThat(events.get(0).getConsuming().getElapsedMs()).isEqualTo(10L);
+
+    assertThat(events.get(1).getConsuming().getMessagesConsumed()).isEqualTo(8);
+    assertThat(events.get(1).getConsuming().getBytesConsumed()).isEqualTo(150L);
+    assertThat(events.get(1).getConsuming().getElapsedMs()).isEqualTo(15L);
+  }
+
+  @Test
+  void sendFinishEventIncludesAccumulatedInRangeStats() {
+    ConsumingStats stats = new ConsumingStats();
+    stats.sendConsumingEvt(sink, 2, 200L, 100L);
+    stats.sendFinishEvent(sink, null);
+
+    verify(sink, times(2)).next(eventCaptor.capture());
+    TopicMessageEventDTO doneEvent = eventCaptor.getAllValues().get(1);
+    assertThat(doneEvent.getType()).isEqualTo(TopicMessageEventDTO.TypeEnum.DONE);
+    assertThat(doneEvent.getConsuming().getMessagesConsumed()).isEqualTo(2);
+    assertThat(doneEvent.getConsuming().getBytesConsumed()).isEqualTo(200L);
+    assertThat(doneEvent.getConsuming().getElapsedMs()).isEqualTo(100L);
+  }
+}

--- a/api/src/test/java/io/kafbat/ui/emitter/CursorTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/CursorTest.java
@@ -71,6 +71,40 @@ class CursorTest extends AbstractIntegrationTest {
   }
 
   @Test
+  void forwardEmitterWithZeroLimitCompletesWithoutHanging() {
+    var consumerPosition = new ConsumerPosition(PollingModeDTO.EARLIEST, TOPIC, List.of(), null, null);
+    var emitter = new ForwardEmitter(
+        this::createConsumer,
+        consumerPosition,
+        0,
+        createRecordsDeserializer(),
+        _ -> true,
+        PollingSettings.createDefault(),
+        cursorsStorage.createNewCursor(createRecordsDeserializer(), consumerPosition, _ -> true, PAGE_SIZE)
+    );
+    List<TopicMessageEventDTO> events = Flux.create(emitter).collectList().block();
+    assertThat(events).isNotNull();
+    assertThat(events.stream().filter(m -> m.getType() == TopicMessageEventDTO.TypeEnum.DONE).count()).isEqualTo(1);
+  }
+
+  @Test
+  void backwardEmitterWithZeroLimitCompletesWithoutHanging() {
+    var consumerPosition = new ConsumerPosition(PollingModeDTO.LATEST, TOPIC, List.of(), null, null);
+    var emitter = new BackwardEmitter(
+        this::createConsumer,
+        consumerPosition,
+        0,
+        createRecordsDeserializer(),
+        _ -> true,
+        PollingSettings.createDefault(),
+        cursorsStorage.createNewCursor(createRecordsDeserializer(), consumerPosition, _ -> true, PAGE_SIZE)
+    );
+    List<TopicMessageEventDTO> events = Flux.create(emitter).collectList().block();
+    assertThat(events).isNotNull();
+    assertThat(events.stream().filter(m -> m.getType() == TopicMessageEventDTO.TypeEnum.DONE).count()).isEqualTo(1);
+  }
+
+  @Test
   void forwardEmitter() {
     var consumerPosition = new ConsumerPosition(PollingModeDTO.EARLIEST, TOPIC, List.of(), null, null);
     var emitter = createForwardEmitter(consumerPosition);

--- a/api/src/test/java/io/kafbat/ui/emitter/PolledRecordsTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/PolledRecordsTest.java
@@ -1,0 +1,49 @@
+package io.kafbat.ui.emitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.Test;
+
+class PolledRecordsTest {
+
+  @Test
+  void bytesOfEmptyIsZero() {
+    assertThat(PolledRecords.bytesOf(List.of())).isZero();
+  }
+
+  @Test
+  void bytesOfCountsSerializedSizes() {
+    // bytesOf uses key/value presence: when non-null, adds serializedKeySize/serializedValueSize
+    ConsumerRecord<Bytes, Bytes> rec = new ConsumerRecord<>(
+        "t",
+        0,
+        0L,
+        0L,
+        TimestampType.CREATE_TIME,
+        3,
+        5,
+        Bytes.wrap(new byte[3]),
+        Bytes.wrap(new byte[5]),
+        new RecordHeaders(),
+        Optional.empty()
+    );
+    assertThat(PolledRecords.bytesOf(List.of(rec))).isEqualTo(3 + 5);
+  }
+
+  @Test
+  void bytesOfSumsMultipleRecords() {
+    ConsumerRecord<Bytes, Bytes> r1 = new ConsumerRecord<>(
+        "t", 0, 0L, 0L, TimestampType.CREATE_TIME, 2, 4,
+        Bytes.wrap(new byte[1]), Bytes.wrap(new byte[1]), new RecordHeaders(), Optional.empty());
+    ConsumerRecord<Bytes, Bytes> r2 = new ConsumerRecord<>(
+        "t", 0, 1L, 0L, TimestampType.CREATE_TIME, 1, 1,
+        Bytes.wrap(new byte[1]), Bytes.wrap(new byte[1]), new RecordHeaders(), Optional.empty());
+    assertThat(PolledRecords.bytesOf(List.of(r1, r2))).isEqualTo(2 + 4 + 1 + 1);
+  }
+}

--- a/api/src/test/java/io/kafbat/ui/emitter/PollingSettingsTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/PollingSettingsTest.java
@@ -1,0 +1,49 @@
+package io.kafbat.ui.emitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kafbat.ui.config.ClustersProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PollingSettingsTest {
+
+  @Test
+  void usesConfiguredMaxMessagesToScanPerPoll() {
+    var settings = createPollingSettings(321);
+
+    assertThat(settings.getMaxMessagesToScanPerPoll()).isEqualTo(321);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, -1, -500})
+  void fallsBackToDefaultWhenConfiguredMaxMessagesToScanPerPollIsNonPositive(int configuredValue) {
+    int expectedDefault = PollingSettings.createDefault().getMaxMessagesToScanPerPoll();
+
+    var settings = createPollingSettings(configuredValue);
+
+    assertThat(settings.getMaxMessagesToScanPerPoll()).isEqualTo(expectedDefault);
+  }
+
+  @Test
+  void usesDefaultWhenMaxMessagesToScanPerPollIsNotConfigured() {
+    int expectedDefault = PollingSettings.createDefault().getMaxMessagesToScanPerPoll();
+
+    var settings = createPollingSettings(null);
+
+    assertThat(settings.getMaxMessagesToScanPerPoll()).isEqualTo(expectedDefault);
+  }
+
+  private PollingSettings createPollingSettings(Integer maxMessagesToScanPerPoll) {
+    var cluster = new ClustersProperties.Cluster();
+    cluster.setName("test-cluster");
+
+    var rootProps = new ClustersProperties();
+    var pollingProps = new ClustersProperties.PollingProperties();
+    pollingProps.setMaxMessagesToScanPerPoll(maxMessagesToScanPerPoll);
+    rootProps.setPolling(pollingProps);
+
+    return PollingSettings.create(cluster, rootProps);
+  }
+}

--- a/api/src/test/java/io/kafbat/ui/emitter/RangePollingEmitterTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/RangePollingEmitterTest.java
@@ -1,0 +1,76 @@
+package io.kafbat.ui.emitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.kafbat.ui.config.ClustersProperties;
+import io.kafbat.ui.model.ConsumerPosition;
+import java.util.Comparator;
+import java.util.TreeMap;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+class RangePollingEmitterTest {
+
+  @Test
+  void nextChunkSizePerPartitionBoundedByPollCap() {
+    // 30 partitions, page 30, pollCap 200 -> maxTotalRequested = 200, maxChunkByTotal = ceil(200/30) = 7
+    PollingSettings settings = createPollingSettings(200);
+    TestRangeEmitter emitter = new TestRangeEmitter(30, settings);
+    int chunk = emitter.nextChunkSizePerPartitionPublic(30);
+    assertThat(chunk).isLessThanOrEqualTo(7);
+    assertThat(chunk).isPositive();
+  }
+
+  @Test
+  void nextChunkSizePerPartitionManyPartitionsSmallPage() {
+    // 50 partitions, page 20, pollCap 500 -> reduces tiny iterations
+    PollingSettings settings = createPollingSettings(500);
+    TestRangeEmitter emitter = new TestRangeEmitter(20, settings);
+    int chunk = emitter.nextChunkSizePerPartitionPublic(50);
+    assertThat(chunk * 50).isLessThanOrEqualTo(500);
+    assertThat(chunk).isPositive();
+  }
+
+  @Test
+  void nextChunkSizePerPartitionSinglePartition() {
+    PollingSettings settings = createPollingSettings(500);
+    TestRangeEmitter emitter = new TestRangeEmitter(30, settings);
+    assertThat(emitter.nextChunkSizePerPartitionPublic(1)).isPositive();
+  }
+
+  private static PollingSettings createPollingSettings(int maxMessagesToScanPerPoll) {
+    ClustersProperties.Cluster cluster = new ClustersProperties.Cluster();
+    cluster.setName("test-cluster");
+    ClustersProperties rootProps = new ClustersProperties();
+    ClustersProperties.PollingProperties pollingProps = new ClustersProperties.PollingProperties();
+    pollingProps.setMaxMessagesToScanPerPoll(maxMessagesToScanPerPoll);
+    rootProps.setPolling(pollingProps);
+    return PollingSettings.create(cluster, rootProps);
+  }
+
+  private static final class TestRangeEmitter extends RangePollingEmitter {
+
+    TestRangeEmitter(int messagesPerPage, PollingSettings settings) {
+      super(
+          () -> null,
+          mock(ConsumerPosition.class),
+          messagesPerPage,
+          mock(MessagesProcessing.class),
+          settings,
+          mock(Cursor.Tracking.class)
+      );
+    }
+
+    @Override
+    protected TreeMap<TopicPartition, FromToOffset> nextPollingRange(
+        TreeMap<TopicPartition, FromToOffset> prevRange,
+        SeekOperations seekOperations) {
+      return new TreeMap<>(Comparator.comparingInt(TopicPartition::partition));
+    }
+
+    int nextChunkSizePerPartitionPublic(int activePartitions) {
+      return nextChunkSizePerPartition(activePartitions);
+    }
+  }
+}

--- a/contract-typespec/api/config.tsp
+++ b/contract-typespec/api/config.tsp
@@ -131,6 +131,7 @@ model ApplicationConfig {
         maxPageSize?: int32;
         defaultPageSize?: int32;
         responseTimeoutMs?: int32;
+        maxMessagesToScanPerPoll?: int32;
       };
       adminClientTimeout?: int32;
       internalTopicPrefix?: string;

--- a/contract/src/main/resources/swagger/kafbat-ui-api.yaml
+++ b/contract/src/main/resources/swagger/kafbat-ui-api.yaml
@@ -4624,6 +4624,8 @@ components:
                       type: integer
                     responseTimeoutMs:
                       type: integer
+                    maxMessagesToScanPerPoll:
+                      type: integer
                 adminClientTimeout:
                   type: integer
                 internalTopicPrefix:

--- a/frontend/src/lib/hooks/api/__test__/topicMessages.spec.tsx
+++ b/frontend/src/lib/hooks/api/__test__/topicMessages.spec.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { waitFor, screen } from '@testing-library/react';
+import { render } from 'lib/testHelpers';
+import { useTopicMessages } from 'lib/hooks/api/topicMessages';
+import { useMessageFiltersStore } from 'lib/hooks/useMessageFiltersStore';
+
+const fetchEventSourceMock = jest.fn();
+
+jest.mock('@microsoft/fetch-event-source', () => ({
+  fetchEventSource: (...args: unknown[]) => fetchEventSourceMock(...args),
+}));
+
+const Probe = () => {
+  const { consumptionStats } = useTopicMessages({
+    clusterName: 'cluster-a',
+    topicName: 'topic-a',
+  });
+
+  return (
+    <div data-testid="stats">
+      {String(consumptionStats?.messagesConsumed ?? 'none')}
+    </div>
+  );
+};
+
+describe('useTopicMessages', () => {
+  beforeEach(() => {
+    useMessageFiltersStore.setState({ nextCursor: undefined });
+    fetchEventSourceMock.mockImplementation(
+      async (
+        _url: string,
+        handlers: Record<string, (...args: unknown[]) => void>
+      ) => {
+        await handlers.onopen?.(new Response(null, { status: 200 }));
+
+        handlers.onmessage?.({
+          data: JSON.stringify({
+            type: 'CONSUMING',
+            consuming: {
+              messagesConsumed: 1,
+              bytesConsumed: 10,
+              elapsedMs: 1,
+            },
+          }),
+        } as MessageEvent);
+
+        handlers.onmessage?.({
+          data: JSON.stringify({
+            type: 'DONE',
+            consuming: {
+              messagesConsumed: 2,
+              bytesConsumed: 20,
+              elapsedMs: 2,
+            },
+          }),
+        } as MessageEvent);
+
+        handlers.onclose?.();
+      }
+    );
+  });
+
+  it('updates consuming stats from DONE event', async () => {
+    render(<Probe />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('stats')).toHaveTextContent('2');
+    });
+  });
+});

--- a/frontend/src/lib/hooks/api/__tests__/appConfig.spec.tsx
+++ b/frontend/src/lib/hooks/api/__tests__/appConfig.spec.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { waitFor } from '@testing-library/react';
+import { render } from 'lib/testHelpers';
+import { ApplicationConfigPropertiesKafkaClusters } from 'generated-sources';
+import { useUpdateAppConfig } from 'lib/hooks/api/appConfig';
+
+const getCurrentConfigMock = jest.fn();
+const restartWithConfigMock = jest.fn();
+
+jest.mock('lib/api', () => ({
+  appConfigApiClient: {
+    getCurrentConfig: (...args: unknown[]) => getCurrentConfigMock(...args),
+    restartWithConfig: (...args: unknown[]) => restartWithConfigMock(...args),
+  },
+  internalApiClient: {},
+}));
+
+const Probe = ({
+  cluster,
+}: {
+  cluster: ApplicationConfigPropertiesKafkaClusters;
+}) => {
+  const mutation = useUpdateAppConfig({ initialName: 'cluster-a' });
+  const startedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (!startedRef.current) {
+      startedRef.current = true;
+      mutation.mutate(cluster);
+    }
+  }, [cluster, mutation]);
+
+  return null;
+};
+
+describe('useUpdateAppConfig', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('preserves existing kafka fields when updating clusters', async () => {
+    const existingConfig = {
+      properties: {
+        kafka: {
+          polling: {
+            pollTimeoutMs: 1000,
+            maxPageSize: 500,
+            maxMessagesToScanPerPoll: 500,
+          },
+          adminClientTimeout: 15000,
+          internalTopicPrefix: '_internal',
+          clusters: [
+            {
+              name: 'cluster-a',
+              bootstrapServers: 'localhost:9092',
+            },
+          ],
+        },
+      },
+    };
+
+    getCurrentConfigMock.mockResolvedValue(existingConfig);
+    restartWithConfigMock.mockResolvedValue({});
+
+    const updatedCluster: ApplicationConfigPropertiesKafkaClusters = {
+      name: 'cluster-a',
+      bootstrapServers: 'localhost:19092',
+    };
+
+    render(<Probe cluster={updatedCluster} />);
+
+    await waitFor(() => {
+      expect(restartWithConfigMock).toHaveBeenCalledTimes(1);
+    });
+
+    const payload =
+      restartWithConfigMock.mock.calls[0][0].restartRequest.config;
+    expect(payload.properties.kafka.polling).toEqual(
+      existingConfig.properties.kafka.polling
+    );
+    expect(payload.properties.kafka.adminClientTimeout).toBe(15000);
+    expect(payload.properties.kafka.internalTopicPrefix).toBe('_internal');
+    expect(payload.properties.kafka.clusters).toEqual([updatedCluster]);
+  });
+});

--- a/frontend/src/lib/hooks/api/appConfig.ts
+++ b/frontend/src/lib/hooks/api/appConfig.ts
@@ -102,7 +102,10 @@ export function useUpdateAppConfig({
         ...existingConfig,
         properties: {
           ...existingConfig.properties,
-          kafka: { clusters },
+          kafka: {
+            ...existingConfig.properties?.kafka,
+            clusters,
+          },
         },
       };
       return appConfig.restartWithConfig({ restartRequest: { config } });

--- a/frontend/src/lib/hooks/api/topicMessages.tsx
+++ b/frontend/src/lib/hooks/api/topicMessages.tsx
@@ -154,6 +154,9 @@ export const useTopicMessages = ({
             case TopicMessageEventTypeEnum.CONSUMING:
               if (consuming) setConsumptionStats(consuming);
               break;
+            case TopicMessageEventTypeEnum.DONE:
+              if (consuming) setConsumptionStats(consuming);
+              break;
             default:
           }
         },


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

When messagesPerPage (limit) was 0, msgsToPollPerPartition became 0, producing an empty range (from, from). nextPollingRange then returned the same range, so the consumer never advanced and re-read the same data until timeout, causing hundreds of millions of messages consumed and zero results (No messages found).

Changes:
- ForwardEmitter/BackwardEmitter: ensure msgsToPollPerPartition is at least 1 via Math.max(1, ...) so the range is never empty.
- MessagesService: when loading by cursor, pass fixPageSize(cursor.limit()) so a cursor with limit 0 is normalized to defaultPageSize and never reaches the emitter.

Tests:
- RecordEmitterTest: add forwardAndBackwardEmitterWithZeroMessagesPerPageCompleteWithoutHanging
- CursorTest: add forwardEmitterWithZeroLimitCompletesWithoutHanging and backwardEmitterWithZeroLimitCompletesWithoutHanging

**Is there anything you'd like reviewers to focus on?**

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

Resolves: #1684 