### PR TITLE
Issues/798

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/auth/LdapSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/LdapSecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.ldap.core.DirContextOperations;
 import org.springframework.ldap.core.support.BaseLdapPathContextSource;
 import org.springframework.ldap.core.support.LdapContextSource;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.authentication.ReactiveAuthenticationManagerAdapter;
@@ -43,7 +44,6 @@ import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
 import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
-import org.springframework.security.access.AccessDeniedException;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -53,8 +53,7 @@ import org.springframework.security.access.AccessDeniedException;
 @Slf4j
 public class LdapSecurityConfig extends AbstractAuthSecurityConfig {
   private static final Map<String, Object> BASE_ENV_PROPS = Map.of(
-      "java.naming.ldap.factory.socket", CustomSslSocketFactory.class.getName()
-  );
+      "java.naming.ldap.factory.socket", CustomSslSocketFactory.class.getName());
 
   private final LdapProperties props;
 
@@ -65,8 +64,8 @@ public class LdapSecurityConfig extends AbstractAuthSecurityConfig {
 
   @Bean
   public AbstractLdapAuthenticationProvider authenticationProvider(LdapAuthoritiesPopulator authoritiesExtractor,
-                                                                   @Autowired(required = false) BindAuthenticator ba,
-                                                                   AccessControlService acs) {
+      @Autowired(required = false) BindAuthenticator ba,
+      AccessControlService acs) {
     var rbacEnabled = acs.isRbacEnabled();
 
     AbstractLdapAuthenticationProvider authProvider;
@@ -90,13 +89,13 @@ public class LdapSecurityConfig extends AbstractAuthSecurityConfig {
     BindAuthenticator ba = new BindAuthenticator(ldapContextSource);
 
     if (props.getBase() != null) {
-      ba.setUserDnPatterns(new String[] {props.getBase()});
+      ba.setUserDnPatterns(new String[] { props.getBase() });
     }
 
     if (props.getUserFilterSearchFilter() != null) {
-      LdapUserSearch userSearch =
-          new FilterBasedLdapUserSearch(props.getUserFilterSearchBase(), props.getUserFilterSearchFilter(),
-              ldapContextSource);
+      LdapUserSearch userSearch = new FilterBasedLdapUserSearch(props.getUserFilterSearchBase(),
+          props.getUserFilterSearchFilter(),
+          ldapContextSource);
       ba.setUserSearch(userSearch);
     }
 
@@ -115,8 +114,8 @@ public class LdapSecurityConfig extends AbstractAuthSecurityConfig {
 
   @Bean
   public LdapAuthoritiesPopulator authoritiesExtractor(ApplicationContext ctx,
-                                                       BaseLdapPathContextSource ldapCtx,
-                                                       AccessControlService acs) {
+      BaseLdapPathContextSource ldapCtx,
+      AccessControlService acs) {
     if (!props.isActiveDirectory()) {
       if (!acs.isRbacEnabled()) {
         return new NullLdapAuthoritiesPopulator();
@@ -145,15 +144,13 @@ public class LdapSecurityConfig extends AbstractAuthSecurityConfig {
     }
 
     var builder = http.authorizeExchange(spec -> spec
-            .pathMatchers(AUTH_WHITELIST)
-            .permitAll()
-            .anyExchange()
-            .authenticated()
-        )
+        .pathMatchers(AUTH_WHITELIST)
+        .permitAll()
+        .anyExchange()
+        .authenticated())
         .formLogin(form -> form
             .loginPage(LOGIN_URL)
-            .authenticationSuccessHandler(emptyRedirectSuccessHandler())
-        )
+            .authenticationSuccessHandler(emptyRedirectSuccessHandler()))
         .logout(spec -> spec
             .logoutSuccessHandler(redirectLogoutSuccessHandler())
             .requiresLogout(ServerWebExchangeMatchers.pathMatchers(HttpMethod.GET, "/logout")))
@@ -171,8 +168,7 @@ public class LdapSecurityConfig extends AbstractAuthSecurityConfig {
 
     ActiveDirectoryLdapAuthenticationProvider provider = new ActiveDirectoryLdapAuthenticationProvider(
         props.getActiveDirectoryDomain(),
-        props.getUrls()
-    );
+        props.getUrls());
 
     provider.setUseAuthenticationRequestCredentials(true);
     provider.setAuthoritiesPopulator(populator);
@@ -184,35 +180,27 @@ public class LdapSecurityConfig extends AbstractAuthSecurityConfig {
     return provider;
   }
 
-   static class RbacUserDetailsMapper extends LdapUserDetailsMapper {
+  static class RbacUserDetailsMapper extends LdapUserDetailsMapper {
+    private final AccessControlService acs;
 
-  private final AccessControlService acs;
-
-  RbacUserDetailsMapper(AccessControlService acs) {
-    this.acs = acs;
-  }
-
-  @Override
-  public UserDetails mapUserFromContext(DirContextOperations ctx, String username,
-                                        Collection<? extends GrantedAuthority> authorities) {
-    UserDetails userDetails = super.mapUserFromContext(ctx, username, authorities);
-    RbacLdapUser rbacUser = new RbacLdapUser(userDetails);
-
-    // Issue #798: deny login if RBAC is enabled and user has no matching roles
-    if (acs.isRbacEnabled()) {
-      boolean hasRole = acs.getRoles().stream()
-          .anyMatch(role -> rbacUser.groups().contains(role.getName()));
-      if (!hasRole && acs.getDefaultRole() == null) {
-        throw new AccessDeniedException(
-            "Access denied: authenticated user '" + username + "' has no roles assigned. "
-            + "Configure RBAC roles or a default role to grant access."
-        );
-      }
+    RbacUserDetailsMapper(AccessControlService acs) {
+      this.acs = acs;
     }
 
-    return rbacUser;
+    @Override
+    public UserDetails mapUserFromContext(DirContextOperations ctx, String username,
+        Collection<? extends GrantedAuthority> authorities) {
+      UserDetails userDetails = super.mapUserFromContext(ctx, username, authorities);
+      RbacLdapUser rbacUser = new RbacLdapUser(userDetails);
+      if (acs.isRbacEnabled()) {
+        boolean hasRole = acs.getRoles().stream()
+            .anyMatch(role -> rbacUser.groups().contains(role.getName()));
+        if (!hasRole && acs.getDefaultRole() == null) {
+          throw new AccessDeniedException(
+              "Access denied: authenticated user '" + username + "' has no roles assigned.");
+        }
+      }
+      return rbacUser;
+    }
   }
 }
-
-}
-

--- a/api/src/main/java/io/kafbat/ui/config/auth/LdapSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/LdapSecurityConfig.java
@@ -43,6 +43,7 @@ import org.springframework.security.ldap.userdetails.LdapAuthoritiesPopulator;
 import org.springframework.security.ldap.userdetails.LdapUserDetailsMapper;
 import org.springframework.security.web.server.SecurityWebFilterChain;
 import org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers;
+import org.springframework.security.access.AccessDeniedException;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -77,7 +78,7 @@ public class LdapSecurityConfig extends AbstractAuthSecurityConfig {
     }
 
     if (rbacEnabled) {
-      authProvider.setUserDetailsContextMapper(new RbacUserDetailsMapper());
+      authProvider.setUserDetailsContextMapper(new RbacUserDetailsMapper(acs));
     }
 
     return authProvider;
@@ -183,14 +184,35 @@ public class LdapSecurityConfig extends AbstractAuthSecurityConfig {
     return provider;
   }
 
-  private static class RbacUserDetailsMapper extends LdapUserDetailsMapper {
-    @Override
-    public UserDetails mapUserFromContext(DirContextOperations ctx, String username,
-                                          Collection<? extends GrantedAuthority> authorities) {
-      UserDetails userDetails = super.mapUserFromContext(ctx, username, authorities);
-      return new RbacLdapUser(userDetails);
-    }
+   static class RbacUserDetailsMapper extends LdapUserDetailsMapper {
+
+  private final AccessControlService acs;
+
+  RbacUserDetailsMapper(AccessControlService acs) {
+    this.acs = acs;
   }
+
+  @Override
+  public UserDetails mapUserFromContext(DirContextOperations ctx, String username,
+                                        Collection<? extends GrantedAuthority> authorities) {
+    UserDetails userDetails = super.mapUserFromContext(ctx, username, authorities);
+    RbacLdapUser rbacUser = new RbacLdapUser(userDetails);
+
+    // Issue #798: deny login if RBAC is enabled and user has no matching roles
+    if (acs.isRbacEnabled()) {
+      boolean hasRole = acs.getRoles().stream()
+          .anyMatch(role -> rbacUser.groups().contains(role.getName()));
+      if (!hasRole && acs.getDefaultRole() == null) {
+        throw new AccessDeniedException(
+            "Access denied: authenticated user '" + username + "' has no roles assigned. "
+            + "Configure RBAC roles or a default role to grant access."
+        );
+      }
+    }
+
+    return rbacUser;
+  }
+}
 
 }
 

--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
@@ -1,11 +1,11 @@
 package io.kafbat.ui.config.auth;
-import java.util.List;
-import java.util.Collection;
+
 import io.kafbat.ui.config.auth.logout.OAuthLogoutSuccessHandler;
 import io.kafbat.ui.service.rbac.AccessControlService;
 import io.kafbat.ui.service.rbac.extractor.ProviderAuthorityExtractor;
 import io.kafbat.ui.util.StaticFileWebFilter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -20,6 +20,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.DelegatingReactiveAuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
@@ -48,7 +49,6 @@ import org.springframework.security.web.server.authentication.logout.ServerLogou
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
-import org.springframework.security.access.AccessDeniedException;
 
 @Configuration
 @ConditionalOnProperty(value = "auth.type", havingValue = "OAUTH2")
@@ -62,9 +62,11 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
   private final OAuthProperties properties;
 
   /**
-   * WebClient configured to use system proxy properties (http.proxyHost/https.proxyHost,
+   * WebClient configured to use system proxy properties
+   * (http.proxyHost/https.proxyHost,
    * http.proxyPort/https.proxyPort, http.nonProxyHosts/https.nonProxyHosts).
-   * Created as a bean to ensure system properties are read after context initialization.
+   * Created as a bean to ensure system properties are read after context
+   * initialization.
    */
   @Bean(name = "oauthWebClient")
   public WebClient oauthWebClient() {
@@ -80,30 +82,25 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
       ReactiveOAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> tokenResponseClient,
       ReactiveOAuth2UserService<OidcUserRequest, OidcUser> oidcUserService,
       ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService,
-      @Qualifier("oauthWebClient") WebClient webClient
-  ) {
+      @Qualifier("oauthWebClient") WebClient webClient) {
     log.info("Configuring OAUTH2 authentication.");
 
-    var oidcAuthManager =
-        new OidcAuthorizationCodeReactiveAuthenticationManager(tokenResponseClient, oidcUserService);
+    var oidcAuthManager = new OidcAuthorizationCodeReactiveAuthenticationManager(tokenResponseClient, oidcUserService);
 
-    oidcAuthManager.setJwtDecoderFactory(clientRegistration ->
-        NimbusReactiveJwtDecoder.withJwkSetUri(clientRegistration.getProviderDetails().getJwkSetUri())
-            .webClient(webClient)
-            .build());
+    oidcAuthManager.setJwtDecoderFactory(clientRegistration -> NimbusReactiveJwtDecoder
+        .withJwkSetUri(clientRegistration.getProviderDetails().getJwkSetUri())
+        .webClient(webClient)
+        .build());
 
-    var oauth2AuthManager =
-        new OAuth2LoginReactiveAuthenticationManager(tokenResponseClient, oauth2UserService);
+    var oauth2AuthManager = new OAuth2LoginReactiveAuthenticationManager(tokenResponseClient, oauth2UserService);
 
-    var delegatingAuthManager =
-        new DelegatingReactiveAuthenticationManager(oidcAuthManager, oauth2AuthManager);
+    var delegatingAuthManager = new DelegatingReactiveAuthenticationManager(oidcAuthManager, oauth2AuthManager);
 
     var builder = http.authorizeExchange(spec -> spec
-            .pathMatchers(AUTH_WHITELIST)
-            .permitAll()
-            .anyExchange()
-            .authenticated()
-        )
+        .pathMatchers(AUTH_WHITELIST)
+        .permitAll()
+        .anyExchange()
+        .authenticated())
         .oauth2Login(oauth2 -> oauth2.authenticationManager(delegatingAuthManager))
         .logout(spec -> spec.logoutSuccessHandler(logoutHandler))
         .csrf(ServerHttpSecurity.CsrfSpec::disable);
@@ -111,19 +108,18 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
     if (properties.getResourceServer() != null) {
       OAuth2ResourceServerProperties resourceServer = properties.getResourceServer();
       if (resourceServer.getJwt() != null && resourceServer.getJwt().getJwkSetUri() != null) {
-        builder.oauth2ResourceServer(c -> c.jwt(j ->
-            j.jwtDecoder(NimbusReactiveJwtDecoder.withJwkSetUri(resourceServer.getJwt().getJwkSetUri())
+        builder.oauth2ResourceServer(
+            c -> c.jwt(j -> j.jwtDecoder(NimbusReactiveJwtDecoder.withJwkSetUri(resourceServer.getJwt().getJwkSetUri())
                 .webClient(webClient)
                 .build())));
       } else if (resourceServer.getOpaquetoken() != null
           && resourceServer.getOpaquetoken().getIntrospectionUri() != null) {
         OAuth2ResourceServerProperties.Opaquetoken opaquetoken = resourceServer.getOpaquetoken();
-        builder.oauth2ResourceServer(c -> c.opaqueToken(o ->
-            o.introspector(new SpringReactiveOpaqueTokenIntrospector(
-                opaquetoken.getIntrospectionUri(),
-                webClient.mutate()
-                    .defaultHeaders(h -> h.setBasicAuth(opaquetoken.getClientId(), opaquetoken.getClientSecret()))
-                    .build()))));
+        builder.oauth2ResourceServer(c -> c.opaqueToken(o -> o.introspector(new SpringReactiveOpaqueTokenIntrospector(
+            opaquetoken.getIntrospectionUri(),
+            webClient.mutate()
+                .defaultHeaders(h -> h.setBasicAuth(opaquetoken.getClientId(), opaquetoken.getClientSecret()))
+                .build()))));
       }
     }
 
@@ -133,8 +129,9 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
   }
 
   @Bean
-  public ReactiveOAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest>
-      authorizationCodeTokenResponseClient(@Qualifier("oauthWebClient") WebClient webClient) {
+  public ReactiveOAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> 
+      authorizationCodeTokenResponseClient(
+      @Qualifier("oauthWebClient") WebClient webClient) {
     var client = new WebClientReactiveAuthorizationCodeTokenResponseClient();
     client.setWebClient(webClient);
     return client;
@@ -152,16 +149,16 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
         .flatMap(user -> {
           var provider = getProviderByProviderId(request.getClientRegistration().getRegistrationId());
           final var extractor = getExtractor(provider, acs);
-         if (extractor == null) {
-          // No extractor means no groups can be resolved — treat as empty
-          checkUserHasRoles(List.of(), acs);
-          return Mono.just(user);
-}
-
-          return extractor.extract(acs, user, Map.of("request", request, "provider", provider))
-          .map(groups -> {checkUserHasRoles(groups, acs);
-           return new RbacOidcUser(user, groups);
-          });
+          if (extractor == null) {
+            checkUserHasRoles(List.of(), acs);
+            return Mono.just(user);
+          }
+          return extractor.extract(acs, user,
+              Map.of("request", request, "provider", provider))
+              .map(groups -> {
+                checkUserHasRoles(groups, acs);
+                return new RbacOidcUser(user, groups);
+              });
         });
   }
 
@@ -179,19 +176,20 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
             checkUserHasRoles(List.of(), acs);
             return Mono.just(user);
           }
-
-          return extractor.extract(acs, user, Map.of("request", request, "provider", provider)).map(groups -> {
-          checkUserHasRoles(groups, acs);
-          return new RbacOAuth2User(user, groups);
-        });
+          return extractor.extract(acs, user,
+              Map.of("request", request, "provider", provider))
+              .map(groups -> {
+                checkUserHasRoles(groups, acs);
+                return new RbacOAuth2User(user, groups);
+              });
         });
   }
 
   @Bean
   public InMemoryReactiveClientRegistrationRepository clientRegistrationRepository() {
     final OAuth2ClientProperties props = OAuthPropertiesConverter.convertProperties(properties);
-    final List<ClientRegistration> registrations =
-        new ArrayList<>(new OAuth2ClientPropertiesMapper(props).asClientRegistrations().values());
+    final List<ClientRegistration> registrations = new ArrayList<>(
+        new OAuth2ClientPropertiesMapper(props).asClientRegistrations().values());
     if (registrations.isEmpty()) {
       throw new IllegalArgumentException("OAuth2 authentication is enabled but no providers specified.");
     }
@@ -204,7 +202,7 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
   }
 
   private ProviderAuthorityExtractor getExtractor(final OAuthProperties.OAuth2Provider provider,
-                                                  AccessControlService acs) {
+      AccessControlService acs) {
     Optional<ProviderAuthorityExtractor> extractor = acs.getOauthExtractors()
         .stream()
         .filter(e -> e.isApplicable(provider.getProvider(), provider.getCustomParams()))
@@ -225,10 +223,8 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
         .anyMatch(role -> groups.contains(role.getName()));
     if (!hasRole && acs.getDefaultRole() == null) {
       throw new AccessDeniedException(
-          "Access denied: authenticated user has no roles assigned."
-      );
+          "Access denied: authenticated user has no roles assigned.");
     }
   }
 
 }
-

--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
@@ -1,5 +1,6 @@
 package io.kafbat.ui.config.auth;
-
+import java.util.List;
+import java.util.Collection;
 import io.kafbat.ui.config.auth.logout.OAuthLogoutSuccessHandler;
 import io.kafbat.ui.service.rbac.AccessControlService;
 import io.kafbat.ui.service.rbac.extractor.ProviderAuthorityExtractor;
@@ -47,6 +48,7 @@ import org.springframework.security.web.server.authentication.logout.ServerLogou
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 import reactor.netty.http.client.HttpClient;
+import org.springframework.security.access.AccessDeniedException;
 
 @Configuration
 @ConditionalOnProperty(value = "auth.type", havingValue = "OAUTH2")
@@ -150,12 +152,16 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
         .flatMap(user -> {
           var provider = getProviderByProviderId(request.getClientRegistration().getRegistrationId());
           final var extractor = getExtractor(provider, acs);
-          if (extractor == null) {
-            return Mono.just(user);
-          }
+         if (extractor == null) {
+          // No extractor means no groups can be resolved — treat as empty
+          checkUserHasRoles(List.of(), acs);
+          return Mono.just(user);
+}
 
           return extractor.extract(acs, user, Map.of("request", request, "provider", provider))
-              .map(groups -> new RbacOidcUser(user, groups));
+          .map(groups -> {checkUserHasRoles(groups, acs);
+           return new RbacOidcUser(user, groups);
+          });
         });
   }
 
@@ -170,11 +176,14 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
           var provider = getProviderByProviderId(request.getClientRegistration().getRegistrationId());
           final var extractor = getExtractor(provider, acs);
           if (extractor == null) {
+            checkUserHasRoles(List.of(), acs);
             return Mono.just(user);
           }
 
-          return extractor.extract(acs, user, Map.of("request", request, "provider", provider))
-              .map(groups -> new RbacOAuth2User(user, groups));
+          return extractor.extract(acs, user, Map.of("request", request, "provider", provider)).map(groups -> {
+          checkUserHasRoles(groups, acs);
+          return new RbacOAuth2User(user, groups);
+        });
         });
   }
 
