### PR TITLE
fix: use getAllVersionsById instead of getAllSubjectsById for Karapace compatibility

### DIFF
--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerde.java
@@ -18,6 +18,7 @@ import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaMetadata;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import io.confluent.kafka.schemaregistry.client.rest.entities.SubjectVersion;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
@@ -355,8 +356,10 @@ public class SchemaRegistrySerde implements BuiltInSerde {
   private List<String> getSubjectsById(int schemaId) {
     return idToSubjectsCache.get(schemaId, (id) -> {
       try {
-        return schemaRegistryClient.getAllSubjectsById(id).stream()
+        return schemaRegistryClient.getAllVersionsById(id).stream()
+            .map(SubjectVersion::getSubject)
             .filter(s -> !s.isEmpty())
+            .distinct()
             .toList();
       } catch (Exception e) {
         throw new RuntimeException(e);


### PR DESCRIPTION
**What changes did you make?** (Give an overview)

Fixes #1701 

  Replaced `schemaRegistryClient.getAllSubjectsById(id)` with `schemaRegistryClient.getAllVersionsById(id)` in `SchemaRegistrySerde.getSubjectsById()`.

  `getAllSubjectsById` hits `GET /schemas/ids/{id}/subjects`, which is not implemented by Karapace (Aiven's open-source Schema Registry). This causes a 404 that propagates as a `RuntimeException`, breaking Avro deserialization for **all**
  messages.

  `getAllVersionsById` hits `GET /schemas/ids/{id}/versions`, which is supported by both Confluent SR and Karapace. The subject names are extracted via `SubjectVersion::getSubject` -  same data, same caching, just a compatible endpoint.

  **Is there anything you'd like reviewers to focus on?**

  The change is in `api/src/main/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerde.java`. It's a one-line functional change plus an import. Confirm that `getAllVersionsById` returns the expected subjects in your environment.

  **How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
  <!-- ignore-task-list-start -->
  - [x] Manually (please, describe, if necessary)
    - Stood up karapace locally to replicate issue. Solution works with both confluent and karapace
  - [x] Unit checks
  - [x] Covered by existing automation
  <!-- ignore-task-list-end -->

  Manually verified with a Docker Compose environment running Karapace as the Schema Registry. Before the fix, all Avro messages failed to deserialize. After the fix, deserialization works correctly. `SchemaRegistrySerdeTest` and
  `SendAndReadTests` both pass.

  **Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
  - [x] My changes generate no new warnings (e.g. Sonar is happy)
  - [x] New and existing unit tests pass locally with my changes
  - [x] Any dependent changes have been merged

  Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

  **A picture of a cute animal (not mandatory but encouraged)**

=^._.^= ∫