### PR TITLE
Redesign UI with shadcn-style components and theme tokens

### DIFF
--- a/frontend/src/components/App.styled.ts
+++ b/frontend/src/components/App.styled.ts
@@ -1,6 +1,9 @@
 import styled from 'styled-components';
 
 export const Layout = styled.div`
+  min-height: 100vh;
+  background: ${({ theme }) => theme.surface.canvas};
+
   @media screen and (max-width: 1023px) {
     min-width: initial;
   }

--- a/frontend/src/components/AuthPage/AuthPage.styled.tsx
+++ b/frontend/src/components/AuthPage/AuthPage.styled.tsx
@@ -7,8 +7,11 @@ export const AuthPageStyled = styled.div(
     align-items: center;
     justify-content: space-between;
     min-height: 100vh;
-    background-color: ${theme.auth_page.backgroundColor};
+    background:
+      linear-gradient(180deg, ${theme.surface.panelAlt} 0, transparent 360px),
+      ${theme.surface.canvas};
     font-family: ${theme.auth_page.fontFamily};
     overflow-x: hidden;
+    color: ${theme.surface.foreground};
   `
 );

--- a/frontend/src/components/AuthPage/Header/Header.styled.tsx
+++ b/frontend/src/components/AuthPage/Header/Header.styled.tsx
@@ -5,13 +5,16 @@ export const HeaderStyled = styled.div`
   grid-template-columns: repeat(47, 41.11px);
   grid-template-rows: repeat(4, 41.11px);
   justify-content: center;
-  margin-bottom: 13.5px;
+  margin-bottom: 24px;
+  opacity: 0.7;
 `;
 
 export const HeaderCell = styled.div<{ $sections?: number }>(
   ({ theme, $sections }) => css`
     border: 1.23px solid ${theme.auth_page.header.cellBorderColor};
     border-radius: 75.98px;
+    background: ${theme.surface.panel};
+    box-shadow: ${theme.surface.shadow};
     ${$sections && `grid-column: span ${$sections};`}
   `
 );

--- a/frontend/src/components/AuthPage/SignIn/BasicSignIn/BasicSignIn.styled.tsx
+++ b/frontend/src/components/AuthPage/SignIn/BasicSignIn/BasicSignIn.styled.tsx
@@ -15,7 +15,7 @@ export const Form = styled.form`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 40px;
+  gap: 24px;
   width: 100%;
 
   ${Fieldset} div {
@@ -34,8 +34,9 @@ export const Field = styled.div`
 
 export const Label = styled.label`
   font-size: 12px;
-  font-weight: 500;
+  font-weight: 600;
   line-height: 16px;
+  color: ${({ theme }) => theme.surface.foregroundMuted};
 `;
 
 export const ErrorMessage = styled.div`

--- a/frontend/src/components/AuthPage/SignIn/SignIn.styled.tsx
+++ b/frontend/src/components/AuthPage/SignIn/SignIn.styled.tsx
@@ -5,15 +5,23 @@ export const SignInStyled = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: 320px;
-  gap: 56px;
+  width: min(380px, calc(100vw - 32px));
+  gap: 28px;
   flex-grow: 1;
+  margin: 24px 0 56px;
+  padding: 28px;
+  border: 1px solid ${({ theme }) => theme.surface.border};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.surface.panel};
+  box-shadow: ${({ theme }) => theme.surface.shadowLg};
 `;
 
 export const SignInTitle = styled.span(
   ({ theme }) => css`
     color: ${theme.auth_page.signIn.titleColor};
-    font-size: 24px;
-    font-weight: 600;
+    font-size: 28px;
+    line-height: 36px;
+    font-weight: 700;
+    letter-spacing: 0;
   `
 );

--- a/frontend/src/components/Dashboard/ClusterName.tsx
+++ b/frontend/src/components/Dashboard/ClusterName.tsx
@@ -3,19 +3,17 @@ import { CellContext } from '@tanstack/react-table';
 import { Tag } from 'components/common/Tag/Tag.styled';
 import { Cluster } from 'generated-sources';
 
+import * as S from './Dashboard.styled';
+
 type ClusterNameProps = CellContext<Cluster, unknown>;
 
 const ClusterName: React.FC<ClusterNameProps> = ({ row }) => {
   const { readOnly, name } = row.original;
   return (
-    <div style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>
-      {readOnly && (
-        <Tag color="blue" style={{ marginRight: '0.75em' }}>
-          readonly
-        </Tag>
-      )}
+    <S.ClusterNameCell>
+      {readOnly && <Tag color="blue">readonly</Tag>}
       {name}
-    </div>
+    </S.ClusterNameCell>
   );
 };
 

--- a/frontend/src/components/Dashboard/Dashboard.styled.ts
+++ b/frontend/src/components/Dashboard/Dashboard.styled.ts
@@ -1,9 +1,39 @@
 import styled from 'styled-components';
 
 export const Toolbar = styled.div`
-  padding: 8px 16px;
+  padding: 0 0 12px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   color: ${({ theme }) => theme.default.color.normal};
+`;
+
+export const FilterToggle = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 38px;
+  padding: 8px 10px;
+  border: 1px solid ${({ theme }) => theme.surface.border};
+  border-radius: 8px;
+  background: ${({ theme }) => theme.surface.panel};
+  box-shadow: ${({ theme }) => theme.surface.shadow};
+  color: ${({ theme }) => theme.surface.foregroundMuted};
+  font-weight: 500;
+
+  label {
+    cursor: pointer;
+  }
+`;
+
+export const ClusterNameCell = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  max-width: 100%;
+  white-space: normal;
+  word-break: break-word;
+  font-weight: 600;
+  color: ${({ theme }) => theme.surface.foreground};
 `;

