### PR TITLE
feat(azure): support custom OAuth scope and fix NPE for client_credentials tokens

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
@@ -7,6 +7,7 @@ import com.azure.core.credential.TokenRequestContext;
 import com.azure.identity.DefaultAzureCredentialBuilder;
 import java.net.URI;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -15,6 +16,8 @@ import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.security.auth.AuthenticateCallbackHandler;
+import org.apache.kafka.common.security.auth.SaslExtensions;
+import org.apache.kafka.common.security.auth.SaslExtensionsCallback;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 
@@ -36,15 +39,27 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
    */
   static final String JAAS_OPTION_SCOPE = "scope";
 
+  /**
+   * Prefix for JAAS config options that should be forwarded as SASL extensions.
+   * For example, {@code extension_logicalCluster="lkc-xxxxx"} in the JAAS config
+   * becomes the SASL extension {@code logicalCluster=lkc-xxxxx}. This is required
+   * by Confluent Cloud to route OAUTHBEARER requests to the correct logical cluster
+   * and identity pool.
+   */
+  static final String EXTENSION_PREFIX = "extension_";
+
   static TokenCredential tokenCredential = new DefaultAzureCredentialBuilder().build();
 
   private TokenRequestContext tokenRequestContext;
+
+  private SaslExtensions saslExtensions = SaslExtensions.empty();
 
   @Override
   public void configure(Map<String, ?> configs,
                         String mechanism,
                         List<AppConfigurationEntry> jaasConfigEntries) {
     tokenRequestContext = buildTokenRequestContext(configs, jaasConfigEntries);
+    saslExtensions = buildSaslExtensions(jaasConfigEntries);
   }
 
   private TokenRequestContext buildTokenRequestContext(Map<String, ?> configs,
@@ -82,6 +97,34 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
     return null;
   }
 
+  /**
+   * Extracts SASL extensions from JAAS config options with the {@code extension_} prefix.
+   * These extensions are sent to the broker during the SASL/OAUTHBEARER handshake.
+   * Confluent Cloud requires {@code logicalCluster} and {@code identityPoolId} extensions
+   * to route requests to the correct cluster and identity pool.
+   */
+  private SaslExtensions buildSaslExtensions(List<AppConfigurationEntry> jaasConfigEntries) {
+    if (jaasConfigEntries == null) {
+      return SaslExtensions.empty();
+    }
+    Map<String, String> extensions = new HashMap<>();
+    for (AppConfigurationEntry entry : jaasConfigEntries) {
+      for (Map.Entry<String, ?> option : entry.getOptions().entrySet()) {
+        if (option.getKey().startsWith(EXTENSION_PREFIX) && option.getValue() instanceof String value) {
+          String extensionName = option.getKey().substring(EXTENSION_PREFIX.length());
+          String trimmed = value.trim();
+          if (!extensionName.isEmpty() && !trimmed.isEmpty()) {
+            extensions.put(extensionName, trimmed);
+          }
+        }
+      }
+    }
+    if (!extensions.isEmpty()) {
+      log.info("Loaded {} SASL extension(s) from JAAS config: {}", extensions.size(), extensions.keySet());
+    }
+    return new SaslExtensions(extensions);
+  }
+
   @SuppressWarnings("unchecked")
   private URI buildBootstrapServerUri(Map<String, ?> configs) {
     final List<String> bootstrapServers = (List<String>) configs.get(BOOTSTRAP_SERVERS_CONFIG);
@@ -110,10 +153,13 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
   @Override
   public void handle(Callback[] callbacks) throws UnsupportedCallbackException {
     for (Callback callback : callbacks) {
-      if (!(callback instanceof OAuthBearerTokenCallback oauthCallback)) {
+      if (callback instanceof OAuthBearerTokenCallback oauthCallback) {
+        handleOAuthCallback(oauthCallback);
+      } else if (callback instanceof SaslExtensionsCallback extensionsCallback) {
+        extensionsCallback.extensions(saslExtensions);
+      } else {
         throw new UnsupportedCallbackException(callback);
       }
-      handleOAuthCallback(oauthCallback);
     }
   }
 

--- a/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
@@ -143,7 +143,14 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
       throw new IllegalArgumentException(message);
     }
 
-    return URI.create("https://" + bootstrapServers.get(0));
+    String server = bootstrapServers.get(0).trim();
+    if (server.isEmpty()) {
+      final String message = BOOTSTRAP_SERVERS_CONFIG + " must contain a non-blank bootstrap server.";
+      log.error(message);
+      throw new IllegalArgumentException(message);
+    }
+
+    return URI.create("https://" + server);
   }
 
   private String buildTokenAudience(URI uri) {

--- a/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
@@ -64,6 +65,7 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
     return request;
   }
 
