### PR TITLE
BE: Add OAuth2 client authentication method support (#1721)

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthProperties.java
@@ -40,6 +40,7 @@ public class OAuthProperties {
     private String provider;
     private String clientId;
     private String clientSecret;
+    private String clientAuthenticationMethod;
     private String clientName;
     private String redirectUri;
     private String authorizationGrantType;

--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthPropertiesConverter.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthPropertiesConverter.java
@@ -24,6 +24,7 @@ public final class OAuthPropertiesConverter {
       var registration = new Registration();
       registration.setClientId(provider.getClientId());
       registration.setClientSecret(provider.getClientSecret());
+      registration.setClientAuthenticationMethod(provider.getClientAuthenticationMethod());
       registration.setClientName(provider.getClientName());
       registration.setScope(Optional.ofNullable(provider.getScope()).orElse(Set.of()));
       registration.setRedirectUri(provider.getRedirectUri());
@@ -75,4 +76,3 @@ public final class OAuthPropertiesConverter {
     return GOOGLE.equalsIgnoreCase(provider.getCustomParams().get(TYPE));
   }
 }
-

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -56,6 +56,8 @@ auth:
         provider: cognito
         redirect-uri: http://localhost:8080/login/oauth2/code/cognito
         authorization-grant-type: authorization_code
+        # Set to none for public clients that rely on PKCE.
+        # client-authentication-method: none
         issuer-uri: https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_M7cIUn1nj
         jwk-set-uri: https://cognito-idp.eu-central-1.amazonaws.com/eu-central-1_M7cIUn1nj/.well-known/jwks.json
         user-name-attribute: cognito:username

--- a/api/src/test/java/io/kafbat/ui/config/auth/OAuthPropertiesConverterTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/OAuthPropertiesConverterTest.java
@@ -1,0 +1,32 @@
+package io.kafbat.ui.config.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class OAuthPropertiesConverterTest {
+
+  @Test
+  void shouldMapClientAuthenticationMethod() {
+    var provider = new OAuthProperties.OAuth2Provider();
+    provider.setProvider("dex");
+    provider.setClientId("client-id");
+    provider.setClientAuthenticationMethod("none");
+    provider.setAuthorizationGrantType("authorization_code");
+    provider.setScope(Set.of("openid"));
+    provider.setCustomParams(Collections.emptyMap());
+
+    var properties = new OAuthProperties();
+    properties.setClient(Map.of("dex", provider));
+
+    var result = OAuthPropertiesConverter.convertProperties(properties);
+
+    assertThat(result.getRegistration())
+        .containsKey("dex");
+    assertThat(result.getRegistration().get("dex").getClientAuthenticationMethod())
+        .isEqualTo("none");
+  }
+}

--- a/contract-typespec/api/config.tsp
+++ b/contract-typespec/api/config.tsp
@@ -73,6 +73,7 @@ model ApplicationConfig {
             provider: string;
             clientId: string;
             clientSecret?: string;
+            clientAuthenticationMethod?: string;
             clientName?: string;
             redirectUri?: string;
             authorizationGrantType?: string;


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] Breaking change? (if so, please describe the impact and migration path for existing application instances)
<!-- ignore-task-list-end -->

**What changes did you make? (Give an overview)**

This change adds support for configuring OAuth2 client-authentication-method in Kafbat UI.

The backend OAuth config model now accepts client-authentication-method and passes it through to Spring Security's OAuth2 client registration. This makes it possible to configure public OAuth2 clients, for example with client-authentication-method: none together with the authorization code flow.

The dynamic config contract was updated as well, and the generated OpenAPI snapshot was regenerated so the new field is exposed consistently across config paths.

**Is there anything you'd like reviewers to focus on?**

Please focus on whether exposing only client-authentication-method is the right surface area for public-client / PKCE-oriented setups, and whether the contract/OpenAPI update is sufficient for dynamic config consistency.

**How Has This Been Tested? (put an "x" (case-sensitive!) next to an item)**
<!-- ignore-task-list-start -->

- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->
**Checklist (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)**
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. ENVIRONMENT VARIABLES)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out Contributing (https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and Code of Conduct (https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

<img width="1394" height="926" alt="image" src="https://github.com/user-attachments/assets/b56e8edf-a63a-4c92-a6fe-8797e277b5a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `clientAuthenticationMethod` configuration option for OAuth2 providers to support additional authentication methods.

* **Documentation**
  * Added example configuration documentation for public client setup.

* **Tests**
  * Added unit test coverage for OAuth2 provider configuration conversion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->