### PR TITLE
feat: add bootstrapServers field to cluster API and visualize it in web UI

### DIFF
--- a/api/src/main/java/io/kafbat/ui/model/InternalClusterState.java
+++ b/api/src/main/java/io/kafbat/ui/model/InternalClusterState.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.Nullable;
 @Data
 public class InternalClusterState {
   private String name;
+  private String bootstrapServers;
   private ServerStatusDTO status;
   private MetricsCollectionErrorDTO lastError;
   private Integer topicCount;
@@ -31,8 +32,14 @@ public class InternalClusterState {
   private Boolean readOnly;
   private ControllerType controller;
 
+  /**
+   * Snapshots a cluster's static configuration ({@link KafkaCluster}) and its
+   * latest scraped {@link Statistics} into the shape consumed by the cluster
+   * DTO mapper.
+   */
   public InternalClusterState(KafkaCluster cluster, Statistics statistics) {
     name = cluster.getName();
+    bootstrapServers = cluster.getBootstrapServers();
     status = statistics.getStatus();
     lastError = Optional.ofNullable(statistics.getLastKafkaException())
         .map(e -> new MetricsCollectionErrorDTO()

--- a/api/src/main/resources/static/openapi/kafbat-ui-api.yaml
+++ b/api/src/main/resources/static/openapi/kafbat-ui-api.yaml
@@ -3732,6 +3732,8 @@ components:
               - MESSAGE_RELATIVE_TIMESTAMP
         controller:
           $ref: '#/components/schemas/ControllerType'
+        bootstrapServers:
+          type: string
     ClusterConfigValidation:
       type: object
       required:

--- a/api/src/test/java/io/kafbat/ui/model/InternalClusterStateTest.java
+++ b/api/src/test/java/io/kafbat/ui/model/InternalClusterStateTest.java
@@ -1,0 +1,37 @@
+package io.kafbat.ui.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Pins the wiring of {@link KafkaCluster#getBootstrapServers()} into
+ * {@link InternalClusterState} so the value reaches the cluster DTO.
+ */
+class InternalClusterStateTest {
+
+  /** Configured bootstrap servers reach the InternalClusterState. */
+  @Test
+  void exposesBootstrapServersFromCluster() {
+    KafkaCluster cluster = KafkaCluster.builder()
+        .name("test-cluster")
+        .bootstrapServers("host1:9092,host2:9092")
+        .build();
+
+    InternalClusterState state = new InternalClusterState(cluster, Statistics.empty());
+
+    assertThat(state.getBootstrapServers()).isEqualTo("host1:9092,host2:9092");
+  }
+
+  /** Bootstrap servers stay null when none were configured. */
+  @Test
+  void bootstrapServersIsNullWhenNotConfigured() {
+    KafkaCluster cluster = KafkaCluster.builder()
+        .name("test-cluster")
+        .build();
+
+    InternalClusterState state = new InternalClusterState(cluster, Statistics.empty());
+
+    assertThat(state.getBootstrapServers()).isNull();
+  }
+}

--- a/contract-typespec/api/clusters.tsp
+++ b/contract-typespec/api/clusters.tsp
@@ -47,6 +47,8 @@ model Cluster {
   version?: string;
   features?: ClusterFeature[];
   controller?: ControllerType;
+  @doc("Comma-separated host:port list the cluster was configured with.")
+  bootstrapServers?: string;
 }
 
 alias ClusterFeature =

--- a/contract/src/main/resources/swagger/kafbat-ui-api.yaml
+++ b/contract/src/main/resources/swagger/kafbat-ui-api.yaml
@@ -2617,6 +2617,9 @@ components:
           type: boolean
         version:
           type: string
+        bootstrapServers:
+          type: string
+          description: Comma-separated host:port list the cluster was configured with.
         features:
           type: array
           items:

--- a/frontend/src/components/Brokers/BrokersList/BrokersList.tsx
+++ b/frontend/src/components/Brokers/BrokersList/BrokersList.tsx
@@ -18,6 +18,10 @@ import ErrorPage from 'components/ErrorPage/ErrorPage';
 import { getBrokersTableColumns, getBrokersTableRows } from './lib';
 import { BrokersMetrics } from './BrokersMetrics/BrokersMetrics';
 
+/**
+ * Per-cluster Brokers page: shows the cluster overview metrics and the list of
+ * brokers, and navigates into a single broker's detail page on row click.
+ */
 const BrokersList: React.FC = () => {
   const navigate = useNavigate();
   const { clusterName } = useAppParams<{ clusterName: ClusterName }>();
@@ -87,6 +91,7 @@ const BrokersList: React.FC = () => {
               onlinePartitionCount={onlinePartitionCount}
               underReplicatedPartitionCount={underReplicatedPartitionCount}
               controller={cluster?.controller}
+              bootstrapServers={cluster?.bootstrapServers}
             />
 
             {isLoading && <PageLoader offsetY={300} />}

--- a/frontend/src/components/Brokers/BrokersList/BrokersMetrics/BrokersMetrics.styled.ts
+++ b/frontend/src/components/Brokers/BrokersList/BrokersMetrics/BrokersMetrics.styled.ts
@@ -3,3 +3,30 @@ import styled from 'styled-components';
 export const DangerText = styled.span`
   color: ${({ theme }) => theme.circularAlert.color.error};
 `;
+
+export const BootstrapServersValue = styled.span`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+`;
+
+export const CopyButton = styled.button`
+  appearance: none;
+  background: none;
+  border: none;
+  padding: 2px;
+  cursor: pointer;
+  color: inherit;
+  display: inline-flex;
+  align-items: center;
+  opacity: 0.6;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.3;
+  }
+`;

--- a/frontend/src/components/Brokers/BrokersList/BrokersMetrics/BrokersMetrics.tsx
+++ b/frontend/src/components/Brokers/BrokersList/BrokersMetrics/BrokersMetrics.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import * as Metrics from 'components/common/Metrics';
 import { ControllerType } from 'generated-sources';
+import CopyIcon from 'components/common/Icons/CopyIcon';
+import useDataSaver from 'lib/hooks/useDataSaver';
 
 import * as S from './BrokersMetrics.styled';
 
@@ -40,6 +42,11 @@ export const BrokersMetrics = ({
 
   const isActiveControllerUnKnown = typeof activeControllers === 'undefined';
 
+  const { copyToClipboard: copyBootstrapServers } = useDataSaver(
+    'bootstrap-servers',
+    bootstrapServers ?? ''
+  );
+
   return (
     <Metrics.Wrapper>
       <Metrics.Section title="Uptime">
@@ -61,7 +68,18 @@ export const BrokersMetrics = ({
         <Metrics.Indicator label="Version">{version}</Metrics.Indicator>
 
         <Metrics.Indicator label="Bootstrap Servers">
-          {bootstrapServers ?? '—'}
+          <S.BootstrapServersValue>
+            {bootstrapServers ?? '—'}
+            <S.CopyButton
+              type="button"
+              aria-label="Copy bootstrap servers"
+              title="Copy bootstrap servers"
+              onClick={copyBootstrapServers}
+              disabled={!bootstrapServers}
+            >
+              <CopyIcon />
+            </S.CopyButton>
+          </S.BootstrapServersValue>
         </Metrics.Indicator>
       </Metrics.Section>
 

--- a/frontend/src/components/Brokers/BrokersList/BrokersMetrics/BrokersMetrics.tsx
+++ b/frontend/src/components/Brokers/BrokersList/BrokersMetrics/BrokersMetrics.tsx
@@ -14,8 +14,14 @@ type BrokersMetricsProps = {
   underReplicatedPartitionCount: number | undefined;
   version: string | undefined;
   controller: ControllerType | undefined;
+  /** Comma-separated `host:port` list the cluster was configured with. */
+  bootstrapServers: string | undefined;
 };
 
+/**
+ * Cluster overview header. Renders the "Uptime" and "Partitions" indicator
+ * groups for the currently selected cluster.
+ */
 export const BrokersMetrics = ({
   brokerCount,
   version,
@@ -26,6 +32,7 @@ export const BrokersMetrics = ({
   underReplicatedPartitionCount,
   onlinePartitionCount,
   controller,
+  bootstrapServers,
 }: BrokersMetricsProps) => {
   const replicas = (inSyncReplicasCount ?? 0) + (outOfSyncReplicasCount ?? 0);
   const areAllInSync = inSyncReplicasCount && replicas === inSyncReplicasCount;
@@ -52,6 +59,10 @@ export const BrokersMetrics = ({
         </Metrics.Indicator>
 
         <Metrics.Indicator label="Version">{version}</Metrics.Indicator>
+
+        <Metrics.Indicator label="Bootstrap Servers">
+          {bootstrapServers ?? '—'}
+        </Metrics.Indicator>
       </Metrics.Section>
 
       <Metrics.Section title="Partitions">

--- a/frontend/src/components/Brokers/BrokersList/__test__/BrokersList.spec.tsx
+++ b/frontend/src/components/Brokers/BrokersList/__test__/BrokersList.spec.tsx
@@ -9,6 +9,7 @@ import { useClusters, useClusterStats } from 'lib/hooks/api/clusters';
 import { brokersPayload } from 'lib/fixtures/brokers';
 import {
   clusterStatsPayload,
+  offlineClusterPayload,
   onlineClusterPayload,
 } from 'lib/fixtures/clusters';
 
@@ -75,6 +76,14 @@ describe('BrokersList Component', () => {
         renderComponent();
         expect(screen.getByRole('table')).toBeInTheDocument();
         expect(screen.getAllByRole('row').length).toEqual(3);
+      });
+      it('renders the configured bootstrap servers', () => {
+        (useClusters as jest.Mock).mockImplementation(() => ({
+          data: [onlineClusterPayload, offlineClusterPayload],
+        }));
+        renderComponent();
+        expect(screen.getByText('Bootstrap Servers')).toBeInTheDocument();
+        expect(screen.getByText('offline-host:9092')).toBeInTheDocument();
       });
       it('opens broker when row clicked', async () => {
         renderComponent();

--- a/frontend/src/components/Brokers/BrokersList/__test__/BrokersList.spec.tsx
+++ b/frontend/src/components/Brokers/BrokersList/__test__/BrokersList.spec.tsx
@@ -85,6 +85,18 @@ describe('BrokersList Component', () => {
         expect(screen.getByText('Bootstrap Servers')).toBeInTheDocument();
         expect(screen.getByText('offline-host:9092')).toBeInTheDocument();
       });
+      it('copies bootstrap servers to the clipboard on icon click', async () => {
+        (useClusters as jest.Mock).mockImplementation(() => ({
+          data: [onlineClusterPayload, offlineClusterPayload],
+        }));
+        const writeText = jest.fn();
+        Object.assign(navigator, { clipboard: { writeText } });
+        renderComponent();
+        await userEvent.click(
+          screen.getByRole('button', { name: /copy bootstrap servers/i })
+        );
+        expect(writeText).toHaveBeenCalledWith('offline-host:9092');
+      });
       it('opens broker when row clicked', async () => {
         renderComponent();
         await userEvent.click(screen.getByRole('cell', { name: '100' }));

--- a/frontend/src/components/common/Icons/CopyIcon.tsx
+++ b/frontend/src/components/common/Icons/CopyIcon.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const CopyIcon: React.FC<{ fill?: string }> = ({ fill = 'currentColor' }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 448 512"
+    fill={fill}
+    width="14"
+    height="14"
+  >
+    <path d="M384 96V320H192V96H384zM192 32C156.7 32 128 60.65 128 96V320C128 355.3 156.7 384 192 384H384C419.3 384 448 355.3 448 320V96C448 60.65 419.3 32 384 32H192zM64 128C28.65 128 0 156.7 0 192V416C0 451.3 28.65 480 64 480H256C291.3 480 320 451.3 320 416H256V416H64V192H96V128H64z" />
+  </svg>
+);
+
+export default CopyIcon;

--- a/frontend/src/lib/fixtures/clusters.ts
+++ b/frontend/src/lib/fixtures/clusters.ts
@@ -12,6 +12,7 @@ export const onlineClusterPayload: Cluster = {
   readOnly: false,
   features: [],
   controller: ControllerType.KRAFT,
+  bootstrapServers: 'host1:9092,host2:9092',
 };
 export const offlineClusterPayload: Cluster = {
   name: 'local',
@@ -25,6 +26,7 @@ export const offlineClusterPayload: Cluster = {
   features: [],
   readOnly: true,
   controller: ControllerType.KRAFT,
+  bootstrapServers: 'offline-host:9092',
 };
 
 export const clustersPayload: Cluster[] = [


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

This PR adds:
* a `bootstrapServers` field to the clusters APIs that contains the configured bootstrap servers
* a corresponding UI box in the "Broker" list that shows the boostrap servers in the web UI

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

<img width="199" height="199" alt="6887-cute-dog-profile-picture" src="https://github.com/user-attachments/assets/96297414-d5e0-4c59-ab06-cc583166d305" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bootstrap servers are now shown in the Brokers metrics view (“Bootstrap Servers” indicator).

* **Improvements**
  * API and contract schemas include an optional bootstrapServers field on Cluster objects.
  * Frontend components pass and render cluster bootstrap server information where applicable.

* **Tests**
  * Added backend unit tests and frontend fixtures/tests for presence and absence of bootstrap servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->