### PR TITLE
infra: Add focused dependency groups to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,6 +38,9 @@ updates:
         - "org.mockito:*"
         # Bouncy Castle is only used for testing purposes
         - "org.bouncycastle:bcpkix-jdk18on"
+        - "org.wiremock:*"
+        # byte-buddy is only used to support testing needs and it is declared as a testImplementation
+        - "net.bytebuddy:byte-buddy"
     api-build-tools:
       patterns:
         - "org.openapitools:*"
@@ -66,6 +69,15 @@ updates:
     modelcontextprotocol:
       patterns:
         - "io.modelcontextprotocol.sdk:mcp-spring-webflux"
+    identity-libraries:
+      patterns:
+        - "com.google.cloud.hosted.kafka:managed-kafka-auth-login-handler"
+        - "software.amazon.msk:aws-msk-iam-auth"
+        - "com.azure:azure-identity"
+    compression-libraries:
+      patterns:
+        - "org.xerial.snappy:snappy-java"
+        - "at.yawk.lz4:lz4-java"
     gradle-wrapper:
       patterns:
         - "gradle-wrapper"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,8 @@ updates:
     interval: weekly
     time: "10:00"
     timezone: Europe/London
-  open-pull-requests-limit: 10
+  # The default is 5 which conflicts with the number of groups we have
+  open-pull-requests-limit: 12
   labels:
     - "type/dependencies"
     - "scope/backend"
@@ -20,8 +21,6 @@ updates:
     - dependency-name: "*"
       update-types:
         - "version-update:semver-major"
-  # The default is 5 which conflicts with the number of groups we have
-  open-pull-requests-limit: 12
   groups:
     spring-boot-dependencies:
       patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     time: "10:00"
     timezone: Europe/London
   # The default is 5 which conflicts with the number of groups we have
-  open-pull-requests-limit: 12
+  open-pull-requests-limit: 14
   labels:
     - "type/dependencies"
     - "scope/backend"
@@ -87,6 +87,10 @@ updates:
     gradle-wrapper:
       patterns:
         - "gradle-wrapper"
+    # Cel is still a 0.x dependency which means that the may introduce breaking changes at any time
+    cel:
+      patterns:
+        - "dev.cel:cel"
     others:
       patterns:
         - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,6 +47,11 @@ updates:
         - "org.openapitools:*"
         - "com.github.java-json-tools:*"
         - "com.github.victools:*"
+    prometheus:
+      # The Prometheus project generally promises API and feature stability within major versions but does occasionally introduce breaking changes in minor releases
+      # This is a problem grouped under "all"
+      patterns:
+        - "io.prometheus:*"
     # Update Apache Commons libraries together as these dependencies rarely introduce breaking changes
     apache-commons:
       patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
     - dependency-name: "*"
       update-types:
         - "version-update:semver-major"
+  # The default is 5 which conflicts with the number of groups we have
+  open-pull-requests-limit: 12
   groups:
     spring-boot-dependencies:
       patterns:


### PR DESCRIPTION
<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Introduces more focused grouping to help improve the merge rate of Dependabot pull requests.

This change also increases the value of `open-pull-requests-limit` to 12 as that's the current number of groups that we have. The default (5) would block valid and potentially needed pull requests

**Is there anything you'd like reviewers to focus on?**

Grouped pull requests are generally tricky to get right and more so when the groups are not obvious or come from different authors. 

The catch "them all" `others` group is particularly problematic in my opinion

While I understand the motivation for reducing the number of Dependabot pull requests, one downside of these larger groups is that they can make failures more difficult to investigate. They can also complicate future reverts if only a subset of the grouped updates needs to be rolled back.

With that in mind, I think it would be worth considering removing the `others` group in a follow-up PR.


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->

- [x] Manually (please, describe, if necessary)

- The configuration itself is valid: https://github.com/yeikel/kafka-ui/runs/79072517423

- More targeted groups are now raised: https://github.com/yeikel/kafka-ui/pulls?q=is%3Apr+is%3Aopen+label%3Ascope%2Fbackend

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

<img width="50%" height="1407" alt="image" src="https://github.com/user-attachments/assets/199170a0-cb8a-4739-ad2c-35f0e567c670" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the limit for simultaneous automated dependency update PRs to allow more open updates.
  * Expanded the testing dependency group with additional test-only libraries for broader coverage.
  * Added new dependency groups for identity-related libraries and for compression libraries to improve organization and update management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->