### PR TITLE
FE: Fix analysis view rendering for empty topics

### DIFF
--- a/frontend/src/components/Topics/Topic/Statistics/Indicators/Total.tsx
+++ b/frontend/src/components/Topics/Topic/Statistics/Indicators/Total.tsx
@@ -16,29 +16,39 @@ const Total: React.FC<TopicAnalysisStats> = ({
   approxUniqValues,
 }) => {
   const { currentTimezone } = useTimezone();
+  const offsets =
+    minOffset === undefined || maxOffset === undefined
+      ? 'N/A'
+      : `${minOffset} - ${maxOffset}`;
+  const timestamps =
+    minTimestamp === undefined || maxTimestamp === undefined
+      ? 'N/A'
+      : `${formatTimestamp({ timestamp: minTimestamp, timezone: currentTimezone.value })} - ${formatTimestamp({ timestamp: maxTimestamp, timezone: currentTimezone.value })}`;
 
   return (
     <Metrics.Section title="Messages">
-      <Metrics.Indicator label="Total number">{totalMsgs}</Metrics.Indicator>
-      <Metrics.Indicator label="Offsets min-max">
-        {`${minOffset} - ${maxOffset}`}
+      <Metrics.Indicator label="Total number">
+        {totalMsgs ?? 0}
       </Metrics.Indicator>
+      <Metrics.Indicator label="Offsets min-max">{offsets}</Metrics.Indicator>
       <Metrics.Indicator label="Timestamp min-max">
-        {`${formatTimestamp({ timestamp: minTimestamp, timezone: currentTimezone.value })} - ${formatTimestamp({ timestamp: maxTimestamp, timezone: currentTimezone.value })}`}
+        {timestamps}
       </Metrics.Indicator>
-      <Metrics.Indicator label="Null keys">{nullKeys}</Metrics.Indicator>
+      <Metrics.Indicator label="Null keys">{nullKeys ?? 0}</Metrics.Indicator>
       <Metrics.Indicator
         label="Unique keys"
         title="Approximate number of unique keys"
       >
-        {approxUniqKeys}
+        {approxUniqKeys ?? 0}
       </Metrics.Indicator>
-      <Metrics.Indicator label="Null values">{nullValues}</Metrics.Indicator>
+      <Metrics.Indicator label="Null values">
+        {nullValues ?? 0}
+      </Metrics.Indicator>
       <Metrics.Indicator
         label="Unique values"
         title="Approximate number of unique values"
       >
-        {approxUniqValues}
+        {approxUniqValues ?? 0}
       </Metrics.Indicator>
     </Metrics.Section>
   );

--- a/frontend/src/components/Topics/Topic/Statistics/Metrics.tsx
+++ b/frontend/src/components/Topics/Topic/Statistics/Metrics.tsx
@@ -100,8 +100,10 @@ const Metrics: React.FC = () => {
     return null;
   }
 
-  const totalStats = data.result.totalStats || {};
+  const { totalStats } = data.result;
   const partitionStats = data.result.partitionStats || [];
+  const isEmptyTopic =
+    totalStats?.totalMsgs == null && partitionStats.length === 0;
 
   return (
     <>
@@ -128,16 +130,26 @@ const Metrics: React.FC = () => {
           Restart Analysis
         </ActionButton>
       </S.ActionsBar>
-      <Informers.Wrapper>
-        <Total {...totalStats} />
-        {totalStats.keySize && (
-          <SizeStats stats={totalStats.keySize} title="Key size" />
-        )}
-        {totalStats.valueSize && (
-          <SizeStats stats={totalStats.valueSize} title="Value size" />
-        )}
-      </Informers.Wrapper>
-      <PartitionTable data={partitionStats} />
+      {isEmptyTopic ? (
+        <Informers.Wrapper>
+          <Informers.LightText>
+            No data available. The topic appears to be empty.
+          </Informers.LightText>
+        </Informers.Wrapper>
+      ) : (
+        <>
+          <Informers.Wrapper>
+            <Total {...(totalStats || {})} />
+            {totalStats?.keySize && (
+              <SizeStats stats={totalStats.keySize} title="Key size" />
+            )}
+            {totalStats?.valueSize && (
+              <SizeStats stats={totalStats.valueSize} title="Value size" />
+            )}
+          </Informers.Wrapper>
+          <PartitionTable data={partitionStats} />
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Summary

Fixes the analysis view showing "undefined" text and empty values when viewing statistics for an empty topic. The `Total` component now falls back to sensible defaults, and `Metrics` shows an empty state message instead of broken metrics.

## Why this matters

When `totalStats` fields are undefined (empty topic, zero messages), template literals like `${minOffset} - ${maxOffset}` render as literal "undefined - undefined" text. The `formatTimestamp` calls with undefined timestamps produce garbage output. This makes the analysis view unusable for empty topics.

## Changes

**`Total.tsx`**: Added nullish coalescing (`?? 0`) for numeric fields and explicit undefined checks for the offset/timestamp range displays. Shows "N/A" instead of "undefined - undefined" when values aren't available.

**`Metrics.tsx`**: Added `isEmptyTopic` check. When `totalStats.totalMsgs` is null/undefined and partition data is empty, renders a clean "No data available" message using the existing `Informers.LightText` component instead of spreading an empty object into `Total`.

## Testing

- ESLint passes with no errors on both modified files
- Verified `Informers.LightText` component exists in `components/common/Metrics`

Fixes #1053

This contribution was developed with AI assistance (Codex).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or incomplete data in statistics displays
  * Topic statistics now display "No data available" message when appropriate
  * Undefined numeric values now default to 0; missing offset/timestamp ranges show 'N/A'

<!-- end of auto-generated comment: release notes by coderabbit.ai -->