### PR TITLE
BE: Drop non-finite metric data points instead of failing the broker metrics response

### DIFF
--- a/api/src/main/java/io/kafbat/ui/mapper/ClusterMapper.java
+++ b/api/src/main/java/io/kafbat/ui/mapper/ClusterMapper.java
@@ -71,12 +71,22 @@ public interface ClusterMapper {
     return metrics
         .flatMap(m ->
             m.getDataPoints().stream()
-                .map(p ->
-                        new MetricDTO()
-                            .name(m.getMetadata().getName())
-                            .labels(p.getLabels().stream().collect(toMap(Label::getName, Label::getValue)))
-                            .value(BigDecimal.valueOf(readPointValue(p)))
-                )
+                .flatMap(p -> {
+                  double value = readPointValue(p);
+                  // BigDecimal.valueOf(double) throws NumberFormatException on NaN/Infinity.
+                  // JMX/Prometheus exporters legitimately emit NaN for unused metrics
+                  // (e.g. average latency on a never-used listener). Drop those points
+                  // instead of failing the whole broker metrics response.
+                  if (!Double.isFinite(value)) {
+                    return Stream.empty();
+                  }
+                  return Stream.of(
+                      new MetricDTO()
+                          .name(m.getMetadata().getName())
+                          .labels(p.getLabels().stream().collect(toMap(Label::getName, Label::getValue)))
+                          .value(BigDecimal.valueOf(value))
+                  );
+                })
         );
   }
 

--- a/api/src/test/java/io/kafbat/ui/mapper/ClusterMapperTest.java
+++ b/api/src/test/java/io/kafbat/ui/mapper/ClusterMapperTest.java
@@ -1,0 +1,39 @@
+package io.kafbat.ui.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kafbat.ui.model.BrokerMetricsDTO;
+import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
+import io.prometheus.metrics.model.snapshots.Labels;
+import io.prometheus.metrics.model.snapshots.MetricMetadata;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ClusterMapperTest {
+
+  // Reproduces https://github.com/kafbat/kafka-ui/issues/1630 — JMX/Prometheus exporters
+  // emit NaN for unused gauges (e.g. average latency on a never-used listener). Without
+  // a guard, BigDecimal.valueOf(NaN) throws NumberFormatException and the whole broker
+  // metrics response is silently turned into 404 by BrokersController.
+  @Test
+  void toBrokerMetricsDropsNonFiniteDataPoints() {
+    ClusterMapper mapper = new ClusterMapperImpl();
+
+    var withNan = new GaugeSnapshot(new MetricMetadata("nan_metric", "help"), List.of(
+        new GaugeSnapshot.GaugeDataPointSnapshot(Double.NaN, Labels.of("l", "v"), null)));
+    var withPosInf = new GaugeSnapshot(new MetricMetadata("posinf_metric", "help"), List.of(
+        new GaugeSnapshot.GaugeDataPointSnapshot(Double.POSITIVE_INFINITY, Labels.of("l", "v"), null)));
+    var withNegInf = new GaugeSnapshot(new MetricMetadata("neginf_metric", "help"), List.of(
+        new GaugeSnapshot.GaugeDataPointSnapshot(Double.NEGATIVE_INFINITY, Labels.of("l", "v"), null)));
+    var finite = new GaugeSnapshot(new MetricMetadata("ok_metric", "help"), List.of(
+        new GaugeSnapshot.GaugeDataPointSnapshot(42.0, Labels.of("l", "v"), null)));
+
+    BrokerMetricsDTO dto = mapper.toBrokerMetrics(
+        List.<MetricSnapshot>of(withNan, withPosInf, withNegInf, finite));
+
+    assertThat(dto.getMetrics())
+        .extracting(m -> m.getName())
+        .containsExactly("ok_metric");
+  }
+}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
<!-- ignore-task-list-end -->

**What changes did you make?** (Give an overview)

Fixes #1820 (related: #1630).

`ClusterMapper#convert` builds `MetricDTO`s by calling `BigDecimal.valueOf(readPointValue(p))`. `BigDecimal.valueOf(double)` throws `NumberFormatException("Infinite or NaN")` on any non-finite input. JMX-Prometheus exporters (Strimzi `jmxPrometheusExporter`, MSK Open Monitoring, plain `io.prometheus.jmx`) legitimately emit `NaN` for `*_avg` / `*_max` Kafka sensors that have never been observed (e.g. reauthentication latency on a never-used listener, request size on an idle replication listener).

The exception bubbles up to `BrokersController#getBrokersMetrics`, which silently swallows it via `.onErrorReturn(ResponseEntity.notFound().build())`. Net effect: a single NaN data point anywhere in the broker's metric stream collapses the entire `/api/clusters/{name}/brokers/{id}/metrics` response to **404**, with no log line. The broker's Metrics tab never works.

This change makes `convert()` filter non-finite data points before they reach `BigDecimal.valueOf`. Finite points still flow through; the broken point is dropped rather than poisoning the whole response.

The silent `.onErrorReturn(notFound())` in `BrokersController` is a separate issue (it hides every other failure mode in this path too) and is intentionally left out of scope here.

**Is there anything you'd like reviewers to focus on?**

- Is dropping the offending point the right semantic? Alternatives considered:
  - Substitute `0` (changes semantics — `0` is a valid value).
  - Substitute `null` in `MetricDTO.value` (the OpenAPI contract has it as a non-nullable BigDecimal-shaped string in JSON; changing that ripples to clients).
  - Sanitize at the scrape layer in `PrometheusTextFormatParser` (broader blast radius — affects the global `/metrics` re-export too, where Prometheus itself accepts `NaN` and would arguably want it preserved).
  Filtering at the DTO conversion layer keeps the fix localized to the API surface that breaks today.
- The same `convert()` is also called from `toClusterMetrics` (cluster summary). Today that path tends not to hit NaN because `SummarizedMetrics` aggregates, but it's still worth confirming the filter doesn't drop anything operators rely on. I don't think it does — a `NaN`-aggregated bucket would be unusable anyway.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

- New unit test `ClusterMapperTest#toBrokerMetricsDropsNonFiniteDataPoints` builds a `BrokerMetricsDTO` from four `GaugeSnapshot`s (NaN, +Inf, -Inf, finite) and asserts only the finite point survives.
- Reproduced manually against a Strimzi 0.x broker on stage: with stock kafbat-ui v1.5.0 the endpoint returned 404; with this patch it returns 200 with the broker's metrics minus the ~24 NaN points.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**) — n/a, no user-facing config change
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

🐢 (a tortoise — slow, finite, never NaN)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced broker metrics processing to handle invalid numerical values more robustly. Metric values that are non-finite (such as NaN or Infinity) from Prometheus data sources are now properly filtered out during conversion, preventing collection errors and ensuring reliable, continuous metrics monitoring and reporting throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->