### PR TITLE
Add built-in TransactionStateSerde for __transaction_state topic

### DIFF
--- a/api/src/main/java/io/kafbat/ui/serdes/SerdesInitializer.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/SerdesInitializer.java
@@ -18,6 +18,7 @@ import io.kafbat.ui.serdes.builtin.MessagePackSerde;
 import io.kafbat.ui.serdes.builtin.ProtobufFileSerde;
 import io.kafbat.ui.serdes.builtin.ProtobufRawSerde;
 import io.kafbat.ui.serdes.builtin.StringSerde;
+import io.kafbat.ui.serdes.builtin.TransactionStateSerde;
 import io.kafbat.ui.serdes.builtin.UInt32Serde;
 import io.kafbat.ui.serdes.builtin.UInt64Serde;
 import io.kafbat.ui.serdes.builtin.UuidBinarySerde;
@@ -152,6 +153,7 @@ public class SerdesInitializer {
   private void registerTopicRelatedSerde(Map<String, SerdeInstance> serdes) {
     serdes.putAll(consumerOffsetsSerde());
     serdes.putAll(mirrorMakerSerdes());
+    serdes.putAll(transactionStateSerde());
   }
 
   private Map<String, SerdeInstance> consumerOffsetsSerde() {
@@ -161,6 +163,21 @@ public class SerdesInitializer {
         new SerdeInstance(
             ConsumerOffsetsSerde.NAME,
             new ConsumerOffsetsSerde(),
+            pattern,
+            pattern,
+            null,
+            false
+        )
+    );
+  }
+
+  private Map<String, SerdeInstance> transactionStateSerde() {
+    var pattern = Pattern.compile(TransactionStateSerde.TOPIC_NAME);
+    return Map.of(
+        TransactionStateSerde.NAME,
+        new SerdeInstance(
+            TransactionStateSerde.NAME,
+            new TransactionStateSerde(),
             pattern,
             pattern,
             null,

--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/TransactionStateSerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/TransactionStateSerde.java
@@ -1,0 +1,183 @@
+package io.kafbat.ui.serdes.builtin;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.kafbat.ui.serde.api.DeserializeResult;
+import io.kafbat.ui.serdes.BuiltInSerde;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import lombok.SneakyThrows;
+import org.apache.kafka.common.protocol.types.ArrayOf;
+import org.apache.kafka.common.protocol.types.BoundField;
+import org.apache.kafka.common.protocol.types.CompactArrayOf;
+import org.apache.kafka.common.protocol.types.Field;
+import org.apache.kafka.common.protocol.types.Schema;
+import org.apache.kafka.common.protocol.types.Struct;
+import org.apache.kafka.common.protocol.types.Type;
+
+public class TransactionStateSerde extends StructSerde implements BuiltInSerde {
+
+  private static final JsonMapper TX_JSON_MAPPER = createMapper();
+
+  private static JsonMapper createMapper() {
+    var module = new SimpleModule();
+    module.addSerializer(Struct.class, new JsonSerializer<Struct>() {
+          @Override
+          public void serialize(Struct value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            gen.writeStartObject();
+            for (BoundField field : value.schema().fields()) {
+              var fieldValue = value.get(field);
+              var fieldName = field.def.name;
+              if (TRANSACTION_STATUS.equals(fieldName) && fieldValue instanceof Number n) {
+                gen.writeObjectField(fieldName, TransactionStatus.nameForId(n.intValue()));
+              } else {
+                gen.writeObjectField(fieldName, fieldValue);
+              }
+            }
+            gen.writeEndObject();
+          }
+        }
+    );
+    var mapper = new JsonMapper();
+    mapper.registerModule(module);
+    return mapper;
+  }
+
+  public static final String TOPIC_NAME = "__transaction_state";
+  public static final String NAME = "__transaction_state";
+
+  private static final String TRANSACTIONAL_ID = "transaction_id";
+  private static final String PRODUCER_ID = "producer_id";
+  private static final String PRODUCER_EPOCH = "producer_epoch";
+  private static final String TRANSACTION_TIMEOUT_MS = "transaction_timeout_ms";
+  private static final String TRANSACTION_STATUS = "transaction_status";
+  private static final String TRANSACTION_PARTITIONS = "transaction_partitions";
+  private static final String TOPIC = "topic";
+  private static final String PARTITION_IDS = "partition_ids";
+  private static final String TRANSACTION_LAST_UPDATE_TIMESTAMP_MS = "transaction_last_update_timestamp_ms";
+  private static final String TRANSACTION_START_TIMESTAMP_MS = "transaction_start_timestamp_ms";
+
+  @Override
+  public boolean canDeserialize(String topic, Target type) {
+    return topic.equals(TOPIC_NAME);
+  }
+
+  @Override
+  public Deserializer deserializer(String topic, Target type) {
+    return switch (type) {
+      case KEY -> keyDeserializer();
+      case VALUE -> valueDeserializer();
+    };
+  }
+
+  private Deserializer keyDeserializer() {
+    final Schema transactionKeySchema = new Schema(
+        new Field(TRANSACTIONAL_ID, Type.STRING, "")
+    );
+
+    return (headers, data) -> {
+      var bb = ByteBuffer.wrap(data);
+      short version = bb.getShort();
+      return new DeserializeResult(
+          toJson(transactionKeySchema.read(bb)),
+          DeserializeResult.Type.JSON,
+          Map.of()
+      );
+    };
+  }
+
+  private Deserializer valueDeserializer() {
+    final Schema transactionLogSchemaV0 =
+        new Schema(
+            new Field(PRODUCER_ID, Type.INT64, ""),
+            new Field(PRODUCER_EPOCH, Type.INT16, ""),
+            new Field(TRANSACTION_TIMEOUT_MS, Type.INT32, ""),
+            new Field(TRANSACTION_STATUS, Type.INT8, ""),
+            new Field(TRANSACTION_PARTITIONS, ArrayOf.nullable(new Schema(
+                new Field(TOPIC, Type.STRING, ""),
+                new Field(PARTITION_IDS, new ArrayOf(Type.INT32), "")
+            )), ""),
+            new Field(TRANSACTION_LAST_UPDATE_TIMESTAMP_MS, Type.INT64, ""),
+            new Field(TRANSACTION_START_TIMESTAMP_MS, Type.INT64, "")
+        );
+
+    final Schema transactionLogSchemaV1 =
+        new Schema(
+            new Field(PRODUCER_ID, Type.INT64, ""),
+            new Field(PRODUCER_EPOCH, Type.INT16, ""),
+            new Field(TRANSACTION_TIMEOUT_MS, Type.INT32, ""),
+            new Field(TRANSACTION_STATUS, Type.INT8, ""),
+            new Field(TRANSACTION_PARTITIONS, new CompactArrayOf(new Schema(
+                new Field(TOPIC, Type.COMPACT_STRING, ""),
+                new Field(PARTITION_IDS, CompactArrayOf.nullable(Type.INT32), ""),
+                Field.TaggedFieldsSection.of()
+            )), ""),
+            new Field(TRANSACTION_LAST_UPDATE_TIMESTAMP_MS, Type.INT64, ""),
+            new Field(TRANSACTION_START_TIMESTAMP_MS, Type.INT64, ""),
+            Field.TaggedFieldsSection.of()
+        );
+
+    return (headers, data) -> {
+      String result;
+      var bb = ByteBuffer.wrap(data);
+      short version = bb.getShort();
+      System.out.println("TransactionLog: version: " + version);
+      System.out.println("TransactionLog: " + bb.remaining());
+      result = toJson(
+          switch (version) {
+            case 0 -> transactionLogSchemaV0.read(bb);
+            case 1 -> transactionLogSchemaV1.read(bb);
+            default -> throw new IllegalArgumentException("Unrecognized version: " + version);
+          }
+      );
+      System.out.println("TransactionLog: " + bb.remaining());
+
+
+      if (bb.remaining() != 0) {
+        throw new IllegalArgumentException(
+            "Message buffer is not read to the end, which is likely means message is unrecognized");
+      }
+      return new DeserializeResult(
+          result,
+          DeserializeResult.Type.JSON,
+          Map.of()
+      );
+    };
+  }
+
+  @Override
+  @SneakyThrows
+  protected String toJson(Struct s) {
+    return TX_JSON_MAPPER.writeValueAsString(s);
+  }
+
+  public enum TransactionStatus {
+    EMPTY(0),
+    ONGOING(1),
+    PREPARE_COMMIT(2),
+    PREPARE_ABORT(3),
+    COMPLETE_COMMIT(4),
+    COMPLETE_ABORT(5),
+    DEAD(6),
+    PREPARE_EPOCH_FENCE(7);
+
+    private final int id;
+
+    TransactionStatus(int id) {
+      this.id = id;
+    }
+
+    static String nameForId(int id) {
+      for (var status : values()) {
+        if (status.id == id) {
+          return status.name();
+        }
+      }
+      return "UNKNOWN(" + id + ")";
+    }
+  }
+}

--- a/api/src/test/java/io/kafbat/ui/serdes/builtin/TransactionStateSerdeTest.java
+++ b/api/src/test/java/io/kafbat/ui/serdes/builtin/TransactionStateSerdeTest.java
@@ -1,0 +1,168 @@
+package io.kafbat.ui.serdes.builtin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.kafbat.ui.AbstractIntegrationTest;
+import io.kafbat.ui.serde.api.DeserializeResult;
+import io.kafbat.ui.serde.api.Serde;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import lombok.SneakyThrows;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+class TransactionStateSerdeTest extends AbstractIntegrationTest {
+
+
+  private static String targetTopic;
+  private static String transactionalId;
+
+  @BeforeAll
+  static void createTopicAndCommitItsOffset() {
+    targetTopic = TransactionStateSerdeTest.class.getSimpleName() + "-" + UUID.randomUUID();
+    transactionalId = TransactionStateSerdeTest.class.getSimpleName() + "-" + UUID.randomUUID();
+    createTopic(new NewTopic(targetTopic, 1, (short) 1));
+
+    try (var producer = createTransactionalProducer(transactionalId)) {
+      producer.initTransactions();
+
+      producer.beginTransaction();
+      producer.send(new ProducerRecord<>(targetTopic, "key1", "value1"));
+      producer.commitTransaction();
+
+      producer.beginTransaction();
+      producer.send(new ProducerRecord<>(targetTopic, "key2", "value2"));
+      producer.abortTransaction();
+    }
+  }
+
+  @AfterAll
+  static void cleanUp() {
+    deleteTopic(targetTopic);
+  }
+
+  @Test
+  void canOnlyDeserializeConsumerOffsetsTopic() {
+    var serde = new TransactionStateSerde();
+    assertThat(serde.canDeserialize(TransactionStateSerde.TOPIC_NAME, Serde.Target.KEY)).isTrue();
+    assertThat(serde.canDeserialize(TransactionStateSerde.TOPIC_NAME, Serde.Target.VALUE)).isTrue();
+    assertThat(serde.canDeserialize("anyOtherTopic", Serde.Target.KEY)).isFalse();
+    assertThat(serde.canDeserialize("anyOtherTopic", Serde.Target.VALUE)).isFalse();
+  }
+
+  @Test
+  void deserializesMessagesMadeByConsumerActivity() {
+    var serde = new TransactionStateSerde();
+    var keyDeserializer = serde.deserializer(TransactionStateSerde.TOPIC_NAME, Serde.Target.KEY);
+    var valueDeserializer = serde.deserializer(TransactionStateSerde.TOPIC_NAME, Serde.Target.VALUE);
+
+    try (var consumer = createConsumer()) {
+      consumer.subscribe(List.of(TransactionStateSerde.TOPIC_NAME));
+
+      List<Map<String, Object>> values = new ArrayList<>();
+
+      Awaitility.await()
+          .pollInSameThread()
+          .atMost(Duration.ofMinutes(1))
+          .untilAsserted(() -> {
+            for (var rec : consumer.poll(Duration.ofMillis(200))) {
+              if (rec.key() == null || rec.value() == null) {
+                continue;
+              }
+              System.out.println("record");
+              var keyJson = toMapFromJsom(keyDeserializer.deserialize(null, rec.key().get()));
+
+              if (!keyJson.containsKey("transaction_id")) {
+                continue;
+              }
+
+              var valueJson = toMapFromJsom(valueDeserializer.deserialize(null, rec.value().get()));
+              values.add(valueJson);
+            }
+
+            assertThat(values.isEmpty()).isFalse();
+
+            System.out.println("All values: " + values);
+            assertThat(values).allSatisfy(v -> {
+              assertThat(v).containsKeys(
+                  "producer_id",
+                  "producer_epoch",
+                  "transaction_timeout_ms",
+                  "transaction_status",
+                  "transaction_last_update_timestamp_ms",
+                  "transaction_start_timestamp_ms"
+              );
+            });
+
+            // 0 - Empty
+            assertThat(values).anyMatch(v ->
+                TransactionStateSerde.TransactionStatus.EMPTY.name().equals(v.get("transaction_status"))
+                    && v.get("transaction_partitions") == null
+            );
+
+            // 1 - Ongoing
+            assertThat(values).anyMatch(v ->
+                TransactionStateSerde.TransactionStatus.ONGOING.name().equals(v.get("transaction_status"))
+                    && v.get("transaction_partitions") instanceof List<?> list
+                    && !list.isEmpty()
+            );
+
+            // 4 - CompleteCommit
+            assertThat(values).anyMatch(v ->
+                TransactionStateSerde.TransactionStatus.COMPLETE_COMMIT.name().equals(v.get("transaction_status"))
+                    && v.get("transaction_partitions") instanceof List<?> list
+                    && list.isEmpty()
+            );
+
+            // 5 - CompleteAbort
+            assertThat(values).anyMatch(v ->
+                TransactionStateSerde.TransactionStatus.COMPLETE_ABORT.name().equals(v.get("transaction_status"))
+                    && v.get("transaction_partitions") instanceof List<?> list
+                    && list.isEmpty()
+            );
+          });
+    }
+  }
+
+  @SneakyThrows
+  @SuppressWarnings("unchecked")
+  private Map<String, Object> toMapFromJsom(DeserializeResult result) {
+    return new JsonMapper().readValue(result.getResult(), Map.class);
+  }
+
+  private static KafkaConsumer<Bytes, Bytes> createConsumer() {
+    Properties props = new Properties();
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, "transaction-state-" + UUID.randomUUID());
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class);
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    return new KafkaConsumer<>(props);
+  }
+
+  private static KafkaProducer<String, String> createTransactionalProducer(String transactionalId) {
+    return new KafkaProducer<>(Map.of(
+        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers(),
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class,
+        ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId,
+        ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true"
+    ));
+  }
+}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
<!-- ignore-task-list-end -->

No breaking changes.

**What changes did you make?** (Give an overview)

Added built-in `TransactionStateSerde` for deserializing messages from the `__transaction_state` internal Kafka topic (closes #407).

The serde supports:
- **Key** deserialization: reads the version prefix and returns `{"transaction_id": "..."}` JSON
- **Value** deserialization: supports both V0 (standard encoding) and V1 (flexible encoding with `COMPACT_STRING`/`CompactArrayOf` and tagged fields section), returning all transaction metadata fields as JSON
- Human-readable `transaction_status` field — numeric byte values are mapped to named enum constants (e.g. `4` → `COMPLETE_COMMIT`) via the `TransactionStatus` enum

Schema definitions are based on `TransactionLogKey.json` and `TransactionLogValue.json` from the Kafka 3.9 `transaction-coordinator` module.

**Is there anything you'd like reviewers to focus on?**

My implementation was based on __consumer_offsets serde

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Added `TransactionStateSerdeTest` (integration test using Testcontainers), which:
- Spins up a real Kafka broker
- Produces a committed and an aborted transaction
- Reads raw bytes from `__transaction_state`
- Asserts that key deserialization returns the correct `transaction_id`
- Asserts that all expected transaction states (`EMPTY`, `ONGOING`, `COMPLETE_COMMIT`, `COMPLETE_ABORT`) are correctly deserialized, including the nullable partition list cases

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

**A picture of a cute animal (not mandatory but encouraged)**
![image](https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRFvmgn3-bNC0Jcrc1zqluuVx6fvVcoHNFzEd5HXlQIuA&s=10)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for deserializing Kafka's internal transaction-state topic, enabling visibility into transaction metadata including transaction IDs, producer information, status (committed/aborted/ongoing), and partition assignments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->