### PR TITLE
BE: Internal: initialize topicIndex in ScrapedClusterState to prevent NPE

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
+++ b/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
@@ -81,6 +81,7 @@ public class ScrapedClusterState implements AutoCloseable {
         .nodesStates(Map.of())
         .topicStates(Map.of())
         .consumerGroupsStates(Map.of())
+        .topicIndex(new FilterTopicIndex(List.of()))
         .build();
   }
 

--- a/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateTest.java
@@ -1,0 +1,17 @@
+package io.kafbat.ui.service.metrics.scrape;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class ScrapedClusterStateTest {
+
+  @Test
+  void emptyStateHasNonNullTopicIndex() throws Exception {
+    try (ScrapedClusterState empty = ScrapedClusterState.empty()) {
+      assertThat(empty.getTopicIndex()).isNotNull();
+      assertThat(empty.getTopicIndex().find(null, null, false, null)).isEmpty();
+      assertThat(empty.getTopicIndex().find("search", true, true, null)).isEmpty();
+    }
+  }
+}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Fixes #1512

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