--- a/frontend/src/components/Dashboard/Dashboard.tsx
+++ b/frontend/src/components/Dashboard/Dashboard.tsx
@@ -100,7 +100,18 @@ const Dashboard: React.FC = () => {
 
   return (
     <>
-      <PageHeading text="Dashboard" />
+      <PageHeading text="Clusters">
+        {appInfo.hasDynamicConfig && (
+          <ActionCanButton
+            buttonType="primary"
+            buttonSize="M"
+            to={clusterNewConfigPath}
+            canDoAction={hasPermissions}
+          >
+            Configure new cluster
+          </ActionCanButton>
+        )}
+      </PageHeading>
       <Metrics.Wrapper>
         <Metrics.Section>
           <Metrics.Indicator label={<Tag color="green">Online</Tag>}>
@@ -114,24 +125,14 @@ const Dashboard: React.FC = () => {
         </Metrics.Section>
       </Metrics.Wrapper>
       <S.Toolbar>
-        <div>
+        <S.FilterToggle>
           <Switch
             name="switchRoundedDefault"
             checked={showOfflineOnly}
             onChange={toggle}
           />
           <label>Only offline clusters</label>
-        </div>
-        {appInfo.hasDynamicConfig && (
-          <ActionCanButton
-            buttonType="primary"
-            buttonSize="M"
-            to={clusterNewConfigPath}
-            canDoAction={hasPermissions}
-          >
-            Configure new cluster
-          </ActionCanButton>
-        )}
+        </S.FilterToggle>
       </S.Toolbar>
       <Table
         onRowClick={onRowClick}

--- a/frontend/src/components/Nav/Menu/styled.ts
+++ b/frontend/src/components/Nav/Menu/styled.ts
@@ -14,17 +14,19 @@ export const MenuItem = styled('li').attrs({ role: 'menuitem' })<{
   ({ theme, $variant, $isActive }) => css`
     font-size: 14px;
     font-weight: ${theme.menu[$isActive ? 'primary' : $variant].fontWeight};
-    min-height: 28px;
+    min-height: ${$variant === 'primary' ? '36px' : '32px'};
     display: flex;
     align-items: center;
     justify-content: space-between;
     line-height: 17px;
     user-select: none;
     width: 100%;
-    padding: 4px 8px;
+    padding: ${$variant === 'primary' ? '7px 9px' : '6px 10px'};
     cursor: pointer;
     text-decoration: none;
-    border-radius: 8px;
+    border-radius: 7px;
+    border: 1px solid
+      ${$isActive ? theme.surface.selectedBorder : 'transparent'};
     background-color: ${$isActive
       ? theme.menu[$variant].backgroundColor.active
       : theme.menu[$variant].backgroundColor.normal};
@@ -35,6 +37,9 @@ export const MenuItem = styled('li').attrs({ role: 'menuitem' })<{
     &:hover {
       background-color: ${theme.menu[$variant].backgroundColor.hover};
       color: ${theme.menu[$variant].color.hover};
+      border-color: ${$isActive
+        ? theme.surface.selectedBorder
+        : theme.surface.border};
 
       ${ColorPickerWrapper} {
         position: absolute;
@@ -53,12 +58,17 @@ export const MenuItem = styled('li').attrs({ role: 'menuitem' })<{
 export const ContentWrapper = styled.div`
   display: flex;
   align-items: center;
-  column-gap: 4px;
+  column-gap: 8px;
   width: 100%;
+  min-width: 0;
 `;
 
 export const Title = styled.div`
   width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 `;
 
 export const StatusIconWrapper = styled.svg.attrs({
@@ -66,8 +76,9 @@ export const StatusIconWrapper = styled.svg.attrs({
   xmlns: 'http://www.w3.org/2000/svg',
 })`
   fill: none;
-  width: 6px;
-  height: 6px;
+  width: 8px;
+  height: 8px;
+  flex: 0 0 8px;
 `;
 
 export const StatusIcon = styled.circle.attrs({
@@ -97,7 +108,11 @@ export const ChevronClickArea = styled.div`
   cursor: pointer;
   padding: 4px 6px;
   margin: -4px -6px;
-  border-radius: 4px;
+  border-radius: 6px;
+
+  &:hover {
+    background: ${({ theme }) => theme.surface.muted};
+  }
 `;
 
 export const ChevronWrapper = styled.svg.attrs({

--- a/frontend/src/components/Nav/Nav.styled.ts
+++ b/frontend/src/components/Nav/Nav.styled.ts
@@ -2,21 +2,35 @@ import styled from 'styled-components';
 import { ClusterColorKey } from 'theme/theme';
 
 export const List = styled.ul.attrs({ role: 'menu' })`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 0;
+  padding: 0;
+
   & > & {
-    padding: 0 0 0 8px;
+    padding: 4px 0 2px 14px;
   }
 
   & * {
-    margin-bottom: 2px;
+    margin-bottom: 0;
   }
 `;
 
 export const ClusterList = styled.ul.attrs<{ $colorKey: ClusterColorKey }>({
   role: 'menu',
 })`
+  border: 1px solid
+    ${({ theme, $colorKey }) =>
+      $colorKey === 'transparent'
+        ? theme.surface.border
+        : theme.clusterMenu.backgroundColor[$colorKey]};
   border-radius: 8px;
-  padding: 2px 4px;
-  margin-bottom: 2px;
+  padding: 5px;
+  margin: 8px 0 0;
   background-color: ${({ theme, $colorKey }) =>
-    theme.clusterMenu.backgroundColor[$colorKey]};
+    $colorKey === 'transparent'
+      ? theme.surface.panel
+      : theme.clusterMenu.backgroundColor[$colorKey]};
+  box-shadow: ${({ theme }) => theme.surface.shadow};
 `;

--- a/frontend/src/components/NavBar/NavBar.styled.ts
+++ b/frontend/src/components/NavBar/NavBar.styled.ts
@@ -10,33 +10,44 @@ export const Navbar = styled.nav(
     align-items: center;
     justify-content: space-between;
     border-bottom: 1px solid ${theme.layout.stuffBorderColor};
+    box-shadow: ${theme.surface.shadow};
     position: fixed;
     top: 0;
     left: 0;
     right: 0;
     z-index: 30;
-    background-color: ${theme.menu.header.backgroundColor};
-    min-height: 3.25rem;
+    background-color: ${theme.surface.header};
+    min-height: ${theme.layout.navBarHeight};
+    padding: 0 18px;
+    backdrop-filter: blur(18px);
   `
 );
 
 export const NavbarBrand = styled.div`
   display: flex;
-  justify-content: flex-end;
-  align-items: center !important;
+  align-items: center;
+  gap: 10px;
   flex-shrink: 0;
-  min-height: 3.25rem;
-  padding-left: 8px;
+  min-height: ${({ theme }) => theme.layout.navBarHeight};
 `;
 
 export const SocialLink = styled.a(
   ({ theme: { icons } }) => css`
-    display: block;
-    margin-top: 5px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 6px;
     cursor: pointer;
     fill: ${icons.discord.normal};
+    transition:
+      background-color 120ms ease,
+      fill 120ms ease;
 
     &:hover {
+      background-color: ${({ theme }) => theme.surface.muted};
+
       ${DiscordIcon} {
         fill: ${icons.discord.hover};
       }
@@ -69,8 +80,15 @@ export const SocialLink = styled.a(
 export const NavbarSocial = styled.div`
   display: flex;
   align-items: center;
-  gap: 10px;
-  margin: 5px 10px 5px;
+  gap: 8px;
+
+  @media screen and (max-width: 768px) {
+    gap: 4px;
+
+    & > a {
+      display: none;
+    }
+  }
 `;
 
 export const NavbarItem = styled.div`
@@ -80,7 +98,11 @@ export const NavbarItem = styled.div`
   flex-shrink: 0;
   align-items: center;
   line-height: 1.5;
-  padding: 0.5rem 0.75rem;
+  padding: 0 0 0 4px;
+
+  @media screen and (max-width: 900px) {
+    display: none;
+  }
 `;
 
 export const Hyperlink = styled(Link)(
@@ -94,17 +116,20 @@ export const Hyperlink = styled(Link)(
     gap: 8px;
 
     margin: 0;
-    padding: 0.5rem 0.6rem;
+    padding: 0.35rem 0.45rem;
+    border-radius: 8px;
 
     font-family: Inter, sans-serif;
     font-style: normal;
-    font-weight: bold;
-    font-size: 22px;
-    line-height: 16px;
-    color: ${theme.default.color.normal};
+    font-weight: 700;
+    font-size: 18px;
+    line-height: 20px;
+    color: ${theme.surface.foreground};
+    letter-spacing: 0;
 
     &:hover {
-      color: ${theme.default.color.normal};
+      color: ${theme.surface.foreground};
+      background: ${theme.surface.muted};
     }
 
     text-decoration: none;

--- a/frontend/src/components/NavBar/NavBar.tsx
+++ b/frontend/src/components/NavBar/NavBar.tsx
@@ -58,20 +58,18 @@ const NavBar: React.FC<Props> = ({ onBurgerClick }) => {
   return (
     <S.Navbar role="navigation" aria-label="Page Header">
       <S.NavbarBrand>
-        <S.NavbarBrand>
-          <Button buttonType="text" buttonSize="S" onClick={onBurgerClick}>
-            <MenuIcon />
-          </Button>
+        <Button buttonType="text" buttonSize="S" onClick={onBurgerClick}>
+          <MenuIcon />
+        </Button>
 
-          <S.Hyperlink to="/">
-            <Logo />
-            kafbat UI
-          </S.Hyperlink>
+        <S.Hyperlink to="/">
+          <Logo />
+          kafbat UI
+        </S.Hyperlink>
 
-          <S.NavbarItem>
-            <Version />
-          </S.NavbarItem>
-        </S.NavbarBrand>
+        <S.NavbarItem>
+          <Version />
+        </S.NavbarItem>
       </S.NavbarBrand>
       <S.NavbarSocial>
         <UserTimezone />

--- a/frontend/src/components/PageContainer/PageContainer.styled.ts
+++ b/frontend/src/components/PageContainer/PageContainer.styled.ts
@@ -5,11 +5,13 @@ export const Container = styled.main<{ $isSidebarVisible: boolean }>(
     margin-top: ${theme.layout.navBarHeight};
     margin-left: ${$isSidebarVisible ? theme.layout.navBarWidth : 0};
     position: relative;
-    padding-bottom: 30px;
+    min-height: calc(100vh - ${theme.layout.navBarHeight});
+    padding: 20px 24px 40px;
     z-index: 20;
     max-width: calc(
       100vw - ${$isSidebarVisible ? theme.layout.navBarWidth : 0}
     );
+    background: ${theme.surface.canvas};
     transition: ${
       $isSidebarVisible
         ? 'max-width 0.75s ease-in-out'
@@ -20,6 +22,7 @@ export const Container = styled.main<{ $isSidebarVisible: boolean }>(
   @media screen and (max-width: 1024px) {
     margin-left: initial;
     max-width: 100vw;
+    padding: 16px;
   }
   `
 );
@@ -34,7 +37,7 @@ export const Sidebar = styled.div<{ $visible: boolean }>(
     top: ${theme.layout.navBarHeight};
     left: 0;
     bottom: 0;
-    padding: 16px;
+    padding: 14px 12px 18px;
     scrollbar-gutter: stable;
     scrollbar-width: thin;
     overflow-y: auto;
@@ -43,7 +46,8 @@ export const Sidebar = styled.div<{ $visible: boolean }>(
       opacity 0.25s,
       transform 0.25s,
       -webkit-transform 0.25s;
-    background: ${theme.default.backgroundColor};
+    background: ${theme.surface.sidebar};
+    box-shadow: ${theme.surface.shadow};
     transform: ${$visible ? 'translateX(0)' : 'translateX(-100%)'};
 
     @media screen and (max-width: 1024px) {
@@ -96,7 +100,7 @@ export const Overlay = styled.div<{ $visible: boolean }>(
         bottom: 0;
         right: 0;
         visibility: visible;
-        opacity: 0.7;
+        opacity: 0.55;
         background-color: ${theme.layout.overlay.backgroundColor};
       }
     `}

--- a/frontend/src/components/common/Button/Button.styled.ts
+++ b/frontend/src/components/common/Button/Button.styled.ts
@@ -10,10 +10,20 @@ const StyledButton = styled.button<ButtonProps>`
   flex-direction: row;
   align-items: center;
   justify-content: center;
-  padding: ${({ buttonSize }) => (buttonSize === 'S' ? '0 8px' : '0 12px')};
-  border: none;
-  border-radius: 4px;
+  gap: 6px;
+  padding: ${({ buttonSize }) => (buttonSize === 'S' ? '0 10px' : '0 14px')};
+  border: 1px solid
+    ${({ buttonType, theme }) =>
+      buttonType === 'secondary' ? theme.surface.borderStrong : 'transparent'};
+  border-radius: 6px;
   white-space: nowrap;
+  letter-spacing: 0;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    color 120ms ease,
+    transform 120ms ease;
 
   background: ${({ buttonType, theme }) =>
     theme.button[buttonType].backgroundColor.normal};
@@ -22,11 +32,17 @@ const StyledButton = styled.button<ButtonProps>`
   height: ${({ theme, buttonSize }) => theme.button.height[buttonSize]};
   font-size: ${({ theme, buttonSize }) => theme.button.fontSize[buttonSize]};
   font-weight: 500;
+  box-shadow: ${({ buttonType, theme }) =>
+    buttonType === 'primary' || buttonType === 'danger'
+      ? theme.surface.shadow
+      : 'none'};
 
   &:hover {
     background: ${({ buttonType, theme }) =>
       theme.button[buttonType].backgroundColor.hover};
     color: ${({ buttonType, theme }) => theme.button[buttonType].color.hover};
+    border-color: ${({ buttonType, theme }) =>
+      buttonType === 'secondary' ? theme.surface.borderStrong : 'transparent'};
     cursor: pointer;
   }
 
@@ -34,6 +50,12 @@ const StyledButton = styled.button<ButtonProps>`
     background: ${({ buttonType, theme }) =>
       theme.button[buttonType].backgroundColor.active};
     color: ${({ buttonType, theme }) => theme.button[buttonType].color.active};
+    transform: translateY(1px);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.surface.ring};
   }
 
   &:disabled {
@@ -50,7 +72,7 @@ const StyledButton = styled.button<ButtonProps>`
   }
 
   & svg {
-    margin-right: 4px;
+    flex: 0 0 auto;
     fill: ${({ theme, disabled, buttonType }) =>
       disabled
         ? theme.button[buttonType].color.disabled

--- a/frontend/src/components/common/ConfirmationModal/ConfirmationModal.styled.tsx
+++ b/frontend/src/components/common/ConfirmationModal/ConfirmationModal.styled.tsx
@@ -17,6 +17,7 @@ export const Wrapper = styled.div.attrs({ role: 'dialog' })`
 export const Overlay = styled.div(
   ({ theme: { modal } }) => css`
     background-color: ${modal.overlay};
+    backdrop-filter: blur(6px);
     bottom: 0;
     left: 0;
     position: absolute;
@@ -32,16 +33,18 @@ export const Modal = styled.div(
     flex-direction: column;
     width: 560px;
     border-radius: 8px;
+    border: 1px solid ${modal.border.contrast};
 
     background-color: ${confirmModal.backgroundColor};
-    filter: drop-shadow(0px 4px 16px ${modal.shadow});
+    box-shadow: ${({ theme }) => theme.surface.shadowLg};
   `
 );
 
 export const Header = styled.div`
   font-size: 20px;
+  font-weight: 700;
   text-align: start;
-  padding: 16px;
+  padding: 18px 20px;
   width: 100%;
   color: ${({ theme }) => theme.modal.color};
 `;
@@ -57,10 +60,10 @@ export const Content = styled.div(
 );
 
 export const Footer = styled.div`
-  height: 64px;
+  min-height: 68px;
   display: flex;
   justify-content: flex-end;
   gap: 10px;
-  padding: 16px;
+  padding: 16px 20px;
   width: 100%;
 `;

--- a/frontend/src/components/common/Dropdown/Dropdown.styled.ts
+++ b/frontend/src/components/common/Dropdown/Dropdown.styled.ts
@@ -21,9 +21,9 @@ export const Dropdown = styled(ControlledMenu)(
 
     ${menuSelector.name} {
       border: 1px solid ${dropdown.borderColor};
-      box-shadow: 0 4px 16px ${dropdown.shadow};
-      padding: 8px 4px;
-      border-radius: 4px;
+      box-shadow: 0 14px 36px ${dropdown.shadow};
+      padding: 6px;
+      border-radius: 8px;
       font-size: 14px;
       background-color: ${dropdown.backgroundColor};
       text-align: left;
@@ -42,8 +42,9 @@ export const Dropdown = styled(ControlledMenu)(
     }
 
     ${menuItemSelector.name} {
-      padding: 6px 16px;
+      padding: 8px 12px;
       min-width: 150px;
+      border-radius: 6px;
       background-color: ${dropdown.item.backgroundColor.default};
       white-space: nowrap;
     }
@@ -65,8 +66,13 @@ export const DropdownButton = styled.button`
   display: flex;
   cursor: pointer;
   align-self: center;
-  padding: 0;
+  padding: 4px;
   margin: 0 4px;
+  border-radius: 6px;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.surface.muted};
+  }
 
   &:disabled {
     opacity: 0.5;
@@ -75,10 +81,10 @@ export const DropdownButton = styled.button`
 `;
 
 export const SmallButton = styled.div`
-  padding: 4px;
+  padding: 5px;
   margin: 0;
-  min-width: 24px;
-  border-radius: 5px;
+  min-width: 28px;
+  border-radius: 6px;
   display: flex;
   justify-content: center;
 

--- a/frontend/src/components/common/Input/Input.styled.ts
+++ b/frontend/src/components/common/Input/Input.styled.ts
@@ -13,6 +13,7 @@ const INPUT_SIZES = {
 
 export const Wrapper = styled.div`
   position: relative;
+
   &:hover {
     svg:first-child {
       fill: ${({ theme }) => theme.input.icon.hover};
@@ -45,14 +46,20 @@ export const Input = styled.input<InputProps>(
   ({ theme: { input }, inputSize, search }) => css`
     background-color: ${input.backgroundColor.normal};
     border: 1px ${input.borderColor.normal} solid;
-    border-radius: 4px;
+    border-radius: 6px;
     color: ${input.color.normal};
     height: ${inputSize && INPUT_SIZES[inputSize]
       ? INPUT_SIZES[inputSize]
       : '40px'};
     width: 100%;
+    padding: 0 12px;
     padding-left: ${search ? '36px' : '12px'};
     font-size: 14px;
+    box-shadow: ${({ theme }) => theme.surface.shadow};
+    transition:
+      border-color 120ms ease,
+      box-shadow 120ms ease,
+      background-color 120ms ease;
 
     &::placeholder {
       color: ${input.color.placeholder.normal};
@@ -64,6 +71,7 @@ export const Input = styled.input<InputProps>(
     &:focus {
       outline: none;
       border-color: ${input.borderColor.focus};
+      box-shadow: 0 0 0 3px ${({ theme }) => theme.surface.ring};
       &::placeholder {
         color: transparent;
       }

--- a/frontend/src/components/common/Metrics/Metrics.styled.tsx
+++ b/frontend/src/components/common/Metrics/Metrics.styled.tsx
@@ -1,51 +1,60 @@
 import styled, { css } from 'styled-components';
 
 export const Wrapper = styled.div`
-  padding: 1.5rem 1rem;
-  background: ${({ theme }) => theme.metrics.backgroundColor};
-  margin-bottom: 0.5rem !important;
+  padding: 0;
+  background: transparent;
+  margin-bottom: 16px !important;
   display: flex;
-  gap: 16px;
+  gap: 12px;
   flex-wrap: wrap;
 `;
 
 export const IndicatorWrapper = styled.div`
-  background-color: ${({ theme }) => theme.default.backgroundColor};
-  height: 68px;
+  background-color: ${({ theme }) => theme.surface.panel};
+  border: 1px solid ${({ theme }) => theme.surface.border};
+  border-radius: 8px;
+  height: 82px;
   width: fit-content;
-  min-width: 150px;
+  min-width: 168px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: flex-start;
-  padding: 12px 16px;
-  box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.08);
+  padding: 14px 16px;
+  box-shadow: ${({ theme }) => theme.surface.shadow};
   flex-grow: 1;
   color: ${({ theme }) => theme.default.color.normal};
+
+  & > div > span {
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 30px;
+    letter-spacing: 0;
+  }
 `;
 
 export const IndicatorTitle = styled.div`
-  font-weight: 500;
+  font-weight: 600;
   font-size: 12px;
   color: ${({ theme }) => theme.metrics.indicator.titleColor};
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
+  margin-bottom: 8px;
 `;
 
 export const IndicatorsWrapper = styled.div`
   display: flex;
-  gap: 2px;
+  gap: 12px;
   flex-wrap: wrap;
   border-radius: 8px;
-  overflow: auto;
-  box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.08);
+  overflow: visible;
   color: ${({ theme }) => theme.metrics.wrapper};
 `;
 
 export const SectionTitle = styled.h5`
   font-weight: 500;
-  margin: 0 0 0.5rem 16px;
+  margin: 0 0 0.5rem;
   font-size: 100%;
   color: ${({ theme }) => theme.metrics.sectionTitle};
 `;

--- a/frontend/src/components/common/Modal/Modal.styled.tsx
+++ b/frontend/src/components/common/Modal/Modal.styled.tsx
@@ -7,6 +7,7 @@ export const ModalOverlay = styled.div`
   right: 0;
   bottom: 0;
   background-color: ${({ theme }) => theme.modal.overlay};
+  backdrop-filter: blur(6px);
   display: flex;
   align-items: center;
   justify-content: center;
@@ -27,7 +28,7 @@ export const ModalContent = styled.div<{
     overflow: auto;
     position: relative;
     border: 1px solid ${modal.border.contrast};
-    box-shadow: 0 4px 20px ${modal.shadow};
+    box-shadow: ${({ theme }) => theme.surface.shadowLg};
   `
 );
 

--- a/frontend/src/components/common/MultiSelect/MultiSelect.styled.ts
+++ b/frontend/src/components/common/MultiSelect/MultiSelect.styled.ts
@@ -149,8 +149,19 @@ const MultiSelect = styled(ReactMultiSelect)<{
     background-color: ${({ theme }) =>
       theme.input.backgroundColor.normal} !important;
     border-color: ${({ theme }) => theme.select.borderColor.normal} !important;
+    border-radius: 6px !important;
+    box-shadow: ${({ theme }) => theme.surface.shadow};
+    transition:
+      border-color 120ms ease,
+      box-shadow 120ms ease;
     &:hover {
       border-color: ${({ theme }) => theme.select.borderColor.hover} !important;
+    }
+
+    &:focus-within {
+      border-color: ${({ theme }) =>
+        theme.select.borderColor.active} !important;
+      box-shadow: 0 0 0 3px ${({ theme }) => theme.surface.ring};
     }
 
     height: ${({ height }) => height ?? '32px'};

--- a/frontend/src/components/common/NewTable/Table.styled.ts
+++ b/frontend/src/components/common/NewTable/Table.styled.ts
@@ -76,6 +76,7 @@ export const TableHeaderContent = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 8px;
 `;
 
 export const ColumnResizer = styled.div<{ $isResizing?: boolean }>`
@@ -88,9 +89,9 @@ export const ColumnResizer = styled.div<{ $isResizing?: boolean }>`
     return css`
       opacity: ${$isResizing ? 1 : 0};
       position: absolute;
-      top: 4px;
+      top: 10px;
       right: 0;
-      height: calc(100% - 8px);
+      height: calc(100% - 20px);
       width: 4px;
       border-radius: 2px;
       background-color: ${resizer.background.normal};
@@ -114,16 +115,16 @@ export const Th = styled.th<ThProps>(
     sortOrder,
     expander,
   }) => `
-  padding: 8px 0 8px 24px;
-  border-bottom-width: 1px;
+  padding: 12px 16px;
+  border-bottom: 1px solid ${th.backgroundColor.normal};
   vertical-align: middle;
   text-align: left;
   font-family: Inter, sans-serif;
   font-size: 12px;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 600;
   line-height: 16px;
-  letter-spacing: 0em;
+  letter-spacing: 0;
   text-align: left;
   background: ${th.backgroundColor.normal};
   width: ${expander ? '5px' : 'auto'};
@@ -156,6 +157,8 @@ export const Row = styled.tr<RowProps>(
     background-color: ${table.tr.backgroundColor[
       expanded ? 'hover' : 'normal'
     ]};
+    transition: background-color 120ms ease;
+
     & .show-on-hover {
       visibility: hidden;
     }
@@ -170,10 +173,11 @@ export const Row = styled.tr<RowProps>(
 );
 
 export const ExpandedRowInfo = styled.div`
-  background-color: ${({ theme }) => theme.table.tr.backgroundColor.normal};
-  padding: 24px;
+  background-color: ${({ theme }) => theme.surface.panelAlt};
+  border: 1px solid ${({ theme }) => theme.surface.border};
+  padding: 20px;
   border-radius: 8px;
-  margin: 0 8px 8px 0;
+  margin: 0 8px 12px;
 `;
 
 export const Nowrap = styled.div`
@@ -181,22 +185,27 @@ export const Nowrap = styled.div`
 `;
 
 export const TableActionsBar = styled.div`
-  padding: 8px;
+  padding: 12px;
   background-color: ${({ theme }) => theme.table.actionBar.backgroundColor};
-  margin: 16px 0;
+  border: 1px solid ${({ theme }) => theme.surface.border};
+  border-radius: 8px;
+  margin: 0 0 12px;
   display: flex;
   gap: 8px;
+  box-shadow: ${({ theme }) => theme.surface.shadow};
 `;
 
 export const Table = styled.table(
   ({ theme: { table } }) => `
   width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
 
   td {
     border-top: 1px ${table.td.borderTop} solid;
     font-size: 14px;
     font-weight: 400;
-    padding: 8px 8px 8px 24px;
+    padding: 12px 16px;
     color: ${table.td.color.normal};
     vertical-align: middle;
     word-wrap: break-word;
@@ -227,15 +236,23 @@ export const Table = styled.table(
 );
 
 export const EmptyTableMessageCell = styled.td`
-  padding: 16px;
+  padding: 32px;
   text-align: center;
+  color: ${({ theme }) => theme.surface.foregroundMuted};
 `;
 
 export const Pagination = styled.div`
   display: flex;
   justify-content: space-between;
-  padding: 16px;
+  align-items: center;
+  padding: 14px 4px 0;
   line-height: 32px;
+  gap: 12px;
+
+  @media screen and (max-width: 768px) {
+    align-items: stretch;
+    flex-direction: column;
+  }
 `;
 
 export const Pages = styled.div`
@@ -244,6 +261,10 @@ export const Pages = styled.div`
   white-space: nowrap;
   flex-wrap: nowrap;
   gap: 8px;
+
+  @media screen and (max-width: 768px) {
+    flex-wrap: wrap;
+  }
 `;
 
 export const GoToPage = styled.label`
@@ -274,10 +295,14 @@ export const Ellipsis = styled.div`
 `;
 
 export const TableWrapper = styled.div<{ $disabled: boolean }>(
-  ({ $disabled }) => css`
-    overflow: clip;
+  ({ theme, $disabled }) => css`
+    overflow: hidden;
     overflow-x: auto;
     overflow-y: visible;
+    background: ${theme.surface.panel};
+    border: 1px solid ${theme.surface.border};
+    border-radius: 8px;
+    box-shadow: ${theme.surface.shadow};
     ${$disabled &&
     css`
       pointer-events: none;

--- a/frontend/src/components/common/PageHeading/PageHeading.styled.ts
+++ b/frontend/src/components/common/PageHeading/PageHeading.styled.ts
@@ -3,7 +3,8 @@ import { NavLink } from 'react-router-dom';
 
 export const Breadcrumbs = styled.div`
   display: flex;
-  align-items: baseline;
+  align-items: center;
+  min-width: 0;
 `;
 
 export const BackLink = styled(NavLink)`
@@ -26,30 +27,49 @@ export const BackLink = styled(NavLink)`
 `;
 
 export const Wrapper = styled.div`
-  padding: 16px;
+  padding: 4px 0 18px;
 `;
 
 export const Content = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-end;
+  gap: 16px;
 
   & > div {
     display: flex;
-    gap: 16px;
+    gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
   }
 
   & > ${Breadcrumbs} {
     gap: 20px;
   }
+
+  h1 {
+    font-size: 28px;
+    line-height: 36px;
+    font-weight: 700;
+    letter-spacing: 0;
+    color: ${({ theme }) => theme.surface.foreground};
+  }
+
+  @media screen and (max-width: 768px) {
+    align-items: stretch;
+    flex-direction: column;
+  }
 `;
 
 export const Title = styled.div`
   color: ${({ theme }) => theme.pageHeading.title.color};
-  font-weight: 500;
-  line-height: 8px;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 18px;
+  letter-spacing: 0;
+  margin-bottom: 2px;
+
   & + ${Content} h1 {
-    padding-top: 8px;
-    line-height: 24px;
+    line-height: 34px;
   }
 `;

--- a/frontend/src/components/common/Select/Select.styled.ts
+++ b/frontend/src/components/common/Select/Select.styled.ts
@@ -32,16 +32,26 @@ export const Select = styled.ul<Props>`
       return theme.select.borderColor.normal;
     }}
     solid;
-  border-radius: 4px;
+  border-radius: 6px;
   font-size: 14px;
   width: fit-content;
   padding-left: 16px;
   padding-right: 12px;
+  background: ${({ theme, isThemeMode }) =>
+    isThemeMode ? 'transparent' : theme.select.backgroundColor.normal};
   color: ${({ theme, disabled }) =>
     disabled ? theme.select.color.disabled : theme.select.color.normal};
   min-width: ${({ minWidth }) => minWidth || 'auto'};
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    color 120ms ease;
+
   &:hover {
+    background: ${({ theme, isThemeMode }) =>
+      isThemeMode ? theme.surface.muted : theme.select.backgroundColor.hover};
     color: ${({ theme, disabled }) =>
       disabled ? theme.select.color.disabled : theme.select.color.hover};
     border-color: ${({ theme, disabled }) =>
@@ -53,6 +63,7 @@ export const Select = styled.ul<Props>`
     outline: none;
     color: ${({ theme }) => theme.select.color.active};
     border-color: ${({ theme }) => theme.select.borderColor.active};
+    box-shadow: 0 0 0 3px ${({ theme }) => theme.surface.ring};
   }
   &:disabled {
     color: ${({ theme }) => theme.select.color.disabled};
@@ -76,7 +87,8 @@ export const OptionList = styled.ul`
   margin-top: 4px;
   background-color: ${({ theme }) => theme.select.backgroundColor.normal};
   border: 1px ${({ theme }) => theme.select.optionList.borderColor} solid;
-  border-radius: 4px;
+  border-radius: 8px;
+  box-shadow: ${({ theme }) => theme.surface.shadowLg};
   font-size: 14px;
   line-height: 18px;
   color: ${({ theme }) => theme.select.color.normal};
@@ -109,7 +121,9 @@ export const Option = styled.li<OptionProps>`
   align-items: center;
   list-style: none;
   padding: 10px 12px;
-  transition: all 0.2s ease-in-out;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
   gap: 5px;
   color: ${({ theme, disabled }) =>
@@ -134,6 +148,7 @@ export const SelectedOption = styled.li<{ isThemeMode?: boolean }>`
   padding-right: ${({ isThemeMode }) => (isThemeMode ? '' : '16px')};
   list-style-position: inside;
   white-space: nowrap;
+  align-items: center;
   & svg {
     path {
       fill: ${({ theme }) => theme.defaultIconColor};

--- a/frontend/src/components/common/Switch/Switch.styled.ts
+++ b/frontend/src/components/common/Switch/Switch.styled.ts
@@ -7,8 +7,8 @@ interface Props {
 export const StyledLabel = styled.label`
   position: relative;
   display: inline-block;
-  width: 34px;
-  height: 20px;
+  width: 40px;
+  height: 22px;
   margin-right: 8px;
 `;
 export const CheckedIcon = styled.span`
@@ -36,6 +36,7 @@ export const StyledSlider = styled.span<Props>`
     checked ? theme.switch.checked : theme.switch.unchecked};
   transition: 0.4s;
   border-radius: 20px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.04);
 
   &:hover {
     background-color: ${({ theme }) => theme.switch.hover};
@@ -44,14 +45,15 @@ export const StyledSlider = styled.span<Props>`
   &::before {
     position: absolute;
     content: '';
-    height: 14px;
-    width: 14px;
-    left: ${({ checked }) => (checked ? '17px' : '3px')};
+    height: 16px;
+    width: 16px;
+    left: ${({ checked }) => (checked ? '21px' : '3px')};
     bottom: 3px;
     background-color: ${({ theme }) => theme.switch.circle};
     transition: 0.4s;
     border-radius: 50%;
     z-index: 11;
+    box-shadow: ${({ theme }) => theme.surface.shadow};
   }
 `;
 

--- a/frontend/src/components/common/Tag/Tag.styled.tsx
+++ b/frontend/src/components/common/Tag/Tag.styled.tsx
@@ -6,16 +6,17 @@ interface Props {
 }
 
 export const Tag = styled.span.attrs({ role: 'widget' })<Props>`
-  border: none;
-  border-radius: 16px;
-  height: 20px;
+  border: 1px solid ${({ theme }) => theme.surface.border};
+  border-radius: 6px;
+  min-height: 22px;
   line-height: 20px;
   background-color: ${({ theme, color }) => theme.tag.backgroundColor[color]};
   color: ${({ theme }) => theme.tag.color};
   font-size: 12px;
-  display: inline-block;
-  padding-left: 0.75em;
-  padding-right: 0.75em;
+  font-weight: 500;
+  display: inline-flex;
+  align-items: center;
+  padding: 0 0.55rem;
   text-align: center;
   width: max-content;
   margin: 2px 0;
@@ -23,13 +24,14 @@ export const Tag = styled.span.attrs({ role: 'widget' })<Props>`
 `;
 
 export const MultiLineTag = styled.div.attrs({ role: 'widget' })<Props>`
-  border: none;
-  border-radius: 16px;
+  border: 1px solid ${({ theme }) => theme.surface.border};
+  border-radius: 6px;
   height: fit-content;
   line-height: 20px;
   background-color: ${({ theme, color }) => theme.tag.backgroundColor[color]};
   color: ${({ theme }) => theme.tag.color};
   font-size: 12px;
+  font-weight: 500;
   display: inline-block;
   padding-left: 0.75em;
   padding-right: 0.75em;
@@ -40,8 +42,8 @@ export const MultiLineTag = styled.div.attrs({ role: 'widget' })<Props>`
 `;
 
 export const MultiLineChipTag = styled.div`
-  border: none;
-  border-radius: 16px;
+  border: 1px solid ${({ theme }) => theme.surface.border};
+  border-radius: 6px;
   height: fit-content;
   line-height: 20px;
   background-color: ${({ theme }) => theme.chips.backgroundColor.normal};

--- a/frontend/src/components/common/Textbox/Textarea.styled.ts
+++ b/frontend/src/components/common/Textbox/Textarea.styled.ts
@@ -3,12 +3,18 @@ import styled, { css } from 'styled-components';
 export const Textarea = styled.textarea(
   ({ theme: { textArea } }) => css`
     border: 1px ${textArea.borderColor.normal} solid;
-    border-radius: 4px;
+    border-radius: 6px;
     width: 100%;
     padding: 12px;
     padding-top: 6px;
     color: ${({ theme }) => theme.default.color.normal};
     background-color: ${({ theme }) => theme.schema.backgroundColor.textarea};
+    box-shadow: ${({ theme }) => theme.surface.shadow};
+    transition:
+      border-color 120ms ease,
+      box-shadow 120ms ease,
+      background-color 120ms ease;
+
     &::placeholder {
       color: ${textArea.color.placeholder.normal};
       font-size: 14px;
@@ -19,6 +25,7 @@ export const Textarea = styled.textarea(
     &:focus {
       outline: none;
       border-color: ${textArea.borderColor.focus};
+      box-shadow: 0 0 0 3px ${({ theme }) => theme.surface.ring};
       &::placeholder {
         color: ${textArea.color.placeholder.normal};
       }

--- a/frontend/src/components/common/table/Table/Table.styled.ts
+++ b/frontend/src/components/common/table/Table/Table.styled.ts
@@ -6,12 +6,19 @@ interface Props {
 
 export const Table = styled.table<Props>`
   width: ${(props) => (props.isFullwidth ? '100%' : 'auto')};
+  background: ${({ theme }) => theme.surface.panel};
+  border: 1px solid ${({ theme }) => theme.surface.border};
+  border-radius: 8px;
+  border-collapse: separate;
+  border-spacing: 0;
+  overflow: hidden;
+  box-shadow: ${({ theme }) => theme.surface.shadow};
 
   & td {
     border-top: 1px ${({ theme }) => theme.table.td.borderTop} solid;
     font-size: 14px;
     font-weight: 400;
-    padding: 8px 8px 8px 24px;
+    padding: 12px 16px;
     color: ${({ theme }) => theme.table.td.color.normal};
     vertical-align: middle;
     max-width: 350px;

--- a/frontend/src/components/common/table/TableHeaderCell/TableHeaderCell.styled.ts
+++ b/frontend/src/components/common/table/TableHeaderCell/TableHeaderCell.styled.ts
@@ -72,7 +72,7 @@ export const Title = styled.span<TitleProps>(
     font-family: Inter, sans-serif;
     font-size: 12px;
     font-style: normal;
-    font-weight: 400;
+    font-weight: 600;
     line-height: 16px;
     letter-spacing: 0;
     text-align: left;
@@ -106,8 +106,9 @@ export const Preview = styled.span`
 `;
 
 export const TableHeaderCell = styled.th`
-  padding: 4px 0 4px 24px;
-  border-bottom-width: 1px;
+  padding: 12px 16px;
+  border-bottom: 1px solid ${({ theme }) => theme.surface.border};
   vertical-align: middle;
   text-align: left;
+  background: ${({ theme }) => theme.table.th.backgroundColor.normal};
 `;

--- a/frontend/src/components/common/table/TableTitle/TableTitle.styled.tsx
+++ b/frontend/src/components/common/table/TableTitle/TableTitle.styled.tsx
@@ -5,5 +5,6 @@ import styled from 'styled-components';
 const Heading3 = (props: PropsWithChildren) => <Heading level={3} {...props} />;
 
 export const TableTitle = styled(Heading3)`
-  padding: 16px 16px 0;
+  padding: 0 0 12px;
+  color: ${({ theme }) => theme.surface.foreground};
 `;

--- a/frontend/src/components/globalCss.ts
+++ b/frontend/src/components/globalCss.ts
@@ -7,7 +7,7 @@ export default createGlobalStyle(
       font-size: 14px;
       -webkit-font-smoothing: antialiased;
       -moz-osx-font-smoothing: grayscale;
-      background-color: ${theme.default.backgroundColor};
+      background-color: ${theme.surface.canvas};
       overflow-x: hidden;
       overflow-y: scroll;
       text-rendering: optimizeLegibility;
@@ -45,6 +45,32 @@ export default createGlobalStyle(
       font-family: inherit;
     }
 
+    body {
+      min-height: 100vh;
+      color: ${theme.surface.foreground};
+      background:
+        linear-gradient(180deg, ${theme.surface.panelAlt} 0, transparent 260px),
+        ${theme.surface.canvas};
+    }
+
+    #root {
+      min-height: 100vh;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    *:focus-visible {
+      outline: 2px solid ${theme.surface.ring};
+      outline-offset: 2px;
+    }
+
+    ::selection {
+      background: ${theme.surface.accentMuted};
+      color: ${theme.surface.foreground};
+    }
+
     code,
     pre {
       font-family: 'Roboto Mono', sans-serif;
@@ -75,6 +101,10 @@ export default createGlobalStyle(
       color: ${theme.link.color};
       cursor: pointer;
       text-decoration: none;
+      transition:
+        color 120ms ease,
+        background-color 120ms ease,
+        border-color 120ms ease;
       &:hover {
         color: ${theme.link.hoverColor};
       }

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -210,18 +210,40 @@ const baseTheme = {
   },
   layout: {
     minWidth: '1200px',
-    navBarWidth: '240px',
-    navBarHeight: '51px',
+    navBarWidth: '264px',
+    navBarHeight: '64px',
     rightSidebarWidth: '70vw',
     filtersSidebarWidth: '300px',
 
-    mainBackgroundColor: Colors.brand[0],
+    mainBackgroundColor: '#F6F7F9',
     stuffColor: Colors.neutral[5],
-    stuffBorderColor: Colors.neutral[10],
+    stuffBorderColor: '#E4E7EC',
     overlay: {
       backgroundColor: Colors.neutral[50],
     },
     socialLink: Colors.neutral[20],
+  },
+  surface: {
+    canvas: '#F6F7F9',
+    panel: Colors.neutral[0],
+    panelAlt: '#FBFCFD',
+    sidebar: '#FBFCFD',
+    header: hexToRgba(Colors.neutral[0], 0.92),
+    border: '#E4E7EC',
+    borderStrong: '#CED4DA',
+    muted: '#F1F3F5',
+    mutedHover: '#E9ECEF',
+    selected: '#EDF7F4',
+    selectedBorder: '#9AD8CC',
+    accent: '#0F766E',
+    accentMuted: '#DDF7F1',
+    accentText: '#115E59',
+    foreground: '#111827',
+    foregroundMuted: '#667085',
+    foregroundSubtle: '#98A2B3',
+    shadow: '0 1px 2px rgba(16, 24, 40, 0.06)',
+    shadowLg: '0 16px 40px rgba(16, 24, 40, 0.12)',
+    ring: hexToRgba('#0F766E', 0.28),
   },
   alert: {
     color: {
@@ -339,20 +361,20 @@ const baseTheme = {
   },
   tag: {
     backgroundColor: {
-      green: Colors.green[10],
-      gray: Colors.neutral[5],
-      yellow: Colors.yellow[10],
-      white: Colors.neutral[10],
-      red: Colors.red[10],
-      blue: Colors.blue[10],
-      secondary: Colors.neutral[15],
+      green: '#DCFCE7',
+      gray: '#F2F4F7',
+      yellow: '#FEF3C7',
+      white: Colors.neutral[0],
+      red: '#FEE2E2',
+      blue: '#DBEAFE',
+      secondary: '#E9ECEF',
     },
-    color: Colors.neutral[90],
+    color: '#344054',
   },
   switch: {
-    unchecked: Colors.brand[30],
-    hover: Colors.neutral[40],
-    checked: Colors.brand[90],
+    unchecked: '#D0D5DD',
+    hover: '#98A2B3',
+    checked: '#0F766E',
     circle: Colors.neutral[0],
     disabled: Colors.brand[10],
     checkedIcon: {
@@ -439,7 +461,7 @@ export const theme = {
     },
   },
   logo: {
-    color: Colors.brand[90],
+    color: '#0F766E',
   },
   version: {
     currentVersion: {
@@ -451,9 +473,9 @@ export const theme = {
   },
   default: {
     color: {
-      normal: Colors.neutral[90],
+      normal: '#111827',
     },
-    backgroundColor: Colors.brand[0],
+    backgroundColor: '#F6F7F9',
     transparentColor: 'transparent',
   },
   link: {
@@ -465,18 +487,18 @@ export const theme = {
     hoverColor: Colors.brand[50],
   },
   hr: {
-    backgroundColor: Colors.neutral[5],
+    backgroundColor: '#E4E7EC',
   },
   pageHeading: {
-    height: '64px',
-    dividerColor: Colors.neutral[30],
+    height: '72px',
+    dividerColor: '#D0D5DD',
     title: {
-      color: Colors.brand[50],
+      color: '#667085',
     },
     backLink: {
       color: {
-        normal: Colors.brand[70],
-        hover: Colors.brand[60],
+        normal: '#475467',
+        hover: '#0F766E',
       },
     },
   },
@@ -484,23 +506,23 @@ export const theme = {
     borderTop: 'none',
   },
   dropdown: {
-    backgroundColor: Colors.brand[0],
-    borderColor: Colors.brand[10],
-    shadow: Colors.transparency[20],
+    backgroundColor: Colors.neutral[0],
+    borderColor: '#E4E7EC',
+    shadow: 'rgba(16, 24, 40, 0.16)',
     item: {
       color: {
-        normal: Colors.neutral[90],
-        danger: Colors.red[60],
+        normal: '#111827',
+        danger: '#B42318',
       },
       backgroundColor: {
         default: Colors.neutral[0],
-        hover: Colors.neutral[5],
+        hover: '#F6F7F9',
       },
     },
     button: {
       backgroundColor: {
         default: 'transparent',
-        hover: Colors.neutral[20],
+        hover: '#EEF2F6',
       },
     },
   },
@@ -529,10 +551,10 @@ export const theme = {
   button: {
     primary: {
       backgroundColor: {
-        normal: Colors.brand[80],
-        hover: Colors.brand[90],
-        active: Colors.brand[70],
-        disabled: Colors.brand[50],
+        normal: '#111827',
+        hover: '#1F2937',
+        active: '#030712',
+        disabled: '#98A2B3',
       },
       color: {
         normal: Colors.brand[0],
@@ -543,24 +565,24 @@ export const theme = {
     },
     secondary: {
       backgroundColor: {
-        normal: Colors.brand[5],
-        hover: Colors.brand[10],
-        active: Colors.brand[15],
-        disabled: Colors.brand[5],
+        normal: Colors.neutral[0],
+        hover: '#F6F7F9',
+        active: '#EEF2F6',
+        disabled: '#F2F4F7',
       },
       color: {
-        normal: Colors.brand[90],
-        hover: Colors.brand[90],
-        active: Colors.brand[90],
-        disabled: Colors.brand[30],
+        normal: '#344054',
+        hover: '#111827',
+        active: '#111827',
+        disabled: '#98A2B3',
       },
     },
     danger: {
       backgroundColor: {
-        normal: Colors.red[50],
-        hover: Colors.red[55],
-        active: Colors.red[60],
-        disabled: Colors.red[20],
+        normal: '#D92D20',
+        hover: '#B42318',
+        active: '#912018',
+        disabled: '#FCA5A5',
       },
       color: {
         normal: Colors.brand[0],
@@ -571,22 +593,22 @@ export const theme = {
     },
     text: {
       backgroundColor: {
-        normal: Colors.brand[0],
-        hover: Colors.brand[0],
-        active: Colors.brand[0],
-        disabled: Colors.brand[0],
+        normal: 'transparent',
+        hover: '#F2F4F7',
+        active: '#EAECF0',
+        disabled: 'transparent',
       },
       color: {
-        normal: Colors.brand[70],
-        hover: Colors.brand[90],
-        active: Colors.brand[50],
-        disabled: Colors.brand[40],
+        normal: '#475467',
+        hover: '#111827',
+        active: '#0F766E',
+        disabled: '#98A2B3',
       },
     },
     height: {
-      S: '24px',
-      M: '32px',
-      L: '40px',
+      S: '28px',
+      M: '36px',
+      L: '44px',
     },
     fontSize: {
       S: '14px',
@@ -610,39 +632,39 @@ export const theme = {
   },
   menu: {
     header: {
-      backgroundColor: Colors.brand[0],
+      backgroundColor: hexToRgba(Colors.neutral[0], 0.9),
     },
     primary: {
       backgroundColor: {
         normal: 'transparent',
-        hover: 'transparent',
-        active: 'transparent',
+        hover: '#F2F4F7',
+        active: '#EDF7F4',
       },
       color: {
-        normal: Colors.neutral[50],
-        hover: Colors.neutral[90],
-        active: Colors.neutral[95],
+        normal: '#475467',
+        hover: '#111827',
+        active: '#0F766E',
       },
       statusIconColor: {
         online: Colors.green[40],
         offline: Colors.red[50],
         initializing: Colors.yellow[20],
       },
-      chevronIconColor: hexToRgba(Colors.brand[95], 0.5),
-      fontWeight: 500,
+      chevronIconColor: '#98A2B3',
+      fontWeight: 600,
     },
     secondary: {
       backgroundColor: {
         normal: hexToRgba(Colors.brand[95], 0),
-        hover: hexToRgba(Colors.brand[95], 0.03),
-        active: hexToRgba(Colors.brand[95], 0.05),
+        hover: '#F6F7F9',
+        active: '#EDF7F4',
       },
       color: {
-        normal: Colors.brand[50],
-        hover: Colors.brand[90],
-        active: Colors.brand[90],
+        normal: '#667085',
+        hover: '#111827',
+        active: '#0F766E',
       },
-      fontWeight: 400,
+      fontWeight: 500,
     },
   },
   clusterMenu: {
@@ -677,35 +699,35 @@ export const theme = {
     },
     th: {
       backgroundColor: {
-        normal: Colors.neutral[0],
+        normal: '#F8FAFC',
       },
       color: {
-        sortable: Colors.neutral[30],
-        normal: Colors.neutral[60],
-        hover: Colors.brand[50],
-        active: Colors.brand[50],
+        sortable: '#98A2B3',
+        normal: '#667085',
+        hover: '#111827',
+        active: '#0F766E',
       },
       previewColor: {
-        normal: Colors.brand[50],
+        normal: '#0F766E',
       },
     },
     td: {
-      borderTop: Colors.neutral[5],
+      borderTop: '#EEF2F6',
       color: {
-        normal: Colors.neutral[90],
+        normal: '#111827',
       },
     },
     tr: {
       backgroundColor: {
         normal: Colors.neutral[0],
-        hover: Colors.neutral[5],
+        hover: '#F8FAFC',
       },
     },
     link: {
       color: {
-        normal: Colors.neutral[90],
-        hover: Colors.neutral[50],
-        active: Colors.neutral[90],
+        normal: '#111827',
+        hover: '#0F766E',
+        active: '#134E4A',
       },
     },
     colored: {
@@ -715,17 +737,17 @@ export const theme = {
       },
     },
     expander: {
-      normal: Colors.brand[30],
-      hover: Colors.brand[40],
-      active: Colors.brand[50],
-      disabled: Colors.neutral[10],
+      normal: '#98A2B3',
+      hover: '#0F766E',
+      active: '#134E4A',
+      disabled: '#D0D5DD',
     },
     pagination: {
       button: {
-        background: Colors.neutral[90],
-        border: Colors.neutral[80],
+        background: Colors.neutral[0],
+        border: '#D0D5DD',
       },
-      info: Colors.neutral[90],
+      info: '#475467',
     },
     filter: {
       multiSelect: {
@@ -744,9 +766,9 @@ export const theme = {
     },
     resizer: {
       background: {
-        normal: Colors.neutral[30],
-        active: Colors.neutral[90],
-        hover: Colors.neutral[90],
+        normal: '#D0D5DD',
+        active: '#0F766E',
+        hover: '#0F766E',
       },
     },
   },
@@ -778,25 +800,25 @@ export const theme = {
   select: {
     backgroundColor: {
       normal: Colors.neutral[0],
-      hover: Colors.neutral[5],
-      active: Colors.neutral[10],
+      hover: '#F8FAFC',
+      active: '#EEF2F6',
     },
     color: {
-      normal: Colors.neutral[70],
-      hover: Colors.neutral[90],
-      active: Colors.neutral[90],
-      disabled: Colors.neutral[30],
+      normal: '#344054',
+      hover: '#111827',
+      active: '#111827',
+      disabled: '#98A2B3',
     },
     borderColor: {
-      normal: Colors.neutral[30],
-      hover: Colors.neutral[50],
-      active: Colors.neutral[70],
-      disabled: Colors.neutral[10],
+      normal: '#D0D5DD',
+      hover: '#98A2B3',
+      active: '#0F766E',
+      disabled: '#EAECF0',
     },
     optionList: {
-      borderColor: Colors.neutral[10],
+      borderColor: '#E4E7EC',
       scrollbar: {
-        backgroundColor: Colors.neutral[30],
+        backgroundColor: '#D0D5DD',
       },
     },
     multiSelectOption: {
@@ -805,45 +827,45 @@ export const theme = {
         borderColor: Colors.neutral[50],
       },
     },
-    label: Colors.neutral[50],
+    label: '#667085',
   },
   input: {
     borderColor: {
-      normal: Colors.neutral[30],
-      hover: Colors.neutral[50],
-      focus: Colors.neutral[70],
-      disabled: Colors.neutral[10],
+      normal: '#D0D5DD',
+      hover: '#98A2B3',
+      focus: '#0F766E',
+      disabled: '#EAECF0',
     },
     color: {
-      normal: Colors.neutral[90],
+      normal: '#111827',
       placeholder: {
-        normal: Colors.neutral[30],
-        readOnly: Colors.neutral[30],
+        normal: '#98A2B3',
+        readOnly: '#98A2B3',
       },
-      disabled: Colors.neutral[30],
-      readOnly: Colors.neutral[90],
+      disabled: '#98A2B3',
+      readOnly: '#344054',
     },
     backgroundColor: {
       normal: Colors.neutral[0],
-      readOnly: Colors.neutral[5],
+      readOnly: '#F2F4F7',
       disabled: Colors.neutral[0],
     },
-    error: Colors.red[50],
+    error: '#D92D20',
     icon: {
-      color: Colors.neutral[70],
-      hover: Colors.neutral[90],
+      color: '#667085',
+      hover: '#111827',
     },
     label: {
-      color: Colors.neutral[70],
+      color: '#344054',
     },
   },
   metrics: {
-    backgroundColor: Colors.neutral[5],
-    sectionTitle: Colors.neutral[90],
+    backgroundColor: '#F6F7F9',
+    sectionTitle: '#111827',
     indicator: {
-      titleColor: Colors.neutral[50],
-      warningTextColor: Colors.red[50],
-      lightTextColor: Colors.neutral[30],
+      titleColor: '#667085',
+      warningTextColor: '#D92D20',
+      lightTextColor: '#98A2B3',
     },
     wrapper: Colors.neutral[0],
     filters: {
@@ -855,12 +877,12 @@ export const theme = {
   },
   scrollbar: {
     trackColor: {
-      normal: Colors.neutral[5],
-      active: Colors.neutral[5],
+      normal: '#F2F4F7',
+      active: '#F2F4F7',
     },
     thumbColor: {
-      normal: Colors.neutral[15],
-      active: Colors.neutral[50],
+      normal: '#D0D5DD',
+      active: '#98A2B3',
     },
   },
   consumerTopicContent: {
@@ -1038,7 +1060,7 @@ export const darkTheme: ThemeType = {
     },
   },
   logo: {
-    color: '#FDFDFD',
+    color: '#2DD4BF',
   },
   version: {
     currentVersion: {
@@ -1052,8 +1074,30 @@ export const darkTheme: ThemeType = {
     color: {
       normal: Colors.neutral[0],
     },
-    backgroundColor: Colors.brand[90],
+    backgroundColor: '#09090B',
     transparentColor: 'transparent',
+  },
+  surface: {
+    canvas: '#09090B',
+    panel: '#111113',
+    panelAlt: '#18181B',
+    sidebar: '#0F1011',
+    header: hexToRgba('#09090B', 0.88),
+    border: '#27272A',
+    borderStrong: '#3F3F46',
+    muted: '#18181B',
+    mutedHover: '#27272A',
+    selected: '#102A2A',
+    selectedBorder: '#0F766E',
+    accent: '#2DD4BF',
+    accentMuted: '#143C3A',
+    accentText: '#99F6E4',
+    foreground: '#FAFAFA',
+    foregroundMuted: '#A1A1AA',
+    foregroundSubtle: '#71717A',
+    shadow: '0 1px 2px rgba(0, 0, 0, 0.5)',
+    shadowLg: '0 18px 45px rgba(0, 0, 0, 0.42)',
+    ring: hexToRgba('#2DD4BF', 0.34),
   },
   link: {
     color: Colors.brand[50],
@@ -1521,10 +1565,23 @@ export const darkTheme: ThemeType = {
     ...baseTheme.code,
     backgroundColor: Colors.neutral[95],
   },
+  tag: {
+    backgroundColor: {
+      green: '#052E1A',
+      gray: '#27272A',
+      yellow: '#422006',
+      white: '#18181B',
+      red: '#450A0A',
+      blue: '#172554',
+      secondary: '#27272A',
+    },
+    color: '#E4E4E7',
+  },
   layout: {
     ...baseTheme.layout,
-    stuffColor: Colors.neutral[75],
-    stuffBorderColor: Colors.neutral[75],
+    mainBackgroundColor: '#09090B',
+    stuffColor: '#18181B',
+    stuffBorderColor: '#27272A',
     socialLink: Colors.neutral[30],
   },
   icons: {


### PR DESCRIPTION
## Summary
- add shadcn-inspired surface, focus, dark-mode, and accent tokens to the styled-components theme
- refresh the app chrome, sidebar navigation, dashboard, auth screen, modals, tables, metrics, badges, buttons, inputs, selects, switches, and textareas
- move the dashboard primary action into the page heading and tighten the cluster table composition

## Validation
- pnpm lint
- pnpm tsc
- pnpm build

## Notes
- Build still emits existing Vite/Rollup warnings for public-path font URLs, a NewTable column-filter circular re-export, and large chunks.