### PR TITLE
feat(oauth2): support insecure TLS for OIDC/OAuth2 providers

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthProperties.java
@@ -13,8 +13,11 @@ import org.springframework.util.Assert;
 @ConfigurationProperties("auth.oauth2")
 @Data
 public class OAuthProperties {
+  public static final String DEFAULT_AUTHORIZATION_GRANT_TYPE = "authorization_code";
+  public static final String DEFAULT_REDIRECT_URI = "{baseUrl}/login/oauth2/code/{registrationId}";
   private Map<String, OAuth2Provider> client = new HashMap<>();
   private OAuth2ResourceServerProperties resourceServer = null;
+  private boolean insecureSsl = false;
 
   @PostConstruct
   public void init() {
@@ -24,6 +27,12 @@ public class OAuthProperties {
       }
       if (provider.getScope() == null) {
         provider.setScope(Collections.emptySet());
+      }
+      if (provider.getAuthorizationGrantType() == null) {
+        provider.setAuthorizationGrantType(DEFAULT_AUTHORIZATION_GRANT_TYPE);
+      }
+      if (provider.getRedirectUri() == null) {
+        provider.setRedirectUri(DEFAULT_REDIRECT_URI);
       }
     });
 

--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
@@ -1,12 +1,18 @@
 package io.kafbat.ui.config.auth;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.kafbat.ui.config.auth.logout.OAuthLogoutSuccessHandler;
 import io.kafbat.ui.service.rbac.AccessControlService;
 import io.kafbat.ui.service.rbac.extractor.ProviderAuthorityExtractor;
 import io.kafbat.ui.util.StaticFileWebFilter;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,6 +50,7 @@ import org.springframework.security.oauth2.jwt.NimbusReactiveJwtDecoder;
 import org.springframework.security.oauth2.server.resource.introspection.SpringReactiveOpaqueTokenIntrospector;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.authentication.logout.ServerLogoutSuccessHandler;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
@@ -57,17 +64,30 @@ import reactor.netty.http.client.HttpClient;
 @Slf4j
 public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
 
+  private static final Duration OIDC_DISCOVERY_TIMEOUT = Duration.ofSeconds(15);
   private final OAuthProperties properties;
 
   /**
    * WebClient configured to use system proxy properties (http.proxyHost/https.proxyHost,
-   * http.proxyPort/https.proxyPort, http.nonProxyHosts/https.nonProxyHosts).
+   * http.proxyPort/https.proxyPort, http.nonProxyHosts/https.nonProxyHosts) and optionally
+   * skip TLS certificate verification when auth.oauth2.insecure-ssl=true.
    * Created as a bean to ensure system properties are read after context initialization.
    */
   @Bean(name = "oauthWebClient")
   public WebClient oauthWebClient() {
+    HttpClient httpClient = HttpClient.create().proxyWithSystemProperties();
+    if (properties.isInsecureSsl()) {
+      try {
+        var context = SslContextBuilder.forClient()
+            .trustManager(InsecureTrustManagerFactory.INSTANCE)
+            .build();
+        httpClient = httpClient.secure(t -> t.sslContext(context));
+      } catch (Exception e) {
+        throw new IllegalStateException("Failed to initialize OAuth insecure SSL context", e);
+      }
+    }
     return WebClient.builder()
-        .clientConnector(new ReactorClientHttpConnector(HttpClient.create().proxyWithSystemProperties()))
+        .clientConnector(new ReactorClientHttpConnector(httpClient))
         .build();
   }
 
@@ -179,10 +199,16 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
   }
 
   @Bean
