### PR TITLE
fix: preserve null values in json-avro conversion

### DIFF
--- a/api/src/main/java/io/kafbat/ui/util/jsonschema/JsonAvroConversion.java
+++ b/api/src/main/java/io/kafbat/ui/util/jsonschema/JsonAvroConversion.java
@@ -207,9 +207,12 @@ public class JsonAvroConversion {
         ObjectNode node = MAPPER.createObjectNode();
         for (Schema.Field field : avroSchema.getFields()) {
           var fieldVal = rec.get(field.name());
-          if (properties.showNullValues() || fieldVal != null) {
-            node.set(field.name(), convertAvroToJson(fieldVal, field.schema(), properties));
-          }
+          node.set(
+              field.name(),
+              fieldVal == null
+                  ? MAPPER.nullNode()
+                  : convertAvroToJson(fieldVal, field.schema(), properties)
+          );
         }
         yield node;
       }


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
  - Updated JSON conversion for Avro record fields in JsonAvroConversion.java:207-216.
  - Before: null-valued fields were conditionally skipped depending on showNullValues.
  - Now: all record fields are always emitted; when a field value is null, it is explicitly written as JSON null (MAPPER.nullNode()).
  - Preserves schema-defined fields in output and avoids dropping null properties during Avro → JSON conversion.
 
**Is there anything you'd like reviewers to focus on?**
- Confirm the intended behavior is to always preserve field presence for Avro record outputs, even when values are null.
- Validate this aligns with existing Kafka UI expectations for message rendering and Schema Registry-backed payloads.
- Check for any downstream consumers/tests that relied on null fields being omitted.
- Sanity-check that non-null conversion behavior is unchanged.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [ ] Unit checks
- [x] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
This is my cat, Mel :)

![WhatsApp Image 2026-02-26 at 11 30 43](https://github.com/user-attachments/assets/61b817ed-a87d-4743-b63e-1fed71f3421c)
