### PR TITLE
BE: Fix serde selection for explicitly configured serdes without topic patterns

### DIFF
--- a/api/src/main/java/io/kafbat/ui/serdes/ClusterSerdes.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/ClusterSerdes.java
@@ -38,9 +38,10 @@ public class ClusterSerdes implements Closeable {
       var pattern = type == Serde.Target.KEY
           ? serdeInstance.topicKeyPattern
           : serdeInstance.topicValuePattern;
-      if (pattern != null
-          && pattern.matcher(topic).matches()
-          && additionalCheck.test(serdeInstance)) {
+      boolean topicMatches = pattern != null
+          ? pattern.matcher(topic).matches()
+          : serdeInstance.explicitlyConfigured;
+      if (topicMatches && additionalCheck.test(serdeInstance)) {
         return Optional.of(serdeInstance);
       }
     }

--- a/api/src/main/java/io/kafbat/ui/serdes/SerdeInstance.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/SerdeInstance.java
@@ -33,6 +33,8 @@ public class SerdeInstance implements Closeable {
   @Nullable // will be set for custom serdes
   final ClassLoader classLoader;
 
+  final boolean explicitlyConfigured;
+
   private <T> T wrapWithClassloader(Supplier<T> call) {
     if (classLoader == null) {
       return call.get();

--- a/api/src/main/java/io/kafbat/ui/serdes/SerdesInitializer.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/SerdesInitializer.java
@@ -127,7 +127,7 @@ public class SerdesInitializer {
       if (!registeredSerdes.containsKey(name)) {
         BuiltInSerde serde = createSerdeInstance(clazz);
         if (autoConfigureSerde(serde, clusterPropertiesResolver, globalPropertiesResolver)) {
-          registeredSerdes.put(name, new SerdeInstance(name, serde, null, null, null));
+          registeredSerdes.put(name, new SerdeInstance(name, serde, null, null, null, false));
         }
       }
     });
@@ -163,7 +163,8 @@ public class SerdesInitializer {
             new ConsumerOffsetsSerde(),
             pattern,
             pattern,
-            null
+            null,
+            false
         )
     );
   }
@@ -180,13 +181,13 @@ public class SerdesInitializer {
   }
 
   private SerdeInstance mirrorSerde(String name, Pattern pattern, BuiltInSerde serde) {
-    return new SerdeInstance(name, serde, pattern, pattern, null);
+    return new SerdeInstance(name, serde, pattern, pattern, null, false);
   }
 
   private SerdeInstance createFallbackSerde() {
     StringSerde serde = new StringSerde();
     serde.configure(PropertyResolverImpl.empty(), PropertyResolverImpl.empty(), PropertyResolverImpl.empty());
-    return new SerdeInstance("Fallback", serde, null, null, null);
+    return new SerdeInstance("Fallback", serde, null, null, null, false);
   }
 
   @SneakyThrows
@@ -237,7 +238,8 @@ public class SerdesInitializer {
         serde,
         nullablePattern(serdeConfig.getTopicKeysPattern()),
         nullablePattern(serdeConfig.getTopicValuesPattern()),
-        null
+        null,
+        true
     );
   }
 
@@ -265,7 +267,8 @@ public class SerdesInitializer {
         serde,
         nullablePattern(serdeConfig.getTopicKeysPattern()),
         nullablePattern(serdeConfig.getTopicValuesPattern()),
-        null
+        null,
+        true
     );
   }
 
@@ -293,7 +296,8 @@ public class SerdesInitializer {
         loaded.getSerde(),
         nullablePattern(serdeConfig.getTopicKeysPattern()),
         nullablePattern(serdeConfig.getTopicValuesPattern()),
-        loaded.getClassLoader()
+        loaded.getClassLoader(),
+        true
     );
   }
 