-  public InMemoryReactiveClientRegistrationRepository clientRegistrationRepository() {
+  public InMemoryReactiveClientRegistrationRepository clientRegistrationRepository(
+      @Qualifier("oauthWebClient") WebClient webClient
+  ) {
+    Map<String, OidcDiscoveryResponse> discoveredOidcMetadata = enrichOidcMetadataIfInsecureSsl(webClient);
     final OAuth2ClientProperties props = OAuthPropertiesConverter.convertProperties(properties);
-    final List<ClientRegistration> registrations =
-        new ArrayList<>(new OAuth2ClientPropertiesMapper(props).asClientRegistrations().values());
+    final Map<String, ClientRegistration> mappedRegistrations =
+       new OAuth2ClientPropertiesMapper(props).asClientRegistrations();
+    final List<ClientRegistration> registrations = new ArrayList<>(mappedRegistrations.size());
+    mappedRegistrations.forEach((providerId, registration) ->
+        registrations.add(enrichClientRegistrationWithOidcMetadata(registration, discoveredOidcMetadata.get(providerId))));
     if (registrations.isEmpty()) {
       throw new IllegalArgumentException("OAuth2 authentication is enabled but no providers specified.");
     }
@@ -208,5 +234,155 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
     return properties.getClient().get(providerId);
   }
 
-}
+  private Map<String, OidcDiscoveryResponse> enrichOidcMetadataIfInsecureSsl(WebClient webClient) {
+    Map<String, OidcDiscoveryResponse> discoveredMetadata = new HashMap<>();
+    if (!properties.isInsecureSsl()) {
+      return discoveredMetadata;
+    }
 
+    properties.getClient().forEach((providerId, provider) ->
+        enrichProviderOidcMetadata(webClient, discoveredMetadata, providerId, provider));
+    return discoveredMetadata;
+  }
+
+  private void enrichProviderOidcMetadata(
+      WebClient webClient,
+      Map<String, OidcDiscoveryResponse> discoveredMetadata,
+      String providerId,
+      OAuthProperties.OAuth2Provider provider
+  ) {
+    if (!StringUtils.hasText(provider.getIssuerUri())) {
+      return;
+    }
+
+    final boolean discoveryRequired = !hasCompleteOidcEndpoints(provider);
+    final String openIdConfigUri = provider.getIssuerUri().replaceAll("/$", "")
+        + "/.well-known/openid-configuration";
+
+    final OidcDiscoveryResponse metadata = resolveOidcMetadata(
+        webClient,
+        providerId,
+        openIdConfigUri,
+        discoveryRequired
+    );
+    if (metadata != null) {
+      applyMissingEndpoints(provider, metadata);
+      discoveredMetadata.put(providerId, metadata);
+    }
+
+    // Prevent OAuth2ClientPropertiesMapper from performing issuer discovery via RestTemplate,
+    // which would ignore auth.oauth2.insecure-ssl and fail on self-signed certs.
+    provider.setIssuerUri(null);
+  }
+
+  private OidcDiscoveryResponse resolveOidcMetadata(
+      WebClient webClient,
+      String providerId,
+      String openIdConfigUri,
+      boolean discoveryRequired
+  ) {
+    final OidcDiscoveryResponse metadata;
+    try {
+      metadata = webClient.get()
+          .uri(openIdConfigUri)
+          .retrieve()
+          .bodyToMono(OidcDiscoveryResponse.class)
+          .block(OIDC_DISCOVERY_TIMEOUT);
+    } catch (Exception e) {
+      if (!discoveryRequired) {
+        log.warn(
+            "Unable to resolve OIDC discovery metadata for provider [%s] from [%s]. "
+                    .formatted(providerId, openIdConfigUri)
+                + "Continuing because provider endpoints are fully specified; "
+                + "OIDC logout endpoint may be unavailable.",
+            e
+        );
+        return null;
+      }
+      throw new IllegalStateException(
+          "Unable to resolve OIDC discovery metadata for provider [%s] from [%s]"
+              .formatted(providerId, openIdConfigUri),
+          e
+      );
+    }
+
+    if (metadata == null) {
+      if (!discoveryRequired) {
+        log.warn(
+            "Empty OIDC discovery metadata for provider [%s] from [%s]. "
+                    .formatted(providerId, openIdConfigUri)
+                + "Continuing because provider endpoints are fully specified; "
+                + "OIDC logout endpoint may be unavailable."
+        );
+        return null;
+      }
+      throw new IllegalStateException(
+          "Empty OIDC discovery metadata for provider [%s] from [%s]"
+              .formatted(providerId, openIdConfigUri)
+      );
+    }
+    return metadata;
+  }
+
+  private void applyMissingEndpoints(OAuthProperties.OAuth2Provider provider, OidcDiscoveryResponse metadata) {
+    if (!StringUtils.hasText(provider.getAuthorizationUri())) {
+      provider.setAuthorizationUri(metadata.authorizationEndpoint());
+    }
+    if (!StringUtils.hasText(provider.getTokenUri())) {
+      provider.setTokenUri(metadata.tokenEndpoint());
+    }
+    if (!StringUtils.hasText(provider.getJwkSetUri())) {
+      provider.setJwkSetUri(metadata.jwksUri());
+    }
+    if (!StringUtils.hasText(provider.getUserInfoUri())) {
+      provider.setUserInfoUri(metadata.userInfoEndpoint());
+    }
+  }
+
+  private boolean hasCompleteOidcEndpoints(OAuthProperties.OAuth2Provider provider) {
+    return StringUtils.hasText(provider.getAuthorizationUri())
+        && StringUtils.hasText(provider.getTokenUri())
+        && StringUtils.hasText(provider.getJwkSetUri())
+        && StringUtils.hasText(provider.getUserInfoUri());
+  }
+
+  private ClientRegistration enrichClientRegistrationWithOidcMetadata(
+      ClientRegistration registration,
+      OidcDiscoveryResponse metadata
+  ) {
+    if (metadata == null) {
+      return registration;
+    }
+
+    Map<String, Object> providerMetadata = new HashMap<>(registration.getProviderDetails().getConfigurationMetadata());
+    if (StringUtils.hasText(metadata.endSessionEndpoint())) {
+      providerMetadata.put("end_session_endpoint", metadata.endSessionEndpoint());
+    }
+    if (StringUtils.hasText(metadata.issuer())) {
+      providerMetadata.put("issuer", metadata.issuer());
+    }
+
+    if (providerMetadata.equals(registration.getProviderDetails().getConfigurationMetadata())
+        && Objects.equals(registration.getProviderDetails().getIssuerUri(), metadata.issuer())) {
+      return registration;
+    }
+
+    var builder = ClientRegistration.withClientRegistration(registration)
+        .providerConfigurationMetadata(providerMetadata);
+    if (StringUtils.hasText(metadata.issuer())) {
+      builder.issuerUri(metadata.issuer());
+    }
+    return builder.build();
+  }
+
+  private record OidcDiscoveryResponse(
+      @JsonProperty("issuer") String issuer,
+      @JsonProperty("authorization_endpoint") String authorizationEndpoint,
+      @JsonProperty("token_endpoint") String tokenEndpoint,
+      @JsonProperty("jwks_uri") String jwksUri,
+      @JsonProperty("userinfo_endpoint") String userInfoEndpoint,
+      @JsonProperty("end_session_endpoint") String endSessionEndpoint
+  ) {
+  }
+
+}

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -47,6 +47,8 @@ auth:
   #  type: OAUTH2
   #  type: LDAP
   oauth2:
