### PR TITLE
Infra: Add Spring Boot dependency pattern to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
   groups:
     spring-boot-dependencies:
       patterns:
+        - "org.springframework.boot"
         - "org.springframework.boot:*"
         - "io.spring.dependency-management"
         # We defined this dependency explicitly because Spring uses an older version


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Adds an explicit `org.springframework.boot` entry to the Spring group to avoid matching it across groups as described in https://github.com/dependabot/dependabot-core/issues/14143


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Manually

Tested via https://github.com/yeikel/dependabot-reproducer-issue-14143/pull/3

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged


**A picture of a cute animal (not mandatory but encouraged)**

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/b2b110eb-4672-4025-87c1-d9e209acf550" />