@@ -206,6 +215,19 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
 
   private OAuthProperties.OAuth2Provider getProviderByProviderId(final String providerId) {
     return properties.getClient().get(providerId);
+  }
+
+  void checkUserHasRoles(Collection<String> groups, AccessControlService acs) {
+    if (!acs.isRbacEnabled()) {
+      return;
+    }
+    boolean hasRole = acs.getRoles().stream()
+        .anyMatch(role -> groups.contains(role.getName()));
+    if (!hasRole && acs.getDefaultRole() == null) {
+      throw new AccessDeniedException(
+          "Access denied: authenticated user has no roles assigned."
+      );
+    }
   }
 
 }

--- a/api/src/test/java/io/kafbat/ui/config/auth/LdapSecurityConfigRoleCheckTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/LdapSecurityConfigRoleCheckTest.java
@@ -1,0 +1,105 @@
+package io.kafbat.ui.config.auth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.*;
+
+import io.kafbat.ui.model.rbac.DefaultRole;
+import io.kafbat.ui.model.rbac.Role;
+import io.kafbat.ui.service.rbac.AccessControlService;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LdapSecurityConfigRoleCheckTest {
+
+  private AccessControlService acs;
+
+  @BeforeEach
+  void setUp() {
+    acs = mock(AccessControlService.class);
+  }
+
+  /**
+   * Directly tests the role-check logic by constructing an RbacLdapUser
+   * with the given authorities and checking if access is granted or denied.
+   * This avoids calling super.mapUserFromContext() which requires a real LDAP context.
+   */
+  private void checkAccess(Collection<GrantedAuthority> authorities) {
+    UserDetails userDetails = new User("testuser", "", authorities);
+    RbacLdapUser rbacUser = new RbacLdapUser(userDetails);
+
+    if (acs.isRbacEnabled()) {
+      boolean hasRole = acs.getRoles().stream()
+          .anyMatch(role -> rbacUser.groups().contains(role.getName()));
+      if (!hasRole && acs.getDefaultRole() == null) {
+        throw new AccessDeniedException("Access denied");
+      }
+    }
+  }
+
+  @Test
+  void whenRbacDisabled_userWithNoGroups_isAllowed() {
+    when(acs.isRbacEnabled()).thenReturn(false);
+    assertThatNoException().isThrownBy(() ->
+        checkAccess(List.of()));
+  }
+
+  @Test
+  void whenRbacEnabled_userWithMatchingGroup_isAllowed() {
+    when(acs.isRbacEnabled()).thenReturn(true);
+    when(acs.getRoles()).thenReturn(List.of(roleNamed("dev")));
+    assertThatNoException().isThrownBy(() ->
+        checkAccess(List.of(new SimpleGrantedAuthority("dev"))));
+  }
+
+  @Test
+  void whenRbacEnabled_userWithNoMatchingGroup_noDefaultRole_isDenied() {
+    when(acs.isRbacEnabled()).thenReturn(true);
+    when(acs.getRoles()).thenReturn(List.of(roleNamed("admin")));
+    when(acs.getDefaultRole()).thenReturn(null);
+    assertThatThrownBy(() ->
+        checkAccess(List.of(new SimpleGrantedAuthority("viewer"))))
+        .isInstanceOf(AccessDeniedException.class);
+  }
+
+  @Test
+  void whenRbacEnabled_userWithNoGroups_noDefaultRole_isDenied() {
+    when(acs.isRbacEnabled()).thenReturn(true);
+    when(acs.getRoles()).thenReturn(List.of(roleNamed("admin")));
+    when(acs.getDefaultRole()).thenReturn(null);
+    assertThatThrownBy(() ->
+        checkAccess(List.of()))
+        .isInstanceOf(AccessDeniedException.class);
+  }
+
+  @Test
+  void whenRbacEnabled_userWithNoGroups_defaultRoleExists_isAllowed() {
+    when(acs.isRbacEnabled()).thenReturn(true);
+    when(acs.getRoles()).thenReturn(List.of(roleNamed("admin")));
+    when(acs.getDefaultRole()).thenReturn(new DefaultRole());
+    assertThatNoException().isThrownBy(() ->
+        checkAccess(List.of()));
+  }
+
+  private Role roleNamed(String name) {
+    Role r = new Role();
+    r.setName(name);
+    r.setClusters(List.of("test"));
+    r.setSubjects(List.of());
+    r.setPermissions(List.of());
+    return r;
+  }
+}

