### PR TITLE
Keep Kafka version fallback on metadata.version

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/ReactiveAdminClient.java
+++ b/api/src/main/java/io/kafbat/ui/service/ReactiveAdminClient.java
@@ -102,6 +102,7 @@ import reactor.util.function.Tuples;
 @AllArgsConstructor
 public class ReactiveAdminClient implements Closeable {
   private static final String DEFAULT_UNKNOWN_VERSION = "Unknown";
+  private static final String INTER_BROKER_PROTOCOL_VERSION_CONFIG = "inter.broker.protocol.version";
 
   public enum SupportedFeature {
     INCREMENTAL_ALTER_CONFIGS(2.3f),
@@ -164,12 +165,9 @@ public class ReactiveAdminClient implements Closeable {
                 .flatMap(tuple -> {
                   List<ConfigEntry> configs = tuple.getT1();
                   FeatureMetadata featureMetadata = tuple.getT2();
-                  Optional<String> version = Optional.empty();
+                  Optional<String> version = extractKafkaVersion(configs);
                   boolean topicDeletionEnabled = true;
                   for (ConfigEntry entry : configs) {
-                    if (entry.name().contains("inter.broker.protocol.version")) {
-                      version = Optional.ofNullable(entry.value());
-                    }
                     if (entry.name().equals("delete.topic.enable") && entry.value() != null) {
                       topicDeletionEnabled = Boolean.parseBoolean(entry.value());
                     }
@@ -193,6 +191,17 @@ public class ReactiveAdminClient implements Closeable {
           })
           .cache(UPDATE_DURATION);
     }
+
+  }
+
+  @VisibleForTesting
+  static Optional<String> extractKafkaVersion(List<ConfigEntry> configs) {
+    for (ConfigEntry entry : configs) {
+      if (entry.name().equals(INTER_BROKER_PROTOCOL_VERSION_CONFIG) && entry.value() != null) {
+        return Optional.of(entry.value());
+      }
+    }
+    return Optional.empty();
   }
 
   public static Mono<ReactiveAdminClient> create(AdminClient adminClient, ClustersProperties.AdminClient properties) {

--- a/api/src/test/java/io/kafbat/ui/service/ReactiveAdminClientVersionTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/ReactiveAdminClientVersionTest.java
@@ -1,0 +1,46 @@
+package io.kafbat.ui.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.junit.jupiter.api.Test;
+
+class ReactiveAdminClientVersionTest {
+
+  @Test
+  void extractKafkaVersionUsesInterBrokerProtocolVersion() {
+    var configs = List.of(
+        new ConfigEntry("log.message.format.version", "3.8-IV0"),
+        new ConfigEntry("inter.broker.protocol.version", "3.9-IV0")
+    );
+
+    assertThat(ReactiveAdminClient.extractKafkaVersion(configs)).contains("3.9-IV0");
+  }
+
+  @Test
+  void extractKafkaVersionIgnoresLogMessageFormatVersion() {
+    var configs = List.of(
+        new ConfigEntry("log.message.format.version", "3.8-IV0")
+    );
+
+    assertThat(ReactiveAdminClient.extractKafkaVersion(configs)).isEmpty();
+  }
+
+  @Test
+  void extractKafkaVersionReturnsEmptyWhenInterBrokerProtocolVersionIsNull() {
+    var configs = List.of(
+        new ConfigEntry("inter.broker.protocol.version", null),
+        new ConfigEntry("log.message.format.version", "3.8-IV0")
+    );
+
+    assertThat(ReactiveAdminClient.extractKafkaVersion(configs)).isEmpty();
+  }
+
+  @Test
+  void extractKafkaVersionReturnsEmptyWhenVersionConfigsAreMissing() {
+    var configs = List.of(new ConfigEntry("delete.topic.enable", "true"));
+
+    assertThat(ReactiveAdminClient.extractKafkaVersion(configs)).isEmpty();
+  }
+}


### PR DESCRIPTION
## What changed

This reworks the previous approach based on maintainer feedback. The PR no longer uses `log.message.format.version` as a Kafka version fallback.

Instead, broker config version extraction is limited to the exact `inter.broker.protocol.version` config key. If that value is unavailable, the existing `metadata.version` fallback from `describeFeatures` remains the next source, and the existing `Unknown` display fallback remains unchanged.

## Why

`log.message.format.version` is deprecated for newer Kafka versions and is not a reliable source for the displayed Kafka broker version. Without real MSK `DescribeConfigs` / `describeFeatures` output proving otherwise, keeping `metadata.version` as the fallback is the safer behavior.

## Tests

Added focused unit coverage for Kafka version extraction:

- uses `inter.broker.protocol.version` when present
- ignores `log.message.format.version`
- returns empty when the broker protocol version is missing or null, allowing the existing `metadata.version` fallback path to run

Local focused Gradle test was attempted with:

`NPM_CONFIG_CACHE=/private/tmp/kafka-ui-npm-cache ./gradlew :api:test --tests io.kafbat.ui.service.ReactiveAdminClientVersionTest`

It could not complete locally because this machine only has JDK 17 installed while the project currently compiles with source release 25.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kafka version detection by consistently using the configured inter-broker protocol version.
  * Correctly handles missing or null version settings without returning an incorrect version.

* **Tests**
  * Added coverage for valid, missing, null, and unrelated Kafka version configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->