### PR TITLE
Seconds level filtering to improve search precision for high-throughput topics

### DIFF
--- a/frontend/src/components/ConsumerGroups/Details/ResetOffsets/ResetOffsets.styled.ts
+++ b/frontend/src/components/ConsumerGroups/Details/ResetOffsets/ResetOffsets.styled.ts
@@ -9,9 +9,10 @@ export const OffsetsWrapper = styled.div`
 `;
 
 export const DatePickerInput = styled(DatePicker).attrs({
-  showTimeInput: true,
-  timeInputLabel: 'Time:',
-  dateFormat: 'MMMM d, yyyy h:mm aa',
+  showTimeSelect: true,
+  timeFormat: 'HH:mm:ss',
+  timeIntervals: 1,
+  dateFormat: 'MMMM d, yyyy HH:mm:ss',
 })`
   height: 40px;
   border: 1px ${({ theme }) => theme.select.borderColor.normal} solid;

--- a/frontend/src/components/Topics/Topic/Messages/Filters/Filters.styled.ts
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/Filters.styled.ts
@@ -43,6 +43,7 @@ export const DatePickerInput = styled(DatePicker)`
   font-size: 14px;
   width: 100%;
   padding-left: 12px;
+  padding-right: 24px;
   background-color: ${({ theme }) => theme.input.backgroundColor.normal};
   color: ${({ theme }) => theme.input.color.normal};
   &::placeholder {

--- a/frontend/src/components/Topics/Topic/Messages/Filters/Filters.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/Filters.tsx
@@ -135,10 +135,15 @@ const Filters: React.FC<FiltersProps> = ({
               ) : (
                 <S.DatePickerInput
                   selected={date}
-                  onChange={setTimeStamp}
+                  onChange={(newDate: Date | null) => {
+                    if (newDate && !date) {
+                      newDate.setHours(0, 0, 0, 0);
+                    }
+                    setTimeStamp(newDate);
+                  }}
                   showTimeInput
                   timeInputLabel="Time:"
-                  dateFormat="MMM d, yyyy"
+                  dateFormat="MMM d, yyyy HH:mm:ss"
                   placeholderText="Select timestamp"
                 />
               ))}


### PR DESCRIPTION


<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
**No breaking changes**. This is a UI enhancement to the date/time picker.

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Enhanced the date/time picker in the Messages filter to support seconds precision:

- Added seconds to date format :  Updated dateFormat from "MMM d, yyyy" to "MMM d, yyyy HH:mm:ss" so users can see and edit timestamps with seconds precision directly in the input field.
- Added padding to prevent text collision : Added padding-right: 24px to DatePickerInput styled component to prevent the timestamp text from colliding with the dropdown arrow.
- Set default time to 00:00:00 : When a new date is selected (with no previous date), the time now defaults to 00:00:00 instead of the current time.

**Is there anything you'd like reviewers to focus on?**
The logic for setting default time to 00:00:00 only applies when no previous date was selected (!date condition). This preserves the time when users change the date on an existing selection.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Manually
- Verified date picker displays seconds in the input field
- Verified text no longer collides with dropdown arrow
- Verified new date selections default to 00:00:00
- Verified editing time directly in the input field works correctly
- Verified the data is shown as per the time selected

### Minute-level filtering
Filtering using minute-level granularity returns all messages within the same minute

<img width="1728" height="420" alt="Image1" src="https://github.com/user-attachments/assets/ef335fc5-666f-41bd-9895-83787408b1e2" />

### Seconds-level filtering
With seconds-level granularity, filtering becomes more precise and returns only the messages within the specified second.

<img width="1728" height="441" alt="Image2" src="https://github.com/user-attachments/assets/fbcadcc9-84da-49f7-af90-ff780f965262" />


**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Date/time picker now uses 24-hour time format (HH:mm:ss) instead of 12-hour format with AM/PM
  * Time selection now supports 1-minute intervals for greater precision
  * Improved date picker alignment and spacing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->