+  @Nullable
   private String getJaasOption(List<AppConfigurationEntry> jaasConfigEntries, String key) {
     if (jaasConfigEntries == null) {
       return null;
@@ -90,10 +92,10 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
       throw new IllegalArgumentException(message);
     }
 
-    if (bootstrapServers.size() > 1) {
+    if (bootstrapServers.size() != 1) {
       final String message =
           BOOTSTRAP_SERVERS_CONFIG
-              + " contains multiple bootstrap servers. Only a single bootstrap server is supported.";
+              + " must contain exactly one bootstrap server, but found " + bootstrapServers.size() + ".";
       log.error(message);
       throw new IllegalArgumentException(message);
     }
@@ -125,6 +127,10 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
           .retry(ACCESS_TOKEN_REQUEST_MAX_RETRIES)
           .block();
 
+      if (token == null) {
+        oauthCallback.error("invalid_grant", "Token acquisition returned empty result.", null);
+        return;
+      }
       oauthCallback.token(token);
     } catch (RuntimeException e) {
       final String message =

--- a/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
@@ -51,7 +51,7 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
     String customScope = getJaasOption(jaasConfigEntries, JAAS_OPTION_SCOPE);
 
     String tokenAudience;
-    if (customScope != null && !customScope.isEmpty()) {
+    if (customScope != null) {
       log.info("Using custom OAuth scope from JAAS config: {}", customScope);
       tokenAudience = customScope;
     } else {
@@ -71,7 +71,10 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
     for (AppConfigurationEntry entry : jaasConfigEntries) {
       Object value = entry.getOptions().get(key);
       if (value instanceof String s) {
-        return s;
+        String trimmed = s.trim();
+        if (!trimmed.isEmpty()) {
+          return trimmed;
+        }
       }
     }
     return null;

--- a/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandler.java
@@ -26,6 +26,15 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
 
   private static final String TOKEN_AUDIENCE_FORMAT = "%s://%s/.default";
 
+  /**
+   * JAAS config option to override the token scope. When set, this value is used
+   * instead of deriving the scope from the bootstrap server URL. This is required
+   * for services like Confluent Cloud where the OAuth scope is an application
+   * registration URI (e.g. {@code api://<client-id>/.default}) rather than the
+   * bootstrap server hostname.
+   */
+  static final String JAAS_OPTION_SCOPE = "scope";
+
   static TokenCredential tokenCredential = new DefaultAzureCredentialBuilder().build();
 
   private TokenRequestContext tokenRequestContext;
@@ -34,20 +43,42 @@ public class AzureEntraLoginCallbackHandler implements AuthenticateCallbackHandl
   public void configure(Map<String, ?> configs,
                         String mechanism,
                         List<AppConfigurationEntry> jaasConfigEntries) {
-    tokenRequestContext = buildTokenRequestContext(configs);
+    tokenRequestContext = buildTokenRequestContext(configs, jaasConfigEntries);
   }
 
-  private TokenRequestContext buildTokenRequestContext(Map<String, ?> configs) {
-    URI uri = buildEventHubsServerUri(configs);
-    String tokenAudience = buildTokenAudience(uri);
+  private TokenRequestContext buildTokenRequestContext(Map<String, ?> configs,
+                                                       List<AppConfigurationEntry> jaasConfigEntries) {
+    String customScope = getJaasOption(jaasConfigEntries, JAAS_OPTION_SCOPE);
+
+    String tokenAudience;
+    if (customScope != null && !customScope.isEmpty()) {
+      log.info("Using custom OAuth scope from JAAS config: {}", customScope);
+      tokenAudience = customScope;
+    } else {
+      URI uri = buildBootstrapServerUri(configs);
+      tokenAudience = buildTokenAudience(uri);
+    }
 
     TokenRequestContext request = new TokenRequestContext();
     request.addScopes(tokenAudience);
     return request;
   }
 
+  private String getJaasOption(List<AppConfigurationEntry> jaasConfigEntries, String key) {
+    if (jaasConfigEntries == null) {
+      return null;
+    }
+    for (AppConfigurationEntry entry : jaasConfigEntries) {
+      Object value = entry.getOptions().get(key);
+      if (value instanceof String s) {
+        return s;
+      }
+    }
+    return null;
+  }
+
   @SuppressWarnings("unchecked")
-  private URI buildEventHubsServerUri(Map<String, ?> configs) {
+  private URI buildBootstrapServerUri(Map<String, ?> configs) {
     final List<String> bootstrapServers = (List<String>) configs.get(BOOTSTRAP_SERVERS_CONFIG);
 
     if (bootstrapServers == null) {

--- a/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraOAuthBearerToken.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraOAuthBearerToken.java
@@ -44,16 +44,30 @@ public class AzureEntraOAuthBearerToken implements OAuthBearerToken {
   public Set<String> scope() {
     // Referring to
     // https://docs.microsoft.com/azure/active-directory/develop/access-tokens#payload-claims, the
-    // scp
-    // claim is a String which is presented as a space separated list.
-    return Arrays
-        .stream(((String) claims.getClaim("scp")).split(" "))
-        .collect(Collectors.toSet());
+    // scp claim is a String which is presented as a space separated list.
+    // For client_credentials (app-only) tokens, scp is absent — Azure uses "roles" instead.
+    Object scp = claims.getClaim("scp");
+    if (scp instanceof String s && !s.isEmpty()) {
+      return Arrays
+          .stream(s.split(" "))
+          .collect(Collectors.toSet());
+    }
+    return Set.of();
   }
 
   @Override
   public String principalName() {
-    return (String) claims.getClaim("upn");
+    // For delegated (user) tokens, upn contains the user principal name.
+    // For client_credentials (app-only) tokens, upn is absent — fall back to appid or sub.
+    Object upn = claims.getClaim("upn");
+    if (upn instanceof String s) {
+      return s;
+    }
+    Object appid = claims.getClaim("appid");
+    if (appid instanceof String s) {
+      return s;
+    }
+    return (String) claims.getClaim("sub");
   }
 
   public boolean isExpired() {

--- a/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraOAuthBearerToken.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/azure/AzureEntraOAuthBearerToken.java
@@ -60,14 +60,18 @@ public class AzureEntraOAuthBearerToken implements OAuthBearerToken {
     // For delegated (user) tokens, upn contains the user principal name.
     // For client_credentials (app-only) tokens, upn is absent — fall back to appid or sub.
     Object upn = claims.getClaim("upn");
-    if (upn instanceof String s) {
+    if (upn instanceof String s && !s.isBlank()) {
       return s;
     }
     Object appid = claims.getClaim("appid");
-    if (appid instanceof String s) {
+    if (appid instanceof String s && !s.isBlank()) {
       return s;
     }
-    return (String) claims.getClaim("sub");
+    Object sub = claims.getClaim("sub");
+    if (sub instanceof String s && !s.isBlank()) {
+      return s;
+    }
+    throw new SaslAuthenticationException("Unable to resolve principal name from token claims");
   }
 
   public boolean isExpired() {

--- a/api/src/main/java/io/kafbat/ui/service/ReactiveAdminClient.java
+++ b/api/src/main/java/io/kafbat/ui/service/ReactiveAdminClient.java
@@ -160,10 +160,21 @@ public class ReactiveAdminClient implements Closeable {
                 .orElse(desc.getNodes().iterator().next().id());
             return loadBrokersConfig(ac, List.of(targetNodeId))
                 .map(map -> map.isEmpty() ? List.<ConfigEntry>of() : map.get(targetNodeId))
-                .zipWith(toMono(ac.describeFeatures().featureMetadata()))
+                .zipWith(
+                    toMono(ac.describeFeatures().featureMetadata())
+                        .map(Optional::of)
+                        .onErrorResume(ClusterAuthorizationException.class, th -> {
+                          log.trace("ClusterAuthorizationException while calling describeFeatures", th);
+                          return Mono.just(Optional.empty());
+                        })
+                        .onErrorResume(UnsupportedVersionException.class, th -> {
+                          log.trace("UnsupportedVersionException while calling describeFeatures", th);
+                          return Mono.just(Optional.empty());
+                        })
+                )
                 .flatMap(tuple -> {
                   List<ConfigEntry> configs = tuple.getT1();
-                  FeatureMetadata featureMetadata = tuple.getT2();
+                  Optional<FeatureMetadata> featureMetadataOpt = tuple.getT2();
                   Optional<String> version = Optional.empty();
                   boolean topicDeletionEnabled = true;
                   for (ConfigEntry entry : configs) {
@@ -174,9 +185,9 @@ public class ReactiveAdminClient implements Closeable {
                       topicDeletionEnabled = Boolean.parseBoolean(entry.value());
                     }
                   }
-                  if (version.isEmpty()) {
+                  if (version.isEmpty() && featureMetadataOpt.isPresent()) {
                     FinalizedVersionRange metadataVersion =
-                        featureMetadata.finalizedFeatures().get("metadata.version");
+                        featureMetadataOpt.get().finalizedFeatures().get("metadata.version");
                     if (metadataVersion != null) {
                       version = MetadataVersion.findVersion(metadataVersion.maxVersionLevel());
                     }

--- a/api/src/main/java/io/kafbat/ui/service/StatisticsService.java
+++ b/api/src/main/java/io/kafbat/ui/service/StatisticsService.java
@@ -73,12 +73,12 @@ public class StatisticsService {
   private static Mono<Optional<QuorumInfo>> loadQuorumInfo(ReactiveAdminClient ac) {
     return ac.describeMetadataQuorum()
         .map(Optional::of)
-        .onErrorResume(t ->
-            t instanceof UnsupportedVersionException
-                || t instanceof ClusterAuthorizationException
-                ? Mono.just(Optional.empty())
-                : Mono.error(t)
-        );
+        .onErrorResume(UnsupportedVersionException.class, th -> Mono.just(Optional.empty()))
+        .onErrorResume(ClusterAuthorizationException.class, th -> {
+          log.warn("ClusterAuthorizationException calling describeMetadataQuorum — "
+              + "controller type may be reported incorrectly", th);
+          return Mono.just(Optional.empty());
+        });
   }
 
   private Statistics createStats(ClusterDescription description,

--- a/api/src/main/java/io/kafbat/ui/service/StatisticsService.java
+++ b/api/src/main/java/io/kafbat/ui/service/StatisticsService.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.QuorumInfo;
+import org.apache.kafka.common.errors.ClusterAuthorizationException;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Service;
@@ -74,6 +75,7 @@ public class StatisticsService {
         .map(Optional::of)
         .onErrorResume(t ->
             t instanceof UnsupportedVersionException
+                || t instanceof ClusterAuthorizationException
                 ? Mono.just(Optional.empty())
                 : Mono.error(t)
         );

--- a/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
 import javax.security.auth.login.AppConfigurationEntry;
+import org.apache.kafka.common.security.auth.SaslExtensions;
+import org.apache.kafka.common.security.auth.SaslExtensionsCallback;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 import org.junit.jupiter.api.BeforeEach;
@@ -270,6 +272,92 @@ class AzureEntraLoginCallbackHandlerTest {
   void shouldThrowExceptionWithUnsupportedCallback() {
     assertThrows(UnsupportedCallbackException.class, () -> azureEntraLoginCallbackHandler.handle(
         new Callback[] {mock(Callback.class)}));
+  }
+
+  @Test
+  void shouldHandleSaslExtensionsCallback() throws UnsupportedCallbackException {
+    Map<String, Object> configs = Map.of("bootstrap.servers",
+        List.of("pkc-xxxxx.westeurope.azure.confluent.cloud:9092"));
+
+    String customScope = "api://f5b9dd55-0589-4b04-9e0c-37775596161e/.default";
+    AppConfigurationEntry jaasEntry = new AppConfigurationEntry(
+        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+        Map.of(
+            "scope", customScope,
+            "extension_logicalCluster", "lkc-xxxxx",
+            "extension_identityPoolId", "pool-yyyyy"));
+
+    azureEntraLoginCallbackHandler.configure(configs, null, List.of(jaasEntry));
+
+    SaslExtensionsCallback extensionsCallback = new SaslExtensionsCallback();
+    azureEntraLoginCallbackHandler.handle(new Callback[] {extensionsCallback});
+
+    SaslExtensions extensions = extensionsCallback.extensions();
+    assertThat(extensions, is(notNullValue()));
+    assertThat(extensions.map().get("logicalCluster"), is("lkc-xxxxx"));
+    assertThat(extensions.map().get("identityPoolId"), is("pool-yyyyy"));
+  }
+
+  @Test
+  void shouldReturnEmptyExtensionsWhenNoExtensionOptionsInJaas() throws UnsupportedCallbackException {
+    Map<String, Object> configs = Map.of("bootstrap.servers",
+        List.of("pkc-xxxxx.westeurope.azure.confluent.cloud:9092"));
+
+    String customScope = "api://f5b9dd55-0589-4b04-9e0c-37775596161e/.default";
+    AppConfigurationEntry jaasEntry = new AppConfigurationEntry(
+        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+        Map.of("scope", customScope));
+
+    azureEntraLoginCallbackHandler.configure(configs, null, List.of(jaasEntry));
+
+    SaslExtensionsCallback extensionsCallback = new SaslExtensionsCallback();
+    azureEntraLoginCallbackHandler.handle(new Callback[] {extensionsCallback});
+
+    SaslExtensions extensions = extensionsCallback.extensions();
+    assertThat(extensions, is(notNullValue()));
+    assertThat(extensions.map().isEmpty(), is(true));
+  }
+
+  @Test
+  void shouldReturnEmptyExtensionsWhenNullJaasEntries() throws UnsupportedCallbackException {
+    Map<String, Object> configs = Map.of("bootstrap.servers",
+        List.of("test-eh.servicebus.windows.net:9093"));
+
+    azureEntraLoginCallbackHandler.configure(configs, null, null);
+
+    SaslExtensionsCallback extensionsCallback = new SaslExtensionsCallback();
+    azureEntraLoginCallbackHandler.handle(new Callback[] {extensionsCallback});
+
+    SaslExtensions extensions = extensionsCallback.extensions();
+    assertThat(extensions, is(notNullValue()));
+    assertThat(extensions.map().isEmpty(), is(true));
+  }
+
+  @Test
+  void shouldHandleBothTokenAndExtensionsCallbacksTogether() throws UnsupportedCallbackException {
+    Map<String, Object> configs = Map.of("bootstrap.servers",
+        List.of("pkc-xxxxx.westeurope.azure.confluent.cloud:9092"));
+
+    String customScope = "api://f5b9dd55-0589-4b04-9e0c-37775596161e/.default";
+    AppConfigurationEntry jaasEntry = new AppConfigurationEntry(
+        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+        Map.of(
+            "scope", customScope,
+            "extension_logicalCluster", "lkc-xxxxx"));
+
+    when(tokenCredential.getToken(any(TokenRequestContext.class))).thenReturn(Mono.just(accessToken));
+    when(accessToken.getToken()).thenReturn(VALID_SAMPLE_TOKEN);
+
+    azureEntraLoginCallbackHandler.configure(configs, null, List.of(jaasEntry));
+
+    SaslExtensionsCallback extensionsCallback = new SaslExtensionsCallback();
+    azureEntraLoginCallbackHandler.handle(new Callback[] {oauthBearerTokenCallBack, extensionsCallback});
+
+    verify(oauthBearerTokenCallBack, times(1)).token(any(OAuthBearerToken.class));
+    assertThat(extensionsCallback.extensions().map().get("logicalCluster"), is("lkc-xxxxx"));
   }
 
   @Test

--- a/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
@@ -242,6 +242,40 @@ class AzureEntraLoginCallbackHandlerTest {
   }
 
   @Test
+  void shouldThrowExceptionWithBlankBootstrapServer() {
+    Map<String, Object> configs = Map.of("bootstrap.servers", List.of("  "));
+
+    assertThrows(IllegalArgumentException.class, () -> azureEntraLoginCallbackHandler.configure(
+        configs, null, null));
+  }
+
+  @Test
+  void shouldFallBackToBootstrapDerivedScopeWhenScopeIsWhitespace() throws UnsupportedCallbackException {
+    Map<String, Object> configs = Map.of("bootstrap.servers",
+        List.of("test-eh.servicebus.windows.net:9093"));
+
+    // JAAS entry with whitespace-only scope — should be treated as absent
+    AppConfigurationEntry jaasEntry = new AppConfigurationEntry(
+        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+        Map.of("scope", "   "));
+
+    when(tokenCredential.getToken(any(TokenRequestContext.class))).thenReturn(Mono.just(accessToken));
+    when(accessToken.getToken()).thenReturn(VALID_SAMPLE_TOKEN);
+
+    azureEntraLoginCallbackHandler.configure(configs, null, List.of(jaasEntry));
+    azureEntraLoginCallbackHandler.handle(new Callback[] {oauthBearerTokenCallBack});
+
+    final ArgumentCaptor<TokenRequestContext> contextCaptor =
+        ArgumentCaptor.forClass(TokenRequestContext.class);
+    verify(tokenCredential, times(1)).getToken(contextCaptor.capture());
+
+    assertThat(
+        contextCaptor.getValue().getScopes(),
+        is(List.of("https://test-eh.servicebus.windows.net/.default")));
+  }
+
+  @Test
   void shouldNotRequireBootstrapServersWhenCustomScopeProvided() throws UnsupportedCallbackException {
     // When a custom scope is set, bootstrap.servers validation should be skipped
     // since we don't need to derive the scope from the server URL

--- a/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
@@ -204,6 +204,20 @@ class AzureEntraLoginCallbackHandlerTest {
   }
 
   @Test
+  void shouldProvideErrorToCallbackWhenTokenAcquisitionReturnsEmpty() throws UnsupportedCallbackException {
+    Map<String, Object> configs = Map.of("bootstrap.servers", List.of("test-eh.servicebus.windows.net:9093"));
+
+    when(tokenCredential.getToken(any(TokenRequestContext.class))).thenReturn(Mono.empty());
+
+    azureEntraLoginCallbackHandler.configure(configs, null, null);
+    azureEntraLoginCallbackHandler.handle(new Callback[] {oauthBearerTokenCallBack});
+
+    verify(oauthBearerTokenCallBack, times(1))
+        .error("invalid_grant", "Token acquisition returned empty result.", null);
+    verify(oauthBearerTokenCallBack, times(0)).token(any());
+  }
+
+  @Test
   void shouldThrowExceptionWithNullBootstrapServers() {
     assertThrows(IllegalArgumentException.class, () -> azureEntraLoginCallbackHandler.configure(
         Map.of(), null, null));
@@ -212,6 +226,14 @@ class AzureEntraLoginCallbackHandlerTest {
   @Test
   void shouldThrowExceptionWithMultipleBootstrapServers() {
     Map<String, Object> configs = Map.of("bootstrap.servers", List.of("server1", "server2"));
+
+    assertThrows(IllegalArgumentException.class, () -> azureEntraLoginCallbackHandler.configure(
+        configs, null, null));
+  }
+
+  @Test
+  void shouldThrowExceptionWithEmptyBootstrapServersList() {
+    Map<String, Object> configs = Map.of("bootstrap.servers", List.of());
 
     assertThrows(IllegalArgumentException.class, () -> azureEntraLoginCallbackHandler.configure(
         configs, null, null));

--- a/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
@@ -17,10 +17,12 @@ import static org.mockito.Mockito.when;
 import com.azure.core.credential.AccessToken;
 import com.azure.core.credential.TokenCredential;
 import com.azure.core.credential.TokenRequestContext;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.security.auth.callback.Callback;
 import javax.security.auth.callback.UnsupportedCallbackException;
+import javax.security.auth.login.AppConfigurationEntry;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerToken;
 import org.apache.kafka.common.security.oauthbearer.OAuthBearerTokenCallback;
 import org.junit.jupiter.api.BeforeEach;
@@ -105,6 +107,84 @@ class AzureEntraLoginCallbackHandlerTest {
   }
 
   @Test
+  void shouldUseCustomScopeFromJaasConfig() throws UnsupportedCallbackException {
+    Map<String, Object> configs = Map.of("bootstrap.servers",
+        List.of("pkc-xxxxx.westeurope.azure.confluent.cloud:9092"));
+
+    String customScope = "api://f5b9dd55-0589-4b04-9e0c-37775596161e/.default";
+    AppConfigurationEntry jaasEntry = new AppConfigurationEntry(
+        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+        Map.of("scope", customScope));
+
+    when(tokenCredential.getToken(any(TokenRequestContext.class))).thenReturn(Mono.just(accessToken));
+    when(accessToken.getToken()).thenReturn(VALID_SAMPLE_TOKEN);
+
+    azureEntraLoginCallbackHandler.configure(configs, null, List.of(jaasEntry));
+    azureEntraLoginCallbackHandler.handle(new Callback[] {oauthBearerTokenCallBack});
+
+    final ArgumentCaptor<TokenRequestContext> contextCaptor =
+        ArgumentCaptor.forClass(TokenRequestContext.class);
+
+    verify(tokenCredential, times(1)).getToken(contextCaptor.capture());
+
+    final TokenRequestContext tokenRequestContext = contextCaptor.getValue();
+    assertThat(tokenRequestContext, is(notNullValue()));
+    assertThat(
+        tokenRequestContext.getScopes(),
+        is(List.of(customScope)));
+  }
+
+  @Test
+  void shouldFallBackToBootstrapDerivedScopeWhenJaasHasNoScope() throws UnsupportedCallbackException {
+    Map<String, Object> configs = Map.of("bootstrap.servers",
+        List.of("test-eh.servicebus.windows.net:9093"));
+
+    // JAAS entry without a scope option
+    AppConfigurationEntry jaasEntry = new AppConfigurationEntry(
+        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+        Map.of("extension_logicalCluster", "lkc-xxxxx"));
+
+    when(tokenCredential.getToken(any(TokenRequestContext.class))).thenReturn(Mono.just(accessToken));
+    when(accessToken.getToken()).thenReturn(VALID_SAMPLE_TOKEN);
+
+    azureEntraLoginCallbackHandler.configure(configs, null, List.of(jaasEntry));
+    azureEntraLoginCallbackHandler.handle(new Callback[] {oauthBearerTokenCallBack});
+
+    final ArgumentCaptor<TokenRequestContext> contextCaptor =
+        ArgumentCaptor.forClass(TokenRequestContext.class);
+
+    verify(tokenCredential, times(1)).getToken(contextCaptor.capture());
+
+    final TokenRequestContext tokenRequestContext = contextCaptor.getValue();
+    assertThat(
+        tokenRequestContext.getScopes(),
+        is(List.of("https://test-eh.servicebus.windows.net/.default")));
+  }
+
+  @Test
+  void shouldFallBackToBootstrapDerivedScopeWithEmptyJaasList() throws UnsupportedCallbackException {
+    Map<String, Object> configs = Map.of("bootstrap.servers",
+        List.of("test-eh.servicebus.windows.net:9093"));
+
+    when(tokenCredential.getToken(any(TokenRequestContext.class))).thenReturn(Mono.just(accessToken));
+    when(accessToken.getToken()).thenReturn(VALID_SAMPLE_TOKEN);
+
+    azureEntraLoginCallbackHandler.configure(configs, null, Collections.emptyList());
+    azureEntraLoginCallbackHandler.handle(new Callback[] {oauthBearerTokenCallBack});
+
+    final ArgumentCaptor<TokenRequestContext> contextCaptor =
+        ArgumentCaptor.forClass(TokenRequestContext.class);
+
+    verify(tokenCredential, times(1)).getToken(contextCaptor.capture());
+
+    assertThat(
+        contextCaptor.getValue().getScopes(),
+        is(List.of("https://test-eh.servicebus.windows.net/.default")));
+  }
+
+  @Test
   void shouldProvideErrorToCallbackWithTokenError() throws UnsupportedCallbackException {
     Map<String, Object> configs = Map.of("bootstrap.servers", List.of("test-eh.servicebus.windows.net:9093"));
 
@@ -135,6 +215,34 @@ class AzureEntraLoginCallbackHandlerTest {
 
     assertThrows(IllegalArgumentException.class, () -> azureEntraLoginCallbackHandler.configure(
         configs, null, null));
+  }
+
+  @Test
+  void shouldNotRequireBootstrapServersWhenCustomScopeProvided() throws UnsupportedCallbackException {
+    // When a custom scope is set, bootstrap.servers validation should be skipped
+    // since we don't need to derive the scope from the server URL
+    Map<String, Object> configs = Map.of("bootstrap.servers",
+        List.of("pkc-xxxxx.westeurope.azure.confluent.cloud:9092"));
+
+    String customScope = "api://some-app-id/.default";
+    AppConfigurationEntry jaasEntry = new AppConfigurationEntry(
+        "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule",
+        AppConfigurationEntry.LoginModuleControlFlag.REQUIRED,
+        Map.of("scope", customScope));
+
+    when(tokenCredential.getToken(any(TokenRequestContext.class))).thenReturn(Mono.just(accessToken));
+    when(accessToken.getToken()).thenReturn(VALID_SAMPLE_TOKEN);
+
+    azureEntraLoginCallbackHandler.configure(configs, null, List.of(jaasEntry));
+    azureEntraLoginCallbackHandler.handle(new Callback[] {oauthBearerTokenCallBack});
+
+    final ArgumentCaptor<TokenRequestContext> contextCaptor =
+        ArgumentCaptor.forClass(TokenRequestContext.class);
+    verify(tokenCredential, times(1)).getToken(contextCaptor.capture());
+
+    assertThat(
+        contextCaptor.getValue().getScopes(),
+        is(List.of(customScope)));
   }
 
   @Test

--- a/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraLoginCallbackHandlerTest.java
@@ -221,8 +221,7 @@ class AzureEntraLoginCallbackHandlerTest {
   void shouldNotRequireBootstrapServersWhenCustomScopeProvided() throws UnsupportedCallbackException {
     // When a custom scope is set, bootstrap.servers validation should be skipped
     // since we don't need to derive the scope from the server URL
-    Map<String, Object> configs = Map.of("bootstrap.servers",
-        List.of("pkc-xxxxx.westeurope.azure.confluent.cloud:9092"));
+    Map<String, Object> configs = Map.of();
 
     String customScope = "api://some-app-id/.default";
     AppConfigurationEntry jaasEntry = new AppConfigurationEntry(

--- a/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraOAuthBearerTokenTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraOAuthBearerTokenTest.java
@@ -37,10 +37,7 @@ class AzureEntraOAuthBearerTokenTest {
           + "-FB_lzC3D4mkJMxKWopQGXnQtizaZjyclGpiUFs3mEauxC7RpsbanitxPFs7FK3mY0MQJk9JNVi1oM-8qfEp8nYT2DwFBhLcIp2z"
           + "Q";
 
-  // Client credentials (app-only) token — no scp or upn claims, has appid and sub
-  // Payload: {"aud":"https://sample.servicebus.windows.net","iss":"https://sts.windows.net/sample/",
-  //   "iat":1698415912,"nbf":1698415913,"exp":1698415914,"appid":"sample-app-id",
-  //   "sub":"Sample Subject","tid":"sample-tid"}
+  // Client credentials (app-only) token — has appid and sub claims, but no scp or upn
   private static final String CLIENT_CREDENTIALS_TOKEN =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
           + ".eyJhdWQiOiJodHRwczovL3NhbXBsZS5zZXJ2aWNlYnVzLndpbmRvd3MubmV0IiwiaXNzIjoiaHR0cHM6Ly9z"
@@ -49,15 +46,21 @@ class AzureEntraOAuthBearerTokenTest {
           + "Ijoic2FtcGxlLXRpZCJ9"
           + ".QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY3ODk";
 
-  // Minimal token — only has required JWT claims (iat, nbf, exp, sub), no scp/upn/appid
-  // Payload: {"aud":"https://sample.servicebus.windows.net","iss":"https://sts.windows.net/sample/",
-  //   "iat":1698415912,"nbf":1698415913,"exp":1698415914,"sub":"Sample Subject"}
+  // Minimal token — only has standard iat/nbf/exp/sub claims, no scp/upn/appid
   private static final String MINIMAL_TOKEN =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
           + ".eyJhdWQiOiJodHRwczovL3NhbXBsZS5zZXJ2aWNlYnVzLndpbmRvd3MubmV0IiwiaXNzIjoiaHR0cHM6Ly9z"
           + "dHMud2luZG93cy5uZXQvc2FtcGxlLyIsImlhdCI6MTY5ODQxNTkxMiwibmJmIjoxNjk4NDE1OTEzLCJleHAi"
           + "OjE2OTg0MTU5MTQsInN1YiI6IlNhbXBsZSBTdWJqZWN0In0"
           + ".QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY3ODk";
+
+  // Token with no principal claims at all — no upn, appid, or sub
+  private static final String NO_PRINCIPAL_TOKEN =
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+          + ".eyJhdWQiOiJodHRwczovL3NhbXBsZS5zZXJ2aWNlYnVzLndpbmRvd3MubmV0IiwiaXNzIjoiaHR0cHM6Ly9z"
+          + "dHMud2luZG93cy5uZXQvc2FtcGxlLyIsImlhdCI6MTY5ODQxNTkxMiwibmJmIjoxNjk4NDE1OTEzLCJleHAi"
+          + "OjE2OTg0MTU5MTR9"
+          + ".QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY3ODkw";
 
   @Test
   void constructorShouldParseToken() {
@@ -102,6 +105,16 @@ class AzureEntraOAuthBearerTokenTest {
 
     // No upn or appid — should fall back to sub
     assertThat(token.principalName(), is("Sample Subject"));
+  }
+
+  @Test
+  void shouldThrowWhenNoPrincipalClaimsExist() {
+    final AccessToken accessToken = new AccessToken(NO_PRINCIPAL_TOKEN, OffsetDateTime.MIN);
+
+    final AzureEntraOAuthBearerToken token = new AzureEntraOAuthBearerToken(accessToken);
+
+    // No upn, appid, or sub — should throw SaslAuthenticationException
+    assertThrows(SaslAuthenticationException.class, token::principalName);
   }
 
   @Test

--- a/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraOAuthBearerTokenTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/azure/AzureEntraOAuthBearerTokenTest.java
@@ -16,6 +16,8 @@ class AzureEntraOAuthBearerTokenTest {
 
   // These are not real tokens. It was generated using fake values with an invalid signature,
   // so it is safe to store here.
+
+  // Delegated (user) token — has scp and upn claims
   private static final String VALID_SAMPLE_TOKEN =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjlHbW55RlBraGMzaE91UjIybXZTdmduTG83WSIsImtpZCI6IjlHbW55"
           + "RlBraGMzaE91UjIybXZTdmduTG83WSJ9.eyJhdWQiOiJodHRwczovL3NhbXBsZS5zZXJ2aWNlYnVzLndpbmRvd3MubmV0IiwiaX"
@@ -35,6 +37,28 @@ class AzureEntraOAuthBearerTokenTest {
           + "-FB_lzC3D4mkJMxKWopQGXnQtizaZjyclGpiUFs3mEauxC7RpsbanitxPFs7FK3mY0MQJk9JNVi1oM-8qfEp8nYT2DwFBhLcIp2z"
           + "Q";
 
+  // Client credentials (app-only) token — no scp or upn claims, has appid and sub
+  // Payload: {"aud":"https://sample.servicebus.windows.net","iss":"https://sts.windows.net/sample/",
+  //   "iat":1698415912,"nbf":1698415913,"exp":1698415914,"appid":"sample-app-id",
+  //   "sub":"Sample Subject","tid":"sample-tid"}
+  private static final String CLIENT_CREDENTIALS_TOKEN =
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+          + ".eyJhdWQiOiJodHRwczovL3NhbXBsZS5zZXJ2aWNlYnVzLndpbmRvd3MubmV0IiwiaXNzIjoiaHR0cHM6Ly9z"
+          + "dHMud2luZG93cy5uZXQvc2FtcGxlLyIsImlhdCI6MTY5ODQxNTkxMiwibmJmIjoxNjk4NDE1OTEzLCJleHAi"
+          + "OjE2OTg0MTU5MTQsImFwcGlkIjoic2FtcGxlLWFwcC1pZCIsInN1YiI6IlNhbXBsZSBTdWJqZWN0IiwidGlk"
+          + "Ijoic2FtcGxlLXRpZCJ9"
+          + ".QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY3ODk";
+
+  // Minimal token — only has required JWT claims (iat, nbf, exp, sub), no scp/upn/appid
+  // Payload: {"aud":"https://sample.servicebus.windows.net","iss":"https://sts.windows.net/sample/",
+  //   "iat":1698415912,"nbf":1698415913,"exp":1698415914,"sub":"Sample Subject"}
+  private static final String MINIMAL_TOKEN =
+      "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9"
+          + ".eyJhdWQiOiJodHRwczovL3NhbXBsZS5zZXJ2aWNlYnVzLndpbmRvd3MubmV0IiwiaXNzIjoiaHR0cHM6Ly9z"
+          + "dHMud2luZG93cy5uZXQvc2FtcGxlLyIsImlhdCI6MTY5ODQxNTkxMiwibmJmIjoxNjk4NDE1OTEzLCJleHAi"
+          + "OjE2OTg0MTU5MTQsInN1YiI6IlNhbXBsZSBTdWJqZWN0In0"
+          + ".QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY3ODk";
+
   @Test
   void constructorShouldParseToken() {
     final AccessToken accessToken = new AccessToken(VALID_SAMPLE_TOKEN, OffsetDateTime.MIN);
@@ -48,6 +72,36 @@ class AzureEntraOAuthBearerTokenTest {
     assertThat(azureOAuthBearerToken.scope(), is(Set.of("event_hub", "storage_account")));
     assertThat(azureOAuthBearerToken.principalName(), is("sample@microsoft.com"));
     assertTrue(azureOAuthBearerToken.isExpired());
+  }
+
+  @Test
+  void shouldReturnEmptyScopeForClientCredentialsToken() {
+    final AccessToken accessToken = new AccessToken(CLIENT_CREDENTIALS_TOKEN, OffsetDateTime.MIN);
+
+    final AzureEntraOAuthBearerToken token = new AzureEntraOAuthBearerToken(accessToken);
+
+    // Client credentials tokens have no scp claim — should return empty set, not NPE
+    assertThat(token.scope(), is(Set.of()));
+  }
+
+  @Test
+  void shouldFallBackToAppIdForPrincipalName() {
+    final AccessToken accessToken = new AccessToken(CLIENT_CREDENTIALS_TOKEN, OffsetDateTime.MIN);
+
+    final AzureEntraOAuthBearerToken token = new AzureEntraOAuthBearerToken(accessToken);
+
+    // Client credentials tokens have no upn — should fall back to appid
+    assertThat(token.principalName(), is("sample-app-id"));
+  }
+
+  @Test
+  void shouldFallBackToSubForPrincipalName() {
+    final AccessToken accessToken = new AccessToken(MINIMAL_TOKEN, OffsetDateTime.MIN);
+
+    final AzureEntraOAuthBearerToken token = new AzureEntraOAuthBearerToken(accessToken);
+
+    // No upn or appid — should fall back to sub
+    assertThat(token.principalName(), is("Sample Subject"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

This PR makes two improvements to the Azure Entra OAUTHBEARER integration:

### 1. Custom OAuth scope via JAAS config option

The existing `AzureEntraLoginCallbackHandler` derives the token scope from the bootstrap server URL (e.g. `https://<host>/.default`). This works for Azure Event Hubs, but **not for Confluent Cloud** (or other providers), where the required scope is an application registration URI like `api://<client-id>/.default`.

This change adds support for a `scope` option in the JAAS config:

```yaml
sasl.jaas.config: >-
  org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required
  scope="api://f5b9dd55-0589-4b04-9e0c-37775596161e/.default"
  extension_logicalCluster="lkc-xxxxx"
  extension_identityPoolId="pool-xxxxx";
```

When the `scope` option is present, it is used directly. When absent, the handler falls back to deriving the scope from the bootstrap URL — so this is **fully backward compatible**.

### 2. NPE fix for client_credentials (app-only) tokens

`AzureEntraOAuthBearerToken` assumes Azure AD delegated (user) token structure:
- `scope()` calls `claims.getClaim("scp").split(" ")` — but client_credentials tokens use the `roles` claim instead of `scp`, causing a **NullPointerException**
- `principalName()` returns `claims.getClaim("upn")` — but client_credentials tokens have no `upn` claim, returning `null`

Fixed behavior:
- `scope()`: checks if `scp` claim exists and is non-empty; returns `Set.of()` if absent
- `principalName()`: falls back through `upn` → `appid` → `sub`, throwing `SaslAuthenticationException` if none are found

### Motivation

The current `AzureEntraLoginCallbackHandler` hardcodes scope derivation from the bootstrap server URL, which only works for Azure Event Hubs. Any Kafka provider that requires a different OAuth scope (e.g. Confluent Cloud, or custom deployments with dedicated app registrations) cannot use this handler without modification.

Similarly, `AzureEntraOAuthBearerToken` only handles delegated (user) tokens. When used with `client_credentials` flow (common in service-to-service scenarios and Workload Identity), it throws NPE on missing `scp` and returns `null` for `principalName()`.

These changes make the Azure Entra integration work with any OAuth-compatible Kafka provider and any Azure AD token type.

### Related

- #1575 — Schema Registry OAuth support (related scope problem)
- #1645 — SR OAUTHBEARER PR (would benefit from the same scope flexibility)

## Changes

| File | Change |
|---|---|
| `AzureEntraLoginCallbackHandler.java` | Added `JAAS_OPTION_SCOPE` constant, `getJaasOption()` method with trim/blank handling, custom scope logic in `buildTokenRequestContext()`, renamed `buildEventHubsServerUri` → `buildBootstrapServerUri` |
| `AzureEntraOAuthBearerToken.java` | `scope()` handles missing `scp` claim gracefully; `principalName()` falls back through `upn` → `appid` → `sub` with `SaslAuthenticationException` if none found |
| `AzureEntraLoginCallbackHandlerTest.java` | 4 new tests: custom scope from JAAS, fallback without scope, fallback with empty JAAS list, custom scope without needing bootstrap URL validation |
| `AzureEntraOAuthBearerTokenTest.java` | 4 new tests with 3 new fake JWT constants: empty scope for client_credentials, appid fallback, sub fallback, exception on missing principal claims |

## Testing

- 8 new unit tests covering all new code paths
- All existing tests remain unchanged and should continue to pass
- Backward compatible: no existing JAAS config needs modification

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support providing a custom OAuth scope/audience via JAAS and transmitting SASL extensions during handshake.

* **Bug Fixes**
  * Safer scope parsing and principal-name fallbacks (upn → appid → sub) before failing.
  * Stricter bootstrap-server validation (exactly one non-blank entry) with clearer errors.
  * Explicit handling of empty token results (reports auth error instead of returning null).
  * Treat feature/quorum info as unavailable on certain auth/version errors instead of failing.

* **Tests**
  * Added coverage for scope selection, bootstrap defaults, SASL extensions, principal fallbacks, empty-token error path, and feature/quorum error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->