### PR TITLE
fix(serde): use TypeRegistry in ProtobufFileSerde deserializer to resolve google.protobuf.Any types

### DIFF
--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
@@ -40,7 +40,6 @@ import com.squareup.wire.schema.ProtoFile;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ProtoParser;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
-import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils;
 import io.kafbat.ui.exception.ValidationException;
 import io.kafbat.ui.serde.api.DeserializeResult;
 import io.kafbat.ui.serde.api.PropertyResolver;
@@ -161,13 +160,17 @@ public class ProtobufFileSerde implements BuiltInSerde {
   @Override
   public Serde.Deserializer deserializer(String topic, Serde.Target type) {
     var descriptor = descriptorFor(topic, type).orElseThrow();
+    TypeRegistry typeRegistry = TypeRegistry.newBuilder().add(descriptorPaths.keySet()).build();
     return new Serde.Deserializer() {
       @SneakyThrows
       @Override
       public DeserializeResult deserialize(RecordHeaders headers, byte[] data) {
         var protoMsg = DynamicMessage.parseFrom(descriptor, new ByteArrayInputStream(data));
-        byte[] jsonFromProto = ProtobufSchemaUtils.toJson(protoMsg);
-        var result = new String(jsonFromProto);
+        var result = JsonFormat.printer()
+            .usingTypeRegistry(typeRegistry)
+            .includingDefaultValueFields()
+            .omittingInsignificantWhitespace()
+            .print(protoMsg);
         return new DeserializeResult(
             result,
             DeserializeResult.Type.JSON,

--- a/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
+++ b/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
@@ -270,6 +270,55 @@ class ProtobufFileSerdeTest {
   }
 
   @Test
+  void deserializeResolvesCustomTypesInsideAnyFields() throws Exception {
+    // messagewithany.proto defines MessageWithAny { string name; google.protobuf.Any payload; }
+    // and PayloadMessage { string id; }. This test verifies that when PayloadMessage is packed
+    // into the Any field, the deserializer can resolve the type URL and print its content as JSON.
+    Map<Path, ProtobufSchema> files = ProtobufFileSerde.Configuration.loadSchemas(
+        Optional.empty(),
+        Optional.of(protoFilesDir())
+    );
+    Path msgWithAnyPath = ResourceUtils.getFile("classpath:protobuf-serde/messagewithany.proto").toPath();
+    var msgWithAnySchema = files.get(msgWithAnyPath);
+
+    var payloadDescriptor = msgWithAnySchema.toDescriptor("test.PayloadMessage");
+    var outerDescriptor = msgWithAnySchema.toDescriptor("test.MessageWithAny");
+
+    // Build a PayloadMessage and pack it into MessageWithAny.payload as an Any
+    var payloadMsg = com.google.protobuf.DynamicMessage.newBuilder(payloadDescriptor)
+        .setField(payloadDescriptor.findFieldByName("id"), "payload-123")
+        .build();
+    var anyValue = com.google.protobuf.Any.pack(payloadMsg);
+
+    // Workaround: pack() requires a generated class; build Any manually via JSON round-trip
+    var typeRegistry = com.google.protobuf.TypeRegistry.newBuilder()
+        .add(payloadDescriptor)
+        .add(outerDescriptor)
+        .build();
+    var anyJson = "{\"@type\":\"type.googleapis.com/test.PayloadMessage\",\"id\":\"payload-123\"}";
+    var outerJson = "{\"name\":\"test\",\"payload\":" + anyJson + "}";
+
+    var outerBuilder = msgWithAnySchema.newMessageBuilder("test.MessageWithAny");
+    com.google.protobuf.util.JsonFormat.parser().usingTypeRegistry(typeRegistry).merge(outerJson, outerBuilder);
+    var outerMsgBytes = outerBuilder.build().toByteArray();
+
+    var serde = new ProtobufFileSerde();
+    serde.configure(new Configuration(
+        outerDescriptor,
+        null,
+        Map.of(outerDescriptor, msgWithAnyPath, payloadDescriptor, msgWithAnyPath),
+        Map.of(),
+        Map.of()
+    ));
+
+    var result = serde.deserializer("any-topic", Serde.Target.VALUE)
+        .deserialize(null, outerMsgBytes);
+
+    assertThat(result.getResult()).contains("payload-123");
+    assertThat(result.getResult()).contains("test.PayloadMessage");
+  }
+
+  @Test
   void deserializeUsesTopicsMappingToFindMsgDescriptor() {
     var messageNameMap = Map.of(
         "persons", personDescriptor,


### PR DESCRIPTION
## Problem

When a Protobuf message contains a `google.protobuf.Any` field (e.g. a notification wrapper that embeds a custom payload type), Kafka-UI falls back to the **Fallback** serde and logs:

```
com.google.protobuf.InvalidProtocolBufferException: Cannot find type for url:
  type.googleapis.com/com.example.MyPayload
```

This happens because `deserializer()` calls `ProtobufSchemaUtils.toJson(protoMsg)` which internally calls `JsonFormat.printer().print(message)` **without a `TypeRegistry`**. Without one, `JsonFormat` cannot resolve the type URL embedded in the `Any` field and throws.

## Root cause

`serializer()` already does the right thing — it builds a `TypeRegistry` from `descriptorPaths.keySet()` and passes it to `JsonFormat.parser()`. The same pattern was simply never applied to `deserializer()`.

## Fix

Build the same `TypeRegistry` in `deserializer()` and use `JsonFormat.printer().usingTypeRegistry(typeRegistry)` instead of delegating to `ProtobufSchemaUtils.toJson()`. The `includingDefaultValueFields()` and `omittingInsignificantWhitespace()` flags from the original implementation are preserved.

```java
// before
var result = ProtobufSchemaUtils.toJson(protoMsg);

// after
TypeRegistry typeRegistry = TypeRegistry.newBuilder().add(descriptorPaths.keySet()).build();
// ... (capture in anonymous class closure)
var result = JsonFormat.printer()
    .usingTypeRegistry(typeRegistry)
    .includingDefaultValueFields()
    .omittingInsignificantWhitespace()
    .print(protoMsg);
```

## Testing

Added `deserializeResolvesCustomTypesInsideAnyFields()` to `ProtobufFileSerdeTest` using the existing `messagewithany.proto` test resource. The test:
1. Builds a message that has a `google.protobuf.Any` field containing a `PayloadMessage`
2. Serialises it to binary wire format
3. Deserialises with `ProtobufFileSerde` and asserts the `@type` annotation and payload fields are present in the JSON output

Closes #1730

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deserialization of custom types embedded within Protocol Buffer Any fields, ensuring proper type resolution and message reconstruction during data processing.

* **Tests**
  * Added test case validating correct handling of custom types within Any field structures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->