### PR TITLE
BE: Overwrite Netty to 4.1.132.Final temporarily

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -9,6 +9,16 @@ plugins {
 
 configurations.all {
     resolutionStrategy {
+        eachDependency { DependencyResolveDetails details ->
+            // The netty-tcnative-* family (native bindings for OpenSSL/BoringSSL)
+            // uses independent versioning and should not be forced to the core Netty version
+            // It is also not vulnerable to the CVEs fixed in the Netty version we are forcing
+            // so we can safely exclude it from the resolution strategy
+            if (details.requested.group == "io.netty" && !details.requested.name.startsWith("netty-tcnative-")) {
+                details.useVersion(libs.versions.netty.get())
+                details.because("Fixes CVE-2026-33871 and CVE-2026-33870. Revert when Spring Boot releases a version with the fix")
+            }
+        }
         capabilitiesResolution {
             withCapability("org.lz4:lz4-java") {
                 select(libs.lz4.yawk.get().toString())

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 spring-boot = '3.5.12'
 nimbus-jose-jwt = '10.6'
 jackson-core = '2.21.2'
+netty = '4.1.132.Final'
 
 aws-msk-auth = '2.3.0'
 azure-identity = '1.15.4'


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Overwrites Netty to force 4.1.132.Final

Fixes CVE-2026-33871 and CVE-2026-33870

See https://netty.io/news/2026/03/24/4-1-132-Final.html

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [x] Unit checks
- [x] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/2c8856cc-731d-41b6-b1f0-f7030302f43e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized Netty version in the build configuration for consistent dependency management.
  * Temporarily enforced that version across builds to mitigate security vulnerabilities; includes a documented rationale and will be reverted once an upstream fix is available.
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->