### PR TITLE
Prevent invalid JSONPath in message preview from crashing page

### DIFF
--- a/frontend/src/components/Topics/Topic/Messages/Message.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Message.tsx
@@ -80,6 +80,18 @@ const Message: React.FC<Props> = ({ message, keyFilters, contentFilters }) => {
     }
   };
 
+  const evaluateFilter = (path: string, json: unknown) => {
+    // A stored preview filter can hold an invalid JSONPath (e.g. saved before
+    // validation existed, or one that only throws against real message data).
+    // Evaluating it during render would otherwise throw and crash the whole
+    // messages page on every load until local storage is cleared manually.
+    try {
+      return JSON.stringify(JSONPath({ path, json, wrap: false }));
+    } catch {
+      return 'Invalid JSONPath';
+    }
+  };
+
   const renderFilteredJson = (
     jsonValue?: string,
     filters?: PreviewFilter[]
@@ -92,10 +104,7 @@ const Message: React.FC<Props> = ({ message, keyFilters, contentFilters }) => {
         {filters.map((item) => {
           return (
             <div key={`${item.path}--${item.field}`}>
-              {item.field}:{' '}
-              {JSON.stringify(
-                JSONPath({ path: item.path, json: parsedJson, wrap: false })
-              )}
+              {item.field}: {evaluateFilter(item.path, parsedJson)}
             </div>
           );
         })}

--- a/frontend/src/components/Topics/Topic/Messages/__test__/Message.spec.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/__test__/Message.spec.tsx
@@ -176,6 +176,15 @@ describe('Message component', () => {
     expect(keyFiltered).toBeInTheDocument();
   });
 
+  it('does not crash the row when a preview filter has an invalid JSONPath', () => {
+    const props = {
+      message: { ...mockMessage, value: mockMessageValue as string },
+      contentFilters: [{ field: 'broken', path: '$[?(@.foo.bar.baz)]' }],
+    };
+    renderComponent(props);
+    expect(screen.getByText('broken: Invalid JSONPath')).toBeInTheDocument();
+  });
+
   it('shows action options in dropdown on click', async () => {
     renderComponent();
     const trElement = screen.getByRole('row');


### PR DESCRIPTION
## What & why

Closes #1436

When a message **preview** filter holds a JSONPath that errors at evaluation time (e.g. a filter expression that dereferences an undefined property such as `$[?(@.foo.bar.baz)]`), `JSONPath(...)` is called directly inside `renderFilteredJson` during render. The thrown error propagates out of render and crashes the whole Messages page.

Because preview filters are persisted in local storage (`message-preview`), the crash is sticky: it reproduces on every reload until the user manually clears that local-storage key. The existing validation in `PreviewModal` only checks a path against an empty object (`{}`), so an expression that is structurally valid but throws against real message data, or any value saved before that validation existed, still gets through.

## Change

- Wrap the per-filter `JSONPath` evaluation in `Message.tsx` in a guarded helper. On error it renders `Invalid JSONPath` inline for that filter instead of throwing, so a single bad filter degrades gracefully and the rest of the row/page keeps working.

## Testing

- Added a unit test in `Message.spec.tsx` asserting that a stored filter with an invalid JSONPath renders the inline error and does not crash the row.
- `pnpm jest Message.spec.tsx` → 13/13 passing.
- `eslint --max-warnings=0` clean on the changed files.

## Repro (before)

1. Add a preview filter with path `$[?(@.foo.bar.baz)]` on a topic's Messages view.
2. The page crashes; reloading keeps crashing until `message-preview` is removed from local storage.

After this change the filter cell shows `Invalid JSONPath` and the page stays usable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a crash on the messages page that occurred when filters contained invalid expressions. The page now gracefully displays an error message for problematic filters instead of crashing.

* **Tests**
  * Added test coverage for handling invalid message filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->