### PR TITLE
Route GitHub OAuth authority lookups through the configured proxy WebClient

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
@@ -141,7 +141,8 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
   @Bean
   public ReactiveOAuth2UserService<OidcUserRequest, OidcUser> customOidcUserService(
       AccessControlService acs,
-      ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService) {
+      ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService,
+      @Qualifier("oauthWebClient") WebClient webClient) {
     final OidcReactiveOAuth2UserService delegate = new OidcReactiveOAuth2UserService();
 
     delegate.setOauth2UserService(oauth2UserService);
@@ -154,7 +155,10 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
             return Mono.just(user);
           }
 
-          return extractor.extract(acs, user, Map.of("request", request, "provider", provider))
+          return extractor.extract(acs, user, Map.of(
+                  "request", request,
+                  "provider", provider,
+                  ProviderAuthorityExtractor.OAUTH_WEB_CLIENT, webClient))
               .map(groups -> new RbacOidcUser(user, groups));
         });
   }
@@ -173,7 +177,10 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
             return Mono.just(user);
           }
 
-          return extractor.extract(acs, user, Map.of("request", request, "provider", provider))
+          return extractor.extract(acs, user, Map.of(
+                  "request", request,
+                  "provider", provider,
+                  ProviderAuthorityExtractor.OAUTH_WEB_CLIENT, webClient))
               .map(groups -> new RbacOAuth2User(user, groups));
         });
   }
@@ -209,4 +216,3 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
   }
 
 }
-

