### PR TITLE
BE: MCP: Enforce cluster readOnly restriction for write operations

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/mcp/McpSpecificationGenerator.java
+++ b/api/src/main/java/io/kafbat/ui/service/mcp/McpSpecificationGenerator.java
@@ -95,7 +95,9 @@ public class McpSpecificationGenerator {
             if (readOnly) {
               return Mono.just(toErrorResult(new ReadOnlyModeException()));
             }
-          } else if (clusterName != null) {
+          } else if (clusterName == null) {
+            return Mono.just(toErrorResult("clusterName is required for write operations"));
+          } else {
             log.warn("Write operation called with non-String clusterName: {}", clusterName.getClass());
           }
         }

--- a/api/src/test/java/io/kafbat/ui/service/mcp/McpSpecificationGeneratorTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/mcp/McpSpecificationGeneratorTest.java
@@ -241,6 +241,26 @@ class McpSpecificationGeneratorTest {
         .verifyComplete();
   }
 
+  @Test
+  void writeOperationWithoutClusterNameReturnsError() {
+    ClustersStorage storage = mock(ClustersStorage.class);
+    McpSpecificationGenerator generator = generatorWith(storage);
+    List<AsyncToolSpecification> specs = generator.convertTool(topicsController());
+
+    AsyncToolSpecification createTopic = findTool(specs, "createTopic");
+
+    // Invoke without clusterName in args
+    Mono<CallToolResult> result = invokeTool(createTopic, Map.of());
+
+    StepVerifier.create(result)
+        .assertNext(callResult -> {
+          assertThat(callResult.isError()).isTrue();
+          String text = ((McpSchema.TextContent) callResult.content().get(0)).text();
+          assertThat(text).contains("clusterName is required");
+        })
+        .verifyComplete();
+  }
+
   // --- helpers ---
 
   private static ClustersStorage readOnlyClusterStorage() {


### PR DESCRIPTION
## Summary

Fixes #1751

MCP tool calls bypass the `ReadOnlyModeFilter` because they arrive via `POST /mcp/message` instead of `/api/clusters/{clusterName}/...` paths. This means write operations (create topic, delete schema, etc.) can be executed through MCP even when the cluster is configured as read-only.

### Root Cause

`ReadOnlyModeFilter` is a `WebFilter` that checks the HTTP request path against `/api/clusters/{clusterName}` pattern. MCP requests use a different path (`/mcp/message`, `/mcp/sse`), so they bypass this filter entirely.

### Solution

Added a readOnly check in `McpSpecificationGenerator.methodCall()`:

1. **At tool registration time**: Inspects the `@RequestMapping` annotation on the generated API interface method to determine if the operation is a write (POST/PUT/PATCH/DELETE) vs read (GET/OPTIONS/HEAD)
2. **At tool call time**: For write operations, extracts `clusterName` from MCP arguments and checks `ClustersStorage.getClusterByName(clusterName).isReadOnly()`. If the cluster is read-only, returns a `ReadOnlyModeException` error result instead of invoking the controller method.
3. **Safe operations exempted**: `analyzeTopic`, `cancelTopicAnalysis`, and `registerFilter` are exempted from the readOnly check, consistent with `ReadOnlyModeFilter.SAFE_ENDPOINTS`.

### Changes

- `McpSpecificationGenerator.java`: Inject `ClustersStorage`, add `isWriteOperation()` detection via `@RequestMapping`, add readOnly guard in `methodCall()`
- `McpSpecificationGeneratorTest.java`: Add tests verifying write operations are blocked on readOnly clusters and allowed on non-readOnly clusters

## Test plan

- [x] Existing `testConvertController` test passes (tool generation unchanged)
- [x] New `writeOperationBlockedOnReadOnlyCluster` test: verifies `createTopic` (POST) returns "read-only" error on readOnly cluster
- [x] New `writeOperationNotBlockedOnNonReadOnlyCluster` test: verifies `createTopic` proceeds past readOnly check on normal cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Write operations are now detected and blocked on read-only clusters, returning a clear read-only error; invoking a write without specifying the target cluster now returns a validation error.

* **Tests**
  * Added tests covering read-only enforcement, safe/read operations, behavior for unknown clusters, and validation for missing clusterName.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->