### PR TITLE
add custom HTTP headers support for Schema Registry connections

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
@@ -80,6 +80,7 @@ public class ClustersProperties {
     String schemaRegistry;
     SchemaRegistryAuth schemaRegistryAuth;
     KeystoreConfig schemaRegistrySsl;
+    Map<String, String> schemaRegistryHeaders;
 
     String ksqldbServer;
     KsqldbServerAuth ksqldbServerAuth;

--- a/api/src/main/java/io/kafbat/ui/service/KafkaClusterFactory.java
+++ b/api/src/main/java/io/kafbat/ui/service/KafkaClusterFactory.java
@@ -237,6 +237,7 @@ public class KafkaClusterFactory {
     WebClient webClient = new WebClientConfigurator()
         .configureSsl(clusterProperties.getSsl(), clusterProperties.getSchemaRegistrySsl())
         .configureBasicAuth(auth.getUsername(), auth.getPassword())
+        .configureDefaultHeaders(clusterProperties.getSchemaRegistryHeaders())
         .configureBufferSize(webClientMaxBuffSize)
         .configureAdditionalDecoderMediaTypes(SR_V1_JSON, SR_JSON)
         .build();

--- a/api/src/main/java/io/kafbat/ui/util/WebClientConfigurator.java
+++ b/api/src/main/java/io/kafbat/ui/util/WebClientConfigurator.java
@@ -11,6 +11,7 @@ import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.time.Duration;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -123,6 +124,13 @@ public class WebClientConfigurator {
       throw new ValidationException("You specified username but did not specify password");
     } else if (password != null) {
       throw new ValidationException("You specified password but did not specify username");
+    }
+    return this;
+  }
+
+  public WebClientConfigurator configureDefaultHeaders(@Nullable Map<String, String> headers) {
+    if (headers != null && !headers.isEmpty()) {
+      builder.defaultHeaders(httpHeaders -> headers.forEach(httpHeaders::set));
     }
     return this;
   }


### PR DESCRIPTION
Enable per-cluster schemaRegistryHeaders configuration to pass custom
  headers (e.g. X-Registry-GroupId) to the Schema Registry API. This
  allows scoping Apicurio Registry's Confluent compatibility endpoint
  to a specific artifact group.

  Config: KAFKA_CLUSTERS_0_SCHEMAREGISTRYHEADERS_<Header-Name>=<value>

 <!-- ignore-task-list-start -->
  - [ ] **Breaking change?** No — new optional property, fully backward-compatible.
 <!-- ignore-task-list-end -->

  **What changes did you make?**

  Added support for custom HTTP headers on Schema Registry WebClient connections, configured per cluster via `schemaRegistryHeaders` map.

  This enables passing headers like `X-Registry-GroupId` to Apicurio Registry's Confluent compatibility API, scoping schema lookups to a specific artifact group.

  Three files changed:
  - `ClustersProperties.Cluster` — added `Map<String, String> schemaRegistryHeaders`
  - `WebClientConfigurator` — added `configureDefaultHeaders(Map<String, String>)` method
  - `KafkaClusterFactory.schemaRegistryClient()` — wired headers into WebClient builder

  Configuration example:
  KAFKA_CLUSTERS_0_SCHEMAREGISTRYHEADERS_X-Registry-GroupId=my.artifact.group

  **Is there anything you'd like reviewers to focus on?**

  The `configureDefaultHeaders` method appends to the existing `defaultHeaders` consumer chain — verify it doesn't conflict with `configureBasicAuth` which also uses `defaultHeaders`.

  **How Has This Been Tested?**
  <!-- ignore-task-list-start -->
  - [ ] No need to
  - [x] Manually — verified headers are sent to Apicurio Registry and schemas scoped to the configured group are returned
  - [ ] Unit checks
  - [ ] Integration checks
  - [ ] Covered by existing automation
  <!-- ignore-task-list-end -->

  **Checklist**
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
  - [ ] My changes generate no new warnings (e.g. Sonar is happy)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing unit tests pass locally with my changes
  - [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**