--- a/api/src/main/java/io/kafbat/ui/service/rbac/extractor/GithubAuthorityExtractor.java
+++ b/api/src/main/java/io/kafbat/ui/service/rbac/extractor/GithubAuthorityExtractor.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -57,16 +58,21 @@ public class GithubAuthorityExtractor implements ProviderAuthorityExtractor {
     OAuth2UserRequest req = (OAuth2UserRequest) additionalParams.get("request");
     String infoEndpoint = req.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUri();
 
-    if (infoEndpoint == null) {
-      infoEndpoint = CommonOAuth2Provider.GITHUB
+    final String resolvedInfoEndpoint = infoEndpoint == null
+        ? CommonOAuth2Provider.GITHUB
           .getBuilder(DUMMY)
           .clientId(DUMMY)
           .build()
           .getProviderDetails()
           .getUserInfoEndpoint()
-          .getUri();
-    }
-    var webClient = WebClient.create(infoEndpoint);
+          .getUri()
+        : infoEndpoint;
+
+    var webClient = Optional.ofNullable(additionalParams.get(OAUTH_WEB_CLIENT))
+        .filter(WebClient.class::isInstance)
+        .map(WebClient.class::cast)
+        .map(client -> client.mutate().baseUrl(resolvedInfoEndpoint).build())
+        .orElseGet(() -> WebClient.create(resolvedInfoEndpoint));
 
     Mono<Set<String>> organizationRoles = getOrganizationRoles(principal, additionalParams, acs, webClient);
     Mono<Set<String>> teamRoles = getTeamRoles(webClient, additionalParams, acs);

--- a/api/src/main/java/io/kafbat/ui/service/rbac/extractor/ProviderAuthorityExtractor.java
+++ b/api/src/main/java/io/kafbat/ui/service/rbac/extractor/ProviderAuthorityExtractor.java
@@ -8,6 +8,7 @@ import reactor.core.publisher.Mono;
 public interface ProviderAuthorityExtractor {
 
   String TYPE = "type";
+  String OAUTH_WEB_CLIENT = "oauthWebClient";
 
   boolean isApplicable(String provider, Map<String, String> customParams);
 

--- a/api/src/test/java/io/kafbat/ui/config/RegexBasedProviderAuthorityExtractorTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/RegexBasedProviderAuthorityExtractorTest.java
@@ -1,13 +1,24 @@
 package io.kafbat.ui.config;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.security.oauth2.client.registration.ClientRegistration.withRegistrationId;
 
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import io.kafbat.ui.config.auth.OAuthProperties;
 import io.kafbat.ui.config.auth.RoleBasedAccessControlProperties;
+import io.kafbat.ui.model.rbac.Role;
+import io.kafbat.ui.model.rbac.Subject;
+import io.kafbat.ui.model.rbac.provider.Provider;
 import io.kafbat.ui.service.rbac.AccessControlService;
 import io.kafbat.ui.service.rbac.extractor.CognitoAuthorityExtractor;
 import io.kafbat.ui.service.rbac.extractor.GithubAuthorityExtractor;
@@ -33,8 +44,12 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import reactor.netty.transport.ProxyProvider;
 
 @ExtendWith(SpringExtension.class)
 @EnableConfigurationProperties(RoleBasedAccessControlProperties.class)
@@ -161,6 +176,82 @@ public class RegexBasedProviderAuthorityExtractorTest {
     assertEquals(Set.of("viewer"), roles);
     assertFalse(roles.contains("no one's role"));
 
+  }
+
+  @SneakyThrows
+  @Test
+  void extractGithubOrganizationAuthoritiesUsesProvidedProxyWebClient() {
+    WireMockServer githubServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+    WireMockServer proxyServer = new WireMockServer(WireMockConfiguration.wireMockConfig().dynamicPort());
+    githubServer.start();
+    proxyServer.start();
+
+    try {
+      githubServer.stubFor(get(urlPathEqualTo("/user/orgs"))
+          .willReturn(aResponse()
+              .withStatus(200)
+              .withHeader("Content-Type", "application/json")
+              .withBody("[{\"login\":\"open-metadata\"}]")));
+      proxyServer.stubFor(WireMock.any(urlMatching(".*"))
+          .willReturn(aResponse().proxiedFrom(githubServer.baseUrl())));
+
+      ProviderAuthorityExtractor extractor = new GithubAuthorityExtractor();
+      AccessControlService acs = new AccessControlServiceMock(List.of(githubOrganizationRole())).getMock();
+
+      OAuth2User oauth2User = new DefaultOAuth2User(
+          AuthorityUtils.createAuthorityList("SCOPE_read:org"),
+          Map.of("login", "john@kafka.com", "organizations_url", githubServer.baseUrl() + "/orgs"),
+          "login");
+
+      WebClient proxyWebClient = WebClient.builder()
+          .clientConnector(new ReactorClientHttpConnector(HttpClient.create()
+              .proxy(proxy -> proxy
+                  .type(ProxyProvider.Proxy.HTTP)
+                  .host("localhost")
+                  .port(proxyServer.port()))))
+          .build();
+
+      HashMap<String, Object> additionalParams = new HashMap<>();
+      additionalParams.put("provider", new OAuthProperties.OAuth2Provider());
+      additionalParams.put(ProviderAuthorityExtractor.OAUTH_WEB_CLIENT, proxyWebClient);
+      additionalParams.put("request", new OAuth2UserRequest(
+          withRegistrationId("github")
+              .clientId("client-1")
+              .clientSecret("secret")
+              .redirectUri("https://client.com")
+              .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+              .authorizationUri(githubServer.baseUrl() + "/oauth2/authorization")
+              .tokenUri(githubServer.baseUrl() + "/oauth2/token")
+              .userInfoUri(githubServer.baseUrl() + "/user")
+              .userNameAttributeName("login")
+              .clientName("GitHub")
+              .build(),
+          new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "XXXX", Instant.now(),
+              Instant.now().plus(10, ChronoUnit.HOURS))));
+
+      Set<String> roles = extractor.extract(acs, oauth2User, additionalParams).block();
+
+      assertNotNull(roles);
+      assertEquals(Set.of("github-org-viewer"), roles);
+      githubServer.verify(getRequestedFor(urlPathEqualTo("/user/orgs")));
+      proxyServer.verify(getRequestedFor(urlPathEqualTo("/user/orgs")));
+    } finally {
+      proxyServer.stop();
+      githubServer.stop();
+    }
+  }
+
+  private Role githubOrganizationRole() {
+    Subject subject = new Subject();
+    subject.setProvider(Provider.OAUTH_GITHUB);
+    subject.setType("organization");
+    subject.setValue("open-metadata");
+
+    Role role = new Role();
+    role.setName("github-org-viewer");
+    role.setClusters(List.of("local"));
+    role.setSubjects(List.of(subject));
+    return role;
   }
 
   @SneakyThrows


### PR DESCRIPTION
## Problem
OAuth login already uses the configured proxy-aware `WebClient`, but GitHub organization and team authority lookups created a new `WebClient` directly from the user-info endpoint. In proxied deployments, that bypasses the configured proxy during RBAC role extraction.

## Solution
- Pass the OAuth `WebClient` into provider authority extractors.
- Reuse that client for GitHub organization/team lookups while preserving the existing GitHub user-info endpoint fallback.
- Add WireMock coverage that verifies GitHub organization authority requests are routed through the provided proxy client.

## Validation
- `./gradlew :api:test --tests io.kafbat.ui.config.RegexBasedProviderAuthorityExtractorTest --no-daemon`

Fixes #1907


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth and OIDC authorization when provider requests require a configured proxy.
  * GitHub organization and team-based roles can now be resolved through the appropriate network route.
  * Preserved existing authorization behavior while supporting reused OAuth connections.

* **Tests**
  * Added coverage validating GitHub organization role extraction through a proxied connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->