### PR TITLE
Optimize Kafka topic filtering for large clusters (370x+ speedup)

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
+++ b/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
@@ -18,7 +18,6 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -150,23 +149,26 @@ public class ScrapedClusterState implements AutoCloseable {
             )));
   }
 
-  private static Map<String, TopicState> topicStateMap(
+  static Map<String, TopicState> topicStateMap(
       InternalLogDirStats segmentStats,
       Map<String, TopicDescription> topicDescriptions,
       Map<String, List<ConfigEntry>> topicConfigs,
       Map<TopicPartition, Long> latestOffsets,
       Map<TopicPartition, Long> earliestOffsets) {
 
+    Map<String, Map<Integer, Long>> earliestByTopic = groupByTopic(earliestOffsets);
+    Map<String, Map<Integer, Long>> latestByTopic = groupByTopic(latestOffsets);
+    Map<String, Map<Integer, SegmentStats>> partitionsStatsByTopic =
+        segmentStats.getPartitionsStats() == null ? null : groupByTopic(segmentStats.getPartitionsStats());
+
     return topicDescriptions.entrySet().stream().map(entry -> new TopicState(
         entry.getKey(),
         entry.getValue(),
         topicConfigs.getOrDefault(entry.getKey(), List.of()),
-        filterTopic(entry.getKey(), earliestOffsets),
-        filterTopic(entry.getKey(), latestOffsets),
+        earliestByTopic.getOrDefault(entry.getKey(), Map.of()),
+        latestByTopic.getOrDefault(entry.getKey(), Map.of()),
         segmentStats.getTopicStats().get(entry.getKey()),
-        Optional.ofNullable(segmentStats.getPartitionsStats())
-            .map(topicForFilter -> filterTopic(entry.getKey(), topicForFilter))
-            .orElse(null)
+        partitionsStatsByTopic == null ? null : partitionsStatsByTopic.getOrDefault(entry.getKey(), Map.of())
     )).collect(Collectors.toMap(
         TopicState::name,
         Function.identity()
@@ -227,11 +229,11 @@ public class ScrapedClusterState implements AutoCloseable {
     return new FilterTopicIndex(topics);
   }
 
-  private static <T> Map<Integer, T> filterTopic(String topicForFilter, Map<TopicPartition, T> tpMap) {
-    return tpMap.entrySet()
-        .stream()
-        .filter(tp -> tp.getKey().topic().equals(topicForFilter))
-        .collect(Collectors.toMap(e -> e.getKey().partition(), Map.Entry::getValue));
+  private static <T> Map<String, Map<Integer, T>> groupByTopic(Map<TopicPartition, T> tpMap) {
+    Map<String, Map<Integer, T>> result = new HashMap<>();
+    tpMap.forEach((tp, v) ->
+        result.computeIfAbsent(tp.topic(), k -> new HashMap<>()).put(tp.partition(), v));
+    return result;
   }
 
   private static InternalTopic buildInternalTopic(TopicState state,

--- a/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateTest.java
@@ -2,6 +2,14 @@ package io.kafbat.ui.service.metrics.scrape;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.kafbat.ui.model.InternalLogDirStats;
+import io.kafbat.ui.model.InternalLogDirStats.SegmentStats;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 
 class ScrapedClusterStateTest {
@@ -13,5 +21,84 @@ class ScrapedClusterStateTest {
       assertThat(empty.getTopicIndex().find(null, null, false, null)).isEmpty();
       assertThat(empty.getTopicIndex().find("search", true, true, null)).isEmpty();
     }
+  }
+
+  @Test
+  void topicStateMapGroupsOffsetsAndStatsPerTopic() throws Exception {
+    SegmentStats partA0 = new SegmentStats(10L, 1);
+    SegmentStats partA1 = new SegmentStats(20L, 2);
+    SegmentStats partB0 = new SegmentStats(30L, 3);
+    SegmentStats topicAStats = new SegmentStats(30L, 3);
+    SegmentStats topicBStats = new SegmentStats(30L, 3);
+
+    InternalLogDirStats segmentStats = buildLogDirStats(
+        Map.of(
+            new TopicPartition("a", 0), partA0,
+            new TopicPartition("a", 1), partA1,
+            new TopicPartition("b", 0), partB0
+        ),
+        Map.of("a", topicAStats, "b", topicBStats)
+    );
+
+    Map<String, TopicDescription> descriptions = Map.of(
+        "a", topicDescription("a"),
+        "b", topicDescription("b")
+    );
+    Map<String, List<ConfigEntry>> configs = Map.of(
+        "a", List.of(new ConfigEntry("retention.ms", "1000"))
+    );
+    Map<TopicPartition, Long> latest = Map.of(
+        new TopicPartition("a", 0), 100L,
+        new TopicPartition("a", 1), 200L,
+        new TopicPartition("b", 0), 300L
+    );
+    Map<TopicPartition, Long> earliest = Map.of(
+        new TopicPartition("a", 0), 0L,
+        new TopicPartition("a", 1), 5L,
+        new TopicPartition("b", 0), 10L
+    );
+
+    Map<String, ScrapedClusterState.TopicState> result =
+        ScrapedClusterState.topicStateMap(segmentStats, descriptions, configs, latest, earliest);
+
+    assertThat(result).containsOnlyKeys("a", "b");
+
+    var a = result.get("a");
+    assertThat(a.name()).isEqualTo("a");
+    assertThat(a.description()).isSameAs(descriptions.get("a"));
+    assertThat(a.configs()).containsExactly(new ConfigEntry("retention.ms", "1000"));
+    assertThat(a.startOffsets()).containsOnly(Map.entry(0, 0L), Map.entry(1, 5L));
+    assertThat(a.endOffsets()).containsOnly(Map.entry(0, 100L), Map.entry(1, 200L));
+    assertThat(a.segmentStats()).isEqualTo(topicAStats);
+    assertThat(a.partitionsSegmentStats()).containsOnly(Map.entry(0, partA0), Map.entry(1, partA1));
+
+    var b = result.get("b");
+    assertThat(b.configs()).isEmpty();
+    assertThat(b.startOffsets()).containsOnly(Map.entry(0, 10L));
+    assertThat(b.endOffsets()).containsOnly(Map.entry(0, 300L));
+    assertThat(b.segmentStats()).isEqualTo(topicBStats);
+    assertThat(b.partitionsSegmentStats()).containsOnly(Map.entry(0, partB0));
+  }
+
+  private static TopicDescription topicDescription(String name) {
+    return new TopicDescription(name, false, List.of());
+  }
+
+  // InternalLogDirStats is @Value with an explicit 1-arg constructor, so Lombok does not
+  // generate an all-args constructor. Reflection lets tests set the two fields topicStateMap
+  // actually reads without constructing a full Map<Integer, Map<String, LogDirDescription>>.
+  private static InternalLogDirStats buildLogDirStats(
+      Map<TopicPartition, SegmentStats> partitionsStats,
+      Map<String, SegmentStats> topicStats) throws Exception {
+    InternalLogDirStats instance = InternalLogDirStats.empty();
+    setField(instance, "partitionsStats", partitionsStats);
+    setField(instance, "topicStats", topicStats);
+    return instance;
+  }
+
+  private static void setField(Object target, String name, Object value) throws Exception {
+    Field field = target.getClass().getDeclaredField(name);
+    field.setAccessible(true);
+    field.set(target, value);
   }
 }


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Fixes https://github.com/kafbat/kafka-ui/issues/1776

topicStateMap called filterTopic once per topic for each offsets/stats map, each doing an O(P_total) scan — total O(T * P_total) per scrape. On large clusters this was the CPU hotspot behind slow UI.

Fix: group each cluster-wide map by topic once (O(P_total) total), then do O(1) lookups in the per-topic loop.

Measured speedup (partitions = 10 * topics, median per call):
  1K topics:    373ms -> 1ms   (~370x)
  3K topics:    3.2s  -> 4ms   (~800x)
  10K topics:   61s   -> 14ms  (~4400x)

**Is there anything you'd like reviewers to focus on?**

Review correctness of changes, and effectiveness of tests, as I'm not very familiar with Kafka UI code.


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary) - I deployed to our staging environment. The 1.5.0 release of Kafka UI is very obviously much slower at opening the topics page (and other things). I also ran the attached, but not committed benchmarking [ScrapedClusterStatePerfTest.java](https://github.com/user-attachments/files/28409805/ScrapedClusterStatePerfTest.java) (place it in `api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStatePerfTest.java` if you want to run). See results above.
- [x] Unit checks - new tests to validate correctness of touched functions. They pass before my changes, and also after.
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x2] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

<img width="500" height="281" alt="image" src="https://media0.giphy.com/media/v1.Y2lkPTZjMDliOTUyenBxMnE1amg3OXd4aXJmbnM2MjFsNzcxcXlxYTg4c3Bhb28yM2s0dCZlcD12MV9naWZzX3NlYXJjaCZjdD1n/H4uE6w9G1uK4M/source.gif" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal metrics data processing logic for improved efficiency

* **Tests**
  * Expanded test coverage for metrics scraping and state validation to ensure reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kafbat/kafka-ui/pull/1866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->