### PR TITLE
Infra: Implement codecov test coverage reporting

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,19 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 80%
+
+flags:
+  backend:
+    paths:
+      - api/
+    carryforward: true
+  frontend:
+    paths:
+      - frontend/src/
+    carryforward: true

--- a/.github/workflows/backend_main.yml
+++ b/.github/workflows/backend_main.yml
@@ -27,3 +27,5 @@ jobs:
     uses: ./.github/workflows/backend_tests.yml
     with:
       event_name: ${{ github.event_name }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend_pr.yml
+++ b/.github/workflows/backend_pr.yml
@@ -38,3 +38,5 @@ jobs:
     uses: ./.github/workflows/backend_tests.yml
     with:
       event_name: ${{ github.event_name }}
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -7,6 +7,9 @@ on:
         description: 'Original github.event_name'
         required: true
         type: string
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -31,3 +34,11 @@ jobs:
       - name: "Tests"
         run: |
           ./gradlew :api:test
+
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # https://github.com/codecov/codecov-action/releases/tag/v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: api/build/reports/jacoco/test/jacocoTestReport.xml
+          flags: backend
+          fail_ci_if_error: false

--- a/.github/workflows/frontend_main.yml
+++ b/.github/workflows/frontend_main.yml
@@ -17,3 +17,5 @@ concurrency:
 jobs:
   build-and-test:
     uses: ./.github/workflows/frontend_tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/frontend_pr.yml
+++ b/.github/workflows/frontend_pr.yml
@@ -31,3 +31,5 @@ jobs:
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     uses: ./.github/workflows/frontend_tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -2,6 +2,9 @@ name: "Frontend: build and test"
 
 on:
   workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
 
 permissions:
   contents: read
@@ -54,4 +57,10 @@ jobs:
           cd frontend/
           pnpm test:CI
 
-      # TODO check frontend sonar results in sonarcloud after migration to gradle
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # https://github.com/codecov/codecov-action/releases/tag/v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: frontend/coverage/lcov.info
+          flags: frontend
+          fail_ci_if_error: false

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -47,11 +47,6 @@ jobs:
           cd frontend/
           pnpm lint:CI
 
-      - name: Audit dependencies
-        run: |
-          cd frontend/
-          pnpm audit --prod --audit-level=high
-
       - name: Tests
         run: |
           cd frontend/
@@ -64,3 +59,8 @@ jobs:
           files: frontend/coverage/lcov.info
           flags: frontend
           fail_ci_if_error: false
+
+      - name: Audit dependencies
+        run: |
+          cd frontend/
+          pnpm audit --prod --audit-level=high

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'antlr'
     id 'checkstyle'
+    id 'jacoco'
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.git.properties)
     alias(libs.plugins.docker.remote.api)
@@ -188,6 +189,13 @@ checkstyle {
 
 test {
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    reports {
+        xml.required = true
+    }
 }
 
 springBoot {


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Infra: Implement codecov test coverage reporting

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enabled automated code coverage reporting for backend and frontend
  * Coverage is uploaded to Codecov during CI; upload failures are non-blocking
  * Coverage uploads are tagged per component (backend/frontend) for clearer reports

* **Chores**
  * Added project-level coverage configuration with targets to enforce coverage expectations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->