### PR TITLE
BE: Prevent the masking of externally-provided references in Kafka Connect config

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/KafkaConfigSanitizer.java
+++ b/api/src/main/java/io/kafbat/ui/service/KafkaConfigSanitizer.java
@@ -75,8 +75,6 @@ public class KafkaConfigSanitizer {
   public Object sanitize(String key, @Nullable Object value) {
     for (Pattern pattern : sanitizeKeysPatterns) {
       if (pattern.matcher(key).matches()) {
-        // The likelihood that a credential matching key contains exactly CONFIG_PROVIDER_REFERENCE pattern is
-        // astronomically low as it is matching against an exact reference to ${ ... : ... }
         if (isConfigProviderReference(value)) {
           return value;
         }
@@ -94,8 +92,8 @@ public class KafkaConfigSanitizer {
    * @return true if provider reference, false otherwise
    */
   private static boolean isConfigProviderReference(@Nullable Object value) {
-    return value instanceof CharSequence
-        && CONFIG_PROVIDER_REFERENCE.matcher((CharSequence) value).matches();
+    return value instanceof CharSequence charsequence
+        && CONFIG_PROVIDER_REFERENCE.matcher(charsequence).find();
   }
 
   public Map<String, Object> sanitizeConnectorConfig(@Nullable Map<String, Object> original) {

--- a/api/src/main/java/io/kafbat/ui/service/KafkaConfigSanitizer.java
+++ b/api/src/main/java/io/kafbat/ui/service/KafkaConfigSanitizer.java
@@ -25,6 +25,9 @@ public class KafkaConfigSanitizer {
 
   private static final String[] REGEX_PARTS = {"*", "$", "^", "+"};
 
+  private static final Pattern CONFIG_PROVIDER_REFERENCE =
+      Pattern.compile("\\$\\{[^}:]+:([^}:]+:)?[^}]+}");
+
   private static final List<String> DEFAULT_PATTERNS_TO_SANITIZE = ImmutableList.<String>builder()
       .addAll(kafkaConfigKeysToSanitize())
       .add(
@@ -72,10 +75,27 @@ public class KafkaConfigSanitizer {
   public Object sanitize(String key, @Nullable Object value) {
     for (Pattern pattern : sanitizeKeysPatterns) {
       if (pattern.matcher(key).matches()) {
+        // The likelihood that a credential matching key contains exactly CONFIG_PROVIDER_REFERENCE pattern is
+        // astronomically low as it is matching against an exact reference to ${ ... : ... }
+        if (isConfigProviderReference(value)) {
+          return value;
+        }
         return SANITIZED_VALUE;
       }
     }
     return value;
+  }
+
+  /**
+   *  Checks if config value is an externalized secret / config provider indirection: ${provider:[path:]key}.
+   *  Such a value is only a reference resolved at runtime, not an actual
+   *  secret, so it must not be masked (masking would clobber the reference on re-submit).
+   * @param value config value
+   * @return true if provider reference, false otherwise
+   */
+  private static boolean isConfigProviderReference(@Nullable Object value) {
+    return value instanceof CharSequence
+        && CONFIG_PROVIDER_REFERENCE.matcher((CharSequence) value).matches();
   }
 
   public Map<String, Object> sanitizeConnectorConfig(@Nullable Map<String, Object> original) {

--- a/api/src/test/java/io/kafbat/ui/service/KafkaConfigSanitizerTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/KafkaConfigSanitizerTest.java
@@ -54,9 +54,22 @@ class KafkaConfigSanitizerTest {
     assertThat(sanitizer.sanitize("consumer.kafka.ui", "secret")).isEqualTo("******");
     assertThat(sanitizer.sanitize("this.is.test.credentials", "secret")).isEqualTo("******");
     assertThat(sanitizer.sanitize("this.is.not.credential", "not.credential"))
-            .isEqualTo("not.credential");
+        .isEqualTo("not.credential");
     assertThat(sanitizer.sanitize("database.password", "no longer credential"))
-            .isEqualTo("no longer credential");
+        .isEqualTo("no longer credential");
+  }
+
+  @Test
+  void doNotObfuscateConfigProviderReferences() {
+    final var sanitizer = new KafkaConfigSanitizer(true, List.of());
+    assertThat(sanitizer.sanitize("database.password", "${file:/data/secrets.properties:db-password}"))
+        .isEqualTo("${file:/data/secrets.properties:db-password}");
+    assertThat(sanitizer.sanitize("password", "${vault:secret/data/connector:password}"))
+        .isEqualTo("${vault:secret/data/connector:password}");
+    assertThat(sanitizer.sanitize("aws.secret.access.key", "${env:AWS_SECRET}"))
+        .isEqualTo("${env:AWS_SECRET}");
+    assertThat(sanitizer.sanitize("password", "${notAReference}")).isEqualTo("******");
+    assertThat(sanitizer.sanitize("password", "plain-secret")).isEqualTo("******");
   }
 
   @Test


### PR DESCRIPTION
Fixes [#1887](https://github.com/kafbat/kafka-ui/issues/1887)

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Made changes to KafkaConfigSanitizer.java and KafkaConfigSanitizerTest.java to review credential based keys' values to confirm they are not a externalized-secret reference.

**Is there anything you'd like reviewers to focus on?**
Regex Pattern not overstepping into general password domains.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [X] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**) (EDIT: Not necessary but if requested I can add)
- [X] My changes generate no new warnings (e.g. Sonar is happy)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

<img width="2160" height="3840" alt="8E2E6E61-22BE-41DA-8D3F-9227D2B20B0C" src="https://github.com/user-attachments/assets/df587be2-1eb6-425d-bd18-c35a20d6d1bf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sanitization to avoid masking valid external config-provider references (e.g., `${file:...}`, `${vault:...}`, `${env:...}`), while continuing to obfuscate other secret-like values.
* **Tests**
  * Added coverage to ensure config-provider references are preserved and adjusted existing assertions for expected sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Screenshots Proving Functionality:
Config pre submit:

<img width="872" height="555" alt="Image" src="https://github.com/user-attachments/assets/48ef6955-c0aa-4368-9060-c8248452a7ad" />

Route to task screen for a refresh after submitting (could be any screen):

<img width="911" height="431" alt="Image" src="https://github.com/user-attachments/assets/315f20d2-fd67-4858-ad61-facc9577bb74" />

Come back to config:

<img width="872" height="555" alt="Image" src="https://github.com/user-attachments/assets/48ef6955-c0aa-4368-9060-c8248452a7ad" />

Normal passwords that do not match the exact regex pattern of ${provider:path/to/secret:secret-key} still looks like BAU functionality:

<img width="855" height="567" alt="Screenshot 2026-06-24 at 8 48 28 AM" src="https://github.com/user-attachments/assets/319f43f2-504f-4738-ac32-03491ed36aad" />