+    # Set true only for development/testing with self-signed OAuth/OIDC certs.
+    insecure-ssl: false
     client:
       cognito:
         clientId: # CLIENT ID

--- a/api/src/test/java/io/kafbat/ui/config/auth/OAuthSecurityConfigInsecureSslTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/OAuthSecurityConfigInsecureSslTest.java
@@ -1,0 +1,193 @@
+package io.kafbat.ui.config.auth;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+/**
+ * Tests OAuth/OIDC configuration behavior for insecure SSL mode.
+ *
+ * <p>Focuses on:
+ * <ul>
+ *   <li>Defaulting OAuth2 registration values that were previously resolved via issuer discovery flow</li>
+ *   <li>Building client registration from OIDC discovery metadata when insecure SSL is enabled</li>
+ * </ul>
+ */
+class OAuthSecurityConfigInsecureSslTest {
+
+  private WireMockServer oidcServer;
+
+  @AfterEach
+  void tearDown() {
+    if (oidcServer != null) {
+      oidcServer.stop();
+    }
+  }
+
+  /**
+   * Verifies compatibility defaults for OAuth2 registration fields.
+   * <p>If not provided in config, authorization grant type and redirect URI
+   * should fall back to the same values expected by authorization_code flow.</p>
+   */
+  @Test
+  void oauthPropertiesApplyDefaultAuthorizationCodeAndRedirectUri() {
+    OAuthProperties properties = new OAuthProperties();
+    OAuthProperties.OAuth2Provider provider = new OAuthProperties.OAuth2Provider();
+    provider.setProvider("keycloak");
+    provider.setClientId("client-id");
+    properties.setClient(Map.of("keycloak", provider));
+
+    properties.init();
+
+    OAuthProperties.OAuth2Provider configured = properties.getClient().get("keycloak");
+    assertThat(configured.getAuthorizationGrantType())
+        .isEqualTo(OAuthProperties.DEFAULT_AUTHORIZATION_GRANT_TYPE);
+    assertThat(configured.getRedirectUri())
+        .isEqualTo(OAuthProperties.DEFAULT_REDIRECT_URI);
+  }
+
+  /**
+   * Verifies that when insecure SSL is enabled and issuer-uri is configured,
+   * OIDC metadata is resolved and used to build client registration endpoints.
+   */
+  @Test
+  void insecureSslWithIssuerUriBuildsRegistrationFromOidcDiscovery() {
+    oidcServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+    oidcServer.start();
+
+    String issuer = "http://localhost:" + oidcServer.port() + "/realms/test";
+    String metadata = """
+        {
+          "issuer": "%s",
+          "authorization_endpoint": "%s/oauth2/authorize",
+          "token_endpoint": "%s/oauth2/token",
+          "jwks_uri": "%s/.well-known/jwks.json",
+          "userinfo_endpoint": "%s/oauth2/userinfo",
+          "end_session_endpoint": "%s/oauth2/logout"
+        }
+        """.formatted(issuer, issuer, issuer, issuer, issuer, issuer);
+
+    oidcServer.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(metadata)));
+
+    OAuthProperties properties = new OAuthProperties();
+    properties.setInsecureSsl(true);
+
+    OAuthProperties.OAuth2Provider provider = new OAuthProperties.OAuth2Provider();
+    provider.setProvider("keycloak");
+    provider.setClientId("client-id");
+    provider.setClientSecret("client-secret");
+    provider.setIssuerUri(issuer);
+    properties.setClient(Map.of("keycloak", provider));
+    properties.init();
+
+    OAuthSecurityConfig config = new OAuthSecurityConfig(properties);
+    var repository = config.clientRegistrationRepository(config.oauthWebClient());
+    var registration = repository.findByRegistrationId("keycloak").block();
+
+    assertThat(registration).isNotNull();
+    assertThat(registration.getAuthorizationGrantType()).isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
+    assertThat(registration.getRedirectUri()).isEqualTo(OAuthProperties.DEFAULT_REDIRECT_URI);
+    assertThat(registration.getProviderDetails().getAuthorizationUri()).isEqualTo(issuer + "/oauth2/authorize");
+    assertThat(registration.getProviderDetails().getTokenUri()).isEqualTo(issuer + "/oauth2/token");
+    assertThat(registration.getProviderDetails().getJwkSetUri()).isEqualTo(issuer + "/.well-known/jwks.json");
+    assertThat(registration.getProviderDetails().getUserInfoEndpoint().getUri()).isEqualTo(issuer + "/oauth2/userinfo");
+    assertThat(registration.getProviderDetails().getConfigurationMetadata())
+        .containsEntry("end_session_endpoint", issuer + "/oauth2/logout");
+    assertThat(registration.getProviderDetails().getIssuerUri()).isEqualTo(issuer);
+  }
+
+  @Test
+  void insecureSslWithFullySpecifiedProviderSkipsOidcDiscovery() {
+    OAuthProperties properties = new OAuthProperties();
+    properties.setInsecureSsl(true);
+
+    OAuthProperties.OAuth2Provider provider = new OAuthProperties.OAuth2Provider();
+    provider.setProvider("keycloak");
+    provider.setClientId("client-id");
+    provider.setClientSecret("client-secret");
+    provider.setIssuerUri("http://localhost:1/unreachable");
+    provider.setAuthorizationUri("https://idp.example.com/oauth2/authorize");
+    provider.setTokenUri("https://idp.example.com/oauth2/token");
+    provider.setJwkSetUri("https://idp.example.com/.well-known/jwks.json");
+    provider.setUserInfoUri("https://idp.example.com/oauth2/userinfo");
+    properties.setClient(Map.of("keycloak", provider));
+    properties.init();
+
+    OAuthSecurityConfig config = new OAuthSecurityConfig(properties);
+    var repository = config.clientRegistrationRepository(config.oauthWebClient());
+    var registration = repository.findByRegistrationId("keycloak").block();
+
+    assertThat(registration).isNotNull();
+    assertThat(registration.getAuthorizationGrantType()).isEqualTo(AuthorizationGrantType.AUTHORIZATION_CODE);
+    assertThat(registration.getProviderDetails().getAuthorizationUri())
+        .isEqualTo("https://idp.example.com/oauth2/authorize");
+    assertThat(registration.getProviderDetails().getTokenUri())
+        .isEqualTo("https://idp.example.com/oauth2/token");
+    assertThat(registration.getProviderDetails().getJwkSetUri())
+        .isEqualTo("https://idp.example.com/.well-known/jwks.json");
+    assertThat(registration.getProviderDetails().getUserInfoEndpoint().getUri())
+        .isEqualTo("https://idp.example.com/oauth2/userinfo");
+  }
+
+  @Test
+  void insecureSslWithFullySpecifiedProviderAddsLogoutMetadataWhenDiscoveryAvailable() {
+    oidcServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+    oidcServer.start();
+
+    String issuer = "http://localhost:" + oidcServer.port() + "/realms/test";
+    String metadata = """
+        {
+          "issuer": "%s",
+          "authorization_endpoint": "%s/oauth2/authorize",
+          "token_endpoint": "%s/oauth2/token",
+          "jwks_uri": "%s/.well-known/jwks.json",
+          "userinfo_endpoint": "%s/oauth2/userinfo",
+          "end_session_endpoint": "%s/oauth2/logout"
+        }
+        """.formatted(issuer, issuer, issuer, issuer, issuer, issuer);
+
+    oidcServer.stubFor(get(urlEqualTo("/realms/test/.well-known/openid-configuration"))
+        .willReturn(aResponse()
+            .withStatus(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(metadata)));
+
+    OAuthProperties properties = new OAuthProperties();
+    properties.setInsecureSsl(true);
+
+    OAuthProperties.OAuth2Provider provider = new OAuthProperties.OAuth2Provider();
+    provider.setProvider("keycloak");
+    provider.setClientId("client-id");
+    provider.setClientSecret("client-secret");
+    provider.setIssuerUri(issuer);
+    provider.setAuthorizationUri("https://idp.example.com/oauth2/authorize");
+    provider.setTokenUri("https://idp.example.com/oauth2/token");
+    provider.setJwkSetUri("https://idp.example.com/.well-known/jwks.json");
+    provider.setUserInfoUri("https://idp.example.com/oauth2/userinfo");
+    properties.setClient(Map.of("keycloak", provider));
+    properties.init();
+
+    OAuthSecurityConfig config = new OAuthSecurityConfig(properties);
+    var repository = config.clientRegistrationRepository(config.oauthWebClient());
+    var registration = repository.findByRegistrationId("keycloak").block();
+
+    assertThat(registration).isNotNull();
+    assertThat(registration.getProviderDetails().getAuthorizationUri())
+        .isEqualTo("https://idp.example.com/oauth2/authorize");
+    assertThat(registration.getProviderDetails().getConfigurationMetadata())
+        .containsEntry("end_session_endpoint", issuer + "/oauth2/logout");
+    assertThat(registration.getProviderDetails().getIssuerUri()).isEqualTo(issuer);
+  }
+}