--- a/api/src/test/java/io/kafbat/ui/serdes/ClusterSerdesTest.java
+++ b/api/src/test/java/io/kafbat/ui/serdes/ClusterSerdesTest.java
@@ -1,0 +1,77 @@
+package io.kafbat.ui.serdes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kafbat.ui.serde.api.Serde;
+import io.kafbat.ui.serdes.builtin.StringSerde;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+
+class ClusterSerdesTest {
+
+  private final StringSerde stringSerde = new StringSerde();
+
+  private SerdeInstance autoConfiguredSerde(String name) {
+    return new SerdeInstance(name, stringSerde, null, null, null, false);
+  }
+
+  private SerdeInstance explicitSerdeNoPattern(String name, Serde serde) {
+    return new SerdeInstance(name, serde, null, null, null, true);
+  }
+
+  private SerdeInstance explicitSerdeWithPattern(String name, Serde serde, String pattern) {
+    var p = Pattern.compile(pattern);
+    return new SerdeInstance(name, serde, p, p, null, true);
+  }
+
+  @Test
+  void explicitlyConfiguredSerdeWithNullPatternIsSelectedWhenPreferable() {
+    var preferableSerde = new AlwaysPreferableSerde();
+    var serdes = new LinkedHashMap<String, SerdeInstance>();
+    serdes.put("CustomSR", explicitSerdeNoPattern("CustomSR", preferableSerde));
+    serdes.put(StringSerde.NAME, autoConfiguredSerde(StringSerde.NAME));
+
+    var clusterSerdes = new ClusterSerdes(serdes, null, null, autoConfiguredSerde("Fallback"));
+
+    assertThat(clusterSerdes.suggestSerdeForDeserialize("any-topic", Serde.Target.KEY).getName())
+        .isEqualTo("CustomSR");
+    assertThat(clusterSerdes.suggestSerdeForDeserialize("any-topic", Serde.Target.VALUE).getName())
+        .isEqualTo("CustomSR");
+  }
+
+  @Test
+  void autoConfiguredSerdeWithNullPatternIsNotAutoSelected() {
+    var serdes = new LinkedHashMap<String, SerdeInstance>();
+    serdes.put("AutoSR", autoConfiguredSerde("AutoSR"));
+    serdes.put(StringSerde.NAME, autoConfiguredSerde(StringSerde.NAME));
+
+    var clusterSerdes = new ClusterSerdes(serdes, null, null, autoConfiguredSerde("Fallback"));
+
+    assertThat(clusterSerdes.suggestSerdeForDeserialize("any-topic", Serde.Target.KEY).getName())
+        .isEqualTo(StringSerde.NAME);
+  }
+
+  @Test
+  void explicitSerdeWithPatternStillRequiresPatternMatch() {
+    var preferableSerde = new AlwaysPreferableSerde();
+    var serdes = new LinkedHashMap<String, SerdeInstance>();
+    serdes.put("CustomSR", explicitSerdeWithPattern("CustomSR", preferableSerde, "matching-.*"));
+    serdes.put(StringSerde.NAME, autoConfiguredSerde(StringSerde.NAME));
+
+    var clusterSerdes = new ClusterSerdes(serdes, null, null, autoConfiguredSerde("Fallback"));
+
+    assertThat(clusterSerdes.suggestSerdeForDeserialize("matching-topic", Serde.Target.KEY).getName())
+        .isEqualTo("CustomSR");
+    assertThat(clusterSerdes.suggestSerdeForDeserialize("other-topic", Serde.Target.KEY).getName())
+        .isEqualTo(StringSerde.NAME);
+  }
+
+  static class AlwaysPreferableSerde extends StringSerde {
+    @Override
+    public boolean couldBePreferable(String topic, Target type) {
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
Fixes #1854

### Background: the provectus issue

This issue was originally reported as provectus/kafka-ui#3792. Users discovered that message **key** deserialization broke when using Confluent [schema contexts](https://docs.confluent.io/platform/current/schema-registry/schema-linking-cp.html#using-a-base-context-path) (e.g., `http://schemaregistry:8081/contexts/.mycontext`). Values deserialized fine, but keys showed raw bytes.

Merged PR provectus/kafka-ui#3857 ("Minor serdes fixes") and closed the issue. However, that PR only added **resilience** — wrapping schema lookups in 404 handlers so the app wouldn't crash on missing schemas. It did not fix the actual serde selection problem. The team also suggested a workaround: configure separate custom serdes per context with explicit `keySchemaNameTemplate` / `schemaNameTemplate` properties.

The workaround partially worked (values deserialized), but key deserialization remained broken. The issue was closed prematurely, and the underlying bug carried over into the kafbat fork as #1854.

### Root cause

The serde selection mechanism in `ClusterSerdes.findSerdeByPatternsOrDefault()` iterates over registered serdes and for each one:

1. Checks `couldBePreferable(topic, type)` — whether the serde considers itself suitable
2. Checks the topic pattern (`topicKeyPattern` / `topicValuePattern`) — whether the topic matches

When a user configures a custom serde without setting `topicKeysPattern`/`topicValuesPattern` (the common case for context-scoped SR serdes), these patterns are `null`. The old code treated `null` as "never match":

```java
if (pattern != null && pattern.matcher(topic).matches() && ...) {
    return Optional.of(serdeInstance);
}
```

So even though the custom serde correctly reported `couldBePreferable = true`, it was always skipped. The system fell back to the auto-configured root SR serde (which can't resolve context-scoped schema IDs) or ultimately to `StringSerde` (raw bytes).

### Options considered

1. **Treat null patterns as "match all" universally** — rejected because auto-configured built-in serdes (StringSerde, Int32Serde, etc.) also have null patterns and a default `couldBePreferable()` returning `true`. This would cause StringSerde to win for every topic since it's iterated first.

2. **Require users to always set `topicKeysPattern: .*`** — rejected as poor UX. If a user defines a custom serde with context templates, it should just work without requiring a non-obvious extra config property.

3. **Distinguish explicitly configured vs auto-configured serdes** (chosen) — add an `explicitlyConfigured` flag to `SerdeInstance`. For explicitly configured serdes, null patterns mean "match all topics". For auto-configured built-in serdes, null patterns retain the old "never match" behavior.

### Changes

- **`SerdeInstance`**: Added `explicitlyConfigured` field
- **`ClusterSerdes`**: Updated `findSerdeByPatternsOrDefault()` — null pattern on explicitly configured serdes matches any topic
- **`SerdesInitializer`**: All `SerdeInstance` constructors updated — serdes from user config get `true`, auto-configured/internal ones get `false`
- **`ClusterSerdesTest`** (new): Tests for the new selection behavior

**Is there anything you'd like reviewers to focus on?**

Whether there are edge cases where an explicitly configured serde with null patterns matching all topics could cause unexpected serde selection order issues.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined serialization/deserialization format selection to properly prioritize explicitly configured options when selecting formats for topics.
  * Enhanced pattern-based matching for topic-specific format configuration.

* **Tests**
  * Added comprehensive test coverage for serde selection behavior, including explicit configuration and regex pattern matching scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kafbat/kafka-ui/pull/1856)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->