### PR TITLE
Fix "Bad authority" error in Cognito logout behind reverse proxy

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/auth/logout/CognitoLogoutSuccessHandler.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/logout/CognitoLogoutSuccessHandler.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.server.WebFilterExchange;
-import org.springframework.security.web.util.UrlUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.util.Assert;
 import org.springframework.web.server.WebSession;
@@ -35,12 +34,8 @@ public class CognitoLogoutSuccessHandler implements LogoutSuccessHandler {
 
     final var requestUri = exchange.getExchange().getRequest().getURI();
 
-    final var fullUrl = UrlUtils.buildFullRequestUrl(requestUri.getScheme(),
-        requestUri.getHost(), requestUri.getPort(),
-        requestUri.getPath(), requestUri.getQuery());
-
     final UriComponents baseUrl = UriComponentsBuilder
-        .fromUriString(fullUrl)
+        .fromUri(requestUri)
         .replacePath("/")
         .replaceQuery(null)
         .fragment(null)

--- a/api/src/test/java/io/kafbat/ui/config/auth/logout/CognitoLogoutSuccessHandlerTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/logout/CognitoLogoutSuccessHandlerTest.java
@@ -1,0 +1,49 @@
+package io.kafbat.ui.config.auth.logout;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.kafbat.ui.config.auth.OAuthProperties;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.web.server.WebFilterExchange;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+class CognitoLogoutSuccessHandlerTest {
+
+  private final CognitoLogoutSuccessHandler handler = new CognitoLogoutSuccessHandler();
+
+  @Test
+  void buildsLogoutRedirectWhenRequestUriHasNoExplicitPort() {
+    // Behind a reverse proxy (e.g. AWS ALB) with SSL termination, the resolved
+    // request URI has no explicit port, so java.net.URI#getPort() returns -1.
+    // See https://github.com/kafbat/kafka-ui/issues/1878
+    var request = MockServerHttpRequest
+        .post("https://kafka-ui.example.com/logout")
+        .build();
+    var exchange = MockServerWebExchange.from(request);
+    var filterExchange = new WebFilterExchange(exchange, noopChain());
+
+    var provider = new OAuthProperties.OAuth2Provider();
+    provider.setClientId("test-client-id");
+    provider.setCustomParams(Map.of("logoutUrl",
+        "https://cognito-domain.auth.us-east-1.amazoncognito.com/logout"));
+
+    handler.handle(filterExchange, new TestingAuthenticationToken("user", "pass"), provider)
+        .block();
+
+    var location = exchange.getResponse().getHeaders().getLocation();
+    assertThat(location).isNotNull();
+    assertThat(location.toString()).doesNotContain(":-1");
+    assertThat(location.getHost()).isEqualTo("cognito-domain.auth.us-east-1.amazoncognito.com");
+    assertThat(location.getQuery()).contains("client_id=test-client-id");
+    assertThat(location.getQuery()).contains("logout_uri=https");
+  }
+
+  private WebFilterChain noopChain() {
+    return ex -> Mono.empty();
+  }
+}


### PR DESCRIPTION
CognitoLogoutSuccessHandler built the base redirect URL via UrlUtils.buildFullRequestUrl(scheme, host, port, ...), which appends ":-1" when the request URI has no explicit port (the normal case behind a reverse proxy like an AWS ALB with SSL termination). Spring Framework 6.2's stricter RfcUriParser rejects that as an invalid authority, causing a 500 on logout.

Build the base URL directly from the request URI via UriComponentsBuilder.fromUri(), which omits the port correctly when it's -1.

Fixes #1878

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout redirects so the generated sign-out URL works correctly when the app is accessed through a reverse proxy or other setup where the request port is not explicitly present.
  * Prevented invalid `:-1` values from appearing in the redirect URL, helping users complete logout reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->