### PR TITLE
Restore SchemaRegistry serde auto-selection for topic subjects

### DIFF
--- a/api/src/main/java/io/kafbat/ui/serdes/ClusterSerdes.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/ClusterSerdes.java
@@ -47,11 +47,13 @@ public class ClusterSerdes implements Closeable {
     }
     if (type == Serde.Target.KEY
         && defaultKeySerde != null
+        && defaultKeySerde.couldBePreferable(topic, type)
         && additionalCheck.test(defaultKeySerde)) {
       return Optional.of(defaultKeySerde);
     }
     if (type == Serde.Target.VALUE
         && defaultValueSerde != null
+        && defaultValueSerde.couldBePreferable(topic, type)
         && additionalCheck.test(defaultValueSerde)) {
       return Optional.of(defaultValueSerde);
     }

--- a/api/src/main/java/io/kafbat/ui/serdes/SerdesInitializer.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/SerdesInitializer.java
@@ -138,9 +138,13 @@ public class SerdesInitializer {
         registeredSerdes,
         Optional.ofNullable(clusterProperties.getDefaultKeySerde())
             .map(name -> Preconditions.checkNotNull(registeredSerdes.get(name), "Default key serde not found"))
+            .or(() -> Optional.ofNullable(registeredSerdes.get(SchemaRegistrySerde.NAME)))
+            .or(() -> Optional.ofNullable(registeredSerdes.get(ProtobufFileSerde.NAME)))
             .orElse(null),
         Optional.ofNullable(clusterProperties.getDefaultValueSerde())
             .map(name -> Preconditions.checkNotNull(registeredSerdes.get(name), "Default value serde not found"))
+            .or(() -> Optional.ofNullable(registeredSerdes.get(SchemaRegistrySerde.NAME)))
+            .or(() -> Optional.ofNullable(registeredSerdes.get(ProtobufFileSerde.NAME)))
             .orElse(null),
         createFallbackSerde()
     );


### PR DESCRIPTION
Fixes a regression introduced in #1650 where `SchemaRegistrySerde` was removed as the `defaultValueSerde` in `SerdesInitializer`, breaking auto-selection of SchemaRegistry when a schema subject is present in the registry.

This PR restores `SchemaRegistrySerde` (and `ProtobufFileSerde`) as fallback default serdes in `SerdesInitializer` and modifies `ClusterSerdes` to correctly evaluate `couldBePreferable` for default serdes before auto-selecting them. This ensures that SchemaRegistry deserialization is only attempted if a matching subject is actually present in the registry, and gracefully falls back to `StringSerde` otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection of default key and value serializers based on topic and data type compatibility.
  * Added fallback support for schema registry and Protobuf serializers when explicit defaults are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->