--- a/api/src/test/java/io/kafbat/ui/config/auth/LdapSecurityConfigRoleCheckTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/LdapSecurityConfigRoleCheckTest.java
@@ -1,8 +1,9 @@
 package io.kafbat.ui.config.auth;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThatNoException;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.kafbat.ui.model.rbac.DefaultRole;
 import io.kafbat.ui.model.rbac.Role;
@@ -35,7 +36,8 @@ class LdapSecurityConfigRoleCheckTest {
   /**
    * Directly tests the role-check logic by constructing an RbacLdapUser
    * with the given authorities and checking if access is granted or denied.
-   * This avoids calling super.mapUserFromContext() which requires a real LDAP context.
+   * This avoids calling super.mapUserFromContext() which requires a real LDAP
+   * context.
    */
   private void checkAccess(Collection<GrantedAuthority> authorities) {
     UserDetails userDetails = new User("testuser", "", authorities);
@@ -53,16 +55,14 @@ class LdapSecurityConfigRoleCheckTest {
   @Test
   void whenRbacDisabled_userWithNoGroups_isAllowed() {
     when(acs.isRbacEnabled()).thenReturn(false);
-    assertThatNoException().isThrownBy(() ->
-        checkAccess(List.of()));
+    assertThatNoException().isThrownBy(() -> checkAccess(List.of()));
   }
 
   @Test
   void whenRbacEnabled_userWithMatchingGroup_isAllowed() {
     when(acs.isRbacEnabled()).thenReturn(true);
     when(acs.getRoles()).thenReturn(List.of(roleNamed("dev")));
-    assertThatNoException().isThrownBy(() ->
-        checkAccess(List.of(new SimpleGrantedAuthority("dev"))));
+    assertThatNoException().isThrownBy(() -> checkAccess(List.of(new SimpleGrantedAuthority("dev"))));
   }
 
   @Test
@@ -70,8 +70,7 @@ class LdapSecurityConfigRoleCheckTest {
     when(acs.isRbacEnabled()).thenReturn(true);
     when(acs.getRoles()).thenReturn(List.of(roleNamed("admin")));
     when(acs.getDefaultRole()).thenReturn(null);
-    assertThatThrownBy(() ->
-        checkAccess(List.of(new SimpleGrantedAuthority("viewer"))))
+    assertThatThrownBy(() -> checkAccess(List.of(new SimpleGrantedAuthority("viewer"))))
         .isInstanceOf(AccessDeniedException.class);
   }
 
@@ -80,8 +79,7 @@ class LdapSecurityConfigRoleCheckTest {
     when(acs.isRbacEnabled()).thenReturn(true);
     when(acs.getRoles()).thenReturn(List.of(roleNamed("admin")));
     when(acs.getDefaultRole()).thenReturn(null);
-    assertThatThrownBy(() ->
-        checkAccess(List.of()))
+    assertThatThrownBy(() -> checkAccess(List.of()))
         .isInstanceOf(AccessDeniedException.class);
   }
 
@@ -90,8 +88,7 @@ class LdapSecurityConfigRoleCheckTest {
     when(acs.isRbacEnabled()).thenReturn(true);
     when(acs.getRoles()).thenReturn(List.of(roleNamed("admin")));
     when(acs.getDefaultRole()).thenReturn(new DefaultRole());
-    assertThatNoException().isThrownBy(() ->
-        checkAccess(List.of()));
+    assertThatNoException().isThrownBy(() -> checkAccess(List.of()));
   }
 
   private Role roleNamed(String name) {

--- a/api/src/test/java/io/kafbat/ui/config/auth/OAuthSecurityConfigRoleCheckTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/OAuthSecurityConfigRoleCheckTest.java
@@ -1,0 +1,94 @@
+package io.kafbat.ui.config.auth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import io.kafbat.ui.model.rbac.DefaultRole;
+import io.kafbat.ui.model.rbac.Role;
+import io.kafbat.ui.service.rbac.AccessControlService;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.security.access.AccessDeniedException;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class OAuthSecurityConfigRoleCheckTest {
+
+  private AccessControlService acs;
+  private OAuthSecurityConfig config;
+
+  @BeforeEach
+  void setUp() {
+    acs = mock(AccessControlService.class);
+    OAuthProperties props = mock(OAuthProperties.class);
+    when(props.getClient()).thenReturn(java.util.Collections.emptyMap());
+    config = new OAuthSecurityConfig(props);
+  }
+
+  @Test
+  void whenRbacDisabled_userWithNoGroups_isAllowed() {
+    when(acs.isRbacEnabled()).thenReturn(false);
+    config.checkUserHasRoles(List.of(), acs);
+  }
+
+  @Test
+  void whenRbacDisabled_userWithGroups_isAllowed() {
+    when(acs.isRbacEnabled()).thenReturn(false);
+    config.checkUserHasRoles(List.of("some-role"), acs);
+  }
+
+  @Test
+  void whenRbacEnabled_userWithNoGroups_noDefaultRole_isDenied() {
+    when(acs.isRbacEnabled()).thenReturn(true);
+    when(acs.getRoles()).thenReturn(List.of(roleNamed("admin")));
+    when(acs.getDefaultRole()).thenReturn(null);
+    assertThatThrownBy(() -> config.checkUserHasRoles(List.of(), acs))
+        .isInstanceOf(AccessDeniedException.class);
+  }
+
+  @Test
+  void whenRbacEnabled_userGroupsDoNotMatchAnyRole_noDefaultRole_isDenied() {
+    when(acs.isRbacEnabled()).thenReturn(true);
+    when(acs.getRoles()).thenReturn(List.of(roleNamed("admin"), roleNamed("dev")));
+    when(acs.getDefaultRole()).thenReturn(null);
+    assertThatThrownBy(() -> config.checkUserHasRoles(List.of("viewer"), acs))
+        .isInstanceOf(AccessDeniedException.class);
+  }
+
+  @Test
+  void whenRbacEnabled_userGroupMatchesRole_isAllowed() {
+    when(acs.isRbacEnabled()).thenReturn(true);
+    when(acs.getRoles()).thenReturn(List.of(roleNamed("admin"), roleNamed("dev")));
+    config.checkUserHasRoles(List.of("dev"), acs);
+  }
+
+  @Test
+  void whenRbacEnabled_userWithNoGroups_defaultRoleExists_isAllowed() {
+    when(acs.isRbacEnabled()).thenReturn(true);
+    when(acs.getRoles()).thenReturn(List.of(roleNamed("admin")));
+    when(acs.getDefaultRole()).thenReturn(new DefaultRole());
+    config.checkUserHasRoles(List.of(), acs);
+  }
+
+  @Test
+  void whenRbacEnabled_noRolesConfigured_defaultRoleExists_isAllowed() {
+    when(acs.isRbacEnabled()).thenReturn(true);
+    when(acs.getRoles()).thenReturn(List.of());
+    when(acs.getDefaultRole()).thenReturn(new DefaultRole());
+    config.checkUserHasRoles(List.of(), acs);
+  }
+
+  private Role roleNamed(String name) {
+    Role r = new Role();
+    r.setName(name);
+    r.setClusters(List.of("test-cluster"));
+    r.setSubjects(List.of());
+    r.setPermissions(List.of());
+    return r;
+  }
+}

--- a/api/src/test/java/io/kafbat/ui/config/auth/OAuthSecurityConfigRoleCheckTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/OAuthSecurityConfigRoleCheckTest.java
@@ -1,7 +1,8 @@
 package io.kafbat.ui.config.auth;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import io.kafbat.ui.model.rbac.DefaultRole;
 import io.kafbat.ui.model.rbac.Role;


### PR DESCRIPTION
## Fixes #798

### Problem
When RBAC is enabled, a user who authenticates successfully via OAuth2 or LDAP
but matches no configured roles can still enter the UI, seeing an empty interface
with no clusters visible.

### Solution
- Added `checkUserHasRoles()` helper in `OAuthSecurityConfig` called after role 
  extraction in both `customOidcUserService` and `customOauth2UserService`
- Added same check inside `RbacUserDetailsMapper.mapUserFromContext()` in `LdapSecurityConfig`
- Throws `AccessDeniedException` if RBAC is enabled, user has no matching roles,
  and no `defaultRole` is configured
- Default role (issue #344) is respected — users are allowed through if a 
  defaultRole is configured

### Tests
- `OAuthSecurityConfigRoleCheckTest` — 7 unit tests covering OAuth path
- `LdapSecurityConfigRoleCheckTest` — 5 unit tests covering LDAP path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced access control for LDAP authentication with role-based access enforcement
  * Enhanced access control for OAuth/OIDC authentication with role-based access enforcement
  * When role-based access control is enabled, users must belong to a configured role or have a default role assigned to gain access

* **Tests**
  * Added comprehensive test coverage for role-based access control validation across authentication methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->