### PR TITLE
Bump netty to 4.1.133.Final to address CVEs 42583, 42579, 42587, 42584

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 spring-boot = '3.5.13'
 nimbus-jose-jwt = '10.8'
-netty = '4.1.132.Final'
+netty = '4.1.133.Final'
 
 aws-msk-auth = '2.3.0'
 azure-identity = '1.15.4'


### PR DESCRIPTION
Bumps the `netty` version-catalog pin from `4.1.132.Final` → `4.1.133.Final` to clear four recently-published High netty CVEs:

| CVE | Component |
|---|---|
| CVE-2026-42583 | io.netty:netty-codec |
| CVE-2026-42579 | io.netty:netty-codec-dns |
| CVE-2026-42587 | io.netty:netty-codec-http |
| CVE-2026-42584 | io.netty:netty-codec-http |
| CVE-2026-42587 | io.netty:netty-codec-http2 |

All five are fixed in upstream netty 4.1.133.Final ([release notes](https://netty.io/news/2026/05/14/4-1-133-Final.html)).

The existing resolution strategy in `api/build.gradle`:
```groovy
if (details.requested.group == "io.netty" && !details.requested.name.startsWith("netty-tcnative-")) {
    details.useVersion(libs.versions.netty.get())
}
```
ensures the bump cascades through every transitive netty dependency, so this single-line change in `libs.versions.toml` is sufficient.

### Why we (Lightbeam) are sending this upstream
We currently apply this bump downstream via a netty-swap layer in our own Dockerfile overlay, because our chart still pulls the `v1.5.0` release image which carries 4.1.132. Landing the fix upstream means future kafbat releases ship clean and we can drop the overlay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Netty dependency to version 4.1.133.Final

<!-- end of auto-generated comment: release notes by coderabbit.ai -->