--- a/contract-typespec/api/config.tsp
+++ b/contract-typespec/api/config.tsp
@@ -69,6 +69,7 @@ model ApplicationConfig {
     auth?: {
       type: string;
       oauth2?: {
+        insecureSsl?: boolean = false;
         client?: Record<{
             provider: string;
             clientId: string;

--- a/contract/src/main/resources/swagger/kafbat-ui-api.yaml
+++ b/contract/src/main/resources/swagger/kafbat-ui-api.yaml
@@ -4471,6 +4471,8 @@ components:
                 oauth2:
                   type: object
                   properties:
+                    insecureSsl:
+                      type: boolean
                     client:
                       type: object
                       additionalProperties:


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
N/A

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Added support for skipping TLS verification for OAuth2/OIDC provider communication via a new config flag:

```yaml
yamlApplicationConfig:
  auth:
    type: OAUTH2
    oauth2:
      insecure-ssl: true
```

- Added `auth.oauth2.insecure-ssl` to OAuth properties.
- Wired insecure TLS mode into OAuth WebClient used for token/userinfo/jwks/introspection calls.
- Added OIDC metadata enrichment (for `issuer-uri`) through the same OAuth WebClient when `insecure-ssl=true`, so self-signed certs work during startup discovery too.
- Preserved backward compatibility defaults in OAuth config init:
  - `authorization-grant-type: authorization_code`
  - `redirect-uri: {baseUrl}/login/oauth2/code/{registrationId}`
- Updated config contract/spec so `insecureSsl` is available in generated API DTO/OpenAPI.

**Is there anything you'd like reviewers to focus on?**
N/A

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

Manual:
- Built and deployed patched image to Kubernetes.
- Verified startup failure with `self-signed OIDC cert` before fix.
- Verified successful startup and login flow with `auth.oauth2.insecure-ssl=true`.
- Verified `OpenAPI/static spec` contains insecureSsl.

Automation:
- Ran `./gradlew :api:compileJava` successfully after changes.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an insecure SSL/TLS mode for OAuth2/OIDC to allow discovery against self-signed/dev certificates.
  * Provider defaults for authorization grant type and redirect URI are applied when not specified.
  * Conditional OIDC metadata discovery populates missing provider endpoints when insecure SSL mode is enabled.

* **Tests**
  * Added tests for insecure SSL mode, OIDC discovery behavior, and default value application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->