### PR TITLE
Fix OAuth2 login redirect when using context path

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
@@ -102,7 +102,9 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
             .anyExchange()
             .authenticated()
         )
-        .oauth2Login(oauth2 -> oauth2.authenticationManager(delegatingAuthManager))
+        .oauth2Login(oauth2 -> oauth2
+            .authenticationManager(delegatingAuthManager)
+            .authenticationSuccessHandler(emptyRedirectSuccessHandler()))
         .logout(spec -> spec.logoutSuccessHandler(logoutHandler))
         .csrf(ServerHttpSecurity.CsrfSpec::disable);
 

--- a/api/src/test/java/io/kafbat/ui/util/EmptyRedirectStrategyTest.java
+++ b/api/src/test/java/io/kafbat/ui/util/EmptyRedirectStrategyTest.java
@@ -56,6 +56,20 @@ class EmptyRedirectStrategyTest {
     assertThat(exchange.getResponse().getHeaders().getLocation()).isEqualTo(external);
   }
 
+  @Test
+  void treatsEmptyPathAsRootAndPrependsContextPath() {
+    // An absolute URL with no path component (getPath() == "") hits the empty-path branch,
+    // which falls back to "/" and is therefore made context-relative. This input does not
+    // occur in practice (the success handler only passes path-only URIs), but the branch is
+    // documented here so both paths of createLocation() are covered.
+    var exchange = exchangeWithContextPath("/kafka");
+
+    StepVerifier.create(STRATEGY.sendRedirect(exchange, URI.create("https://auth.example.com")))
+        .verifyComplete();
+
+    assertThat(exchange.getResponse().getHeaders().getLocation()).isEqualTo(URI.create("/kafka/"));
+  }
+
   private static MockServerWebExchange exchangeWithContextPath(String contextPath) {
     return MockServerWebExchange.from(
         MockServerHttpRequest.get(contextPath + "/").contextPath(contextPath));

--- a/api/src/test/java/io/kafbat/ui/util/EmptyRedirectStrategyTest.java
+++ b/api/src/test/java/io/kafbat/ui/util/EmptyRedirectStrategyTest.java
@@ -1,0 +1,63 @@
+package io.kafbat.ui.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import reactor.test.StepVerifier;
+
+class EmptyRedirectStrategyTest {
+
+  private static final EmptyRedirectStrategy STRATEGY = new EmptyRedirectStrategy();
+
+  @Test
+  void prependsContextPathToRootRedirect() {
+    var exchange = exchangeWithContextPath("/kafka");
+
+    StepVerifier.create(STRATEGY.sendRedirect(exchange, URI.create("/")))
+        .verifyComplete();
+
+    assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.FOUND);
+    assertThat(exchange.getResponse().getHeaders().getLocation()).isEqualTo(URI.create("/kafka/"));
+  }
+
+  @Test
+  void prependsContextPathToAbsolutePathRedirect() {
+    var exchange = exchangeWithContextPath("/kafka");
+
+    StepVerifier.create(STRATEGY.sendRedirect(exchange, URI.create("/ui/clusters")))
+        .verifyComplete();
+
+    assertThat(exchange.getResponse().getHeaders().getLocation())
+        .isEqualTo(URI.create("/kafka/ui/clusters"));
+  }
+
+  @Test
+  void leavesLocationUntouchedWhenNoContextPath() {
+    var exchange = exchangeWithContextPath("");
+
+    StepVerifier.create(STRATEGY.sendRedirect(exchange, URI.create("/")))
+        .verifyComplete();
+
+    assertThat(exchange.getResponse().getHeaders().getLocation()).isEqualTo(URI.create("/"));
+  }
+
+  @Test
+  void doesNotRewriteAbsoluteUrlRedirects() {
+    var exchange = exchangeWithContextPath("/kafka");
+    var external = URI.create("https://auth.example.com/login");
+
+    StepVerifier.create(STRATEGY.sendRedirect(exchange, external))
+        .verifyComplete();
+
+    assertThat(exchange.getResponse().getHeaders().getLocation()).isEqualTo(external);
+  }
+
+  private static MockServerWebExchange exchangeWithContextPath(String contextPath) {
+    return MockServerWebExchange.from(
+        MockServerHttpRequest.get(contextPath + "/").contextPath(contextPath));
+  }
+}


### PR DESCRIPTION
Closes #1893

## What's changed

OAuth2 login did not set an `authenticationSuccessHandler`, so it fell back to Spring Security's default handler, which is **not aware of the servlet context path** (`SERVER_SERVLET_CONTEXT_PATH` / `server.servlet.context-path`).

When kafka-ui is hosted under a base path (e.g. `/kafka`), the post-login `302` redirect omits the context path. The browser is sent to a location that doesn't include `/kafka`, so the user is stranded after authenticating instead of being routed back into the UI. Manually navigating to `/kafka` after login works, confirming auth itself succeeds — only the redirect target is wrong.

The `LOGIN_FORM` and `LDAP` configs already attach `emptyRedirectSuccessHandler()` (which prepends the context path via `EmptyRedirectStrategy`):

```java
// BasicAuthSecurityConfig / LdapSecurityConfig
.formLogin(form -> form
    .loginPage(LOGIN_URL)
    .authenticationSuccessHandler(emptyRedirectSuccessHandler()))
```

This PR applies the same handler to `oauth2Login` for parity:

```java
.oauth2Login(oauth2 -> oauth2
    .authenticationManager(delegatingAuthManager)
    .authenticationSuccessHandler(emptyRedirectSuccessHandler()))
```

`emptyRedirectSuccessHandler()` is already defined in the shared `AbstractAuthSecurityConfig` base class — it simply wasn't wired into the OAuth2 flow.

## Tests

Adds `EmptyRedirectStrategyTest` covering the context-path behavior the fix depends on (and which was previously untested):
- prepends context path to a root (`/`) redirect → `/kafka/`
- prepends context path to an absolute-path redirect → `/kafka/ui/clusters`
- leaves the location unchanged when no context path is configured
- does not rewrite absolute-URL redirects (e.g. external IdP URLs)

## How to reproduce

1. Configure OAuth2/OIDC auth (`auth.type=OAUTH2`).
2. Set `SERVER_SERVLET_CONTEXT_PATH=/kafka`.
3. Log in — the post-login `302` redirect does not point to `/kafka`, leaving the user on a blank/unrouted page. Manually visiting `/kafka` works.

Affects `main` and the latest release (`v1.5.0`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth login redirect handling by ensuring successful authentication uses the configured “empty redirect” behavior, keeping redirects consistent with the app’s context path.

* **Tests**
  * Added JUnit coverage for redirect rewriting behavior (root redirects, context-path-prefixed paths, unchanged locations when context path is empty, and no rewriting for absolute external URLs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->