### PR TITLE
Throttle SSE CONSUMING events to prevent UI freeze on large topics

### DIFF
--- a/api/src/main/java/io/kafbat/ui/emitter/ConsumingStats.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/ConsumingStats.java
@@ -12,16 +12,21 @@ class ConsumingStats {
   private int records = 0;
   private long elapsed = 0;
   private int filterApplyErrors = 0;
+  private long lastSentTime = 0;
 
   void sendConsumingEvt(FluxSink<TopicMessageEventDTO> sink, PolledRecords polledRecords) {
     bytes += polledRecords.bytes();
     records += polledRecords.count();
     elapsed += polledRecords.elapsed().toMillis();
-    sink.next(
-        new TopicMessageEventDTO()
-            .type(TopicMessageEventDTO.TypeEnum.CONSUMING)
-            .consuming(createConsumingStats())
-    );
+    long now = System.currentTimeMillis();
+    if (lastSentTime == 0 || now - lastSentTime > 500) {
+      sink.next(
+          new TopicMessageEventDTO()
+              .type(TopicMessageEventDTO.TypeEnum.CONSUMING)
+              .consuming(createConsumingStats())
+      );
+      lastSentTime = now;
+    }
   }
 
   void incFilterApplyError() {


### PR DESCRIPTION
Fixes #1896.

This PR throttles the emission of `TopicMessageEventDTO.TypeEnum.CONSUMING` events to a maximum of one per 500ms. When scanning very large topics (e.g., 10M+ messages), the backend can rapidly stream tens of thousands of `CONSUMING` events to the client over Server-Sent Events (SSE). Processing each of these events continuously triggers state updates on the frontend, which easily overwhelms the browser thread and causes the UI to freeze or crash with a white screen.

By rate-limiting these progress updates, we maintain responsive real-time feedback without freezing the user interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced the frequency of consuming status updates while continuing to track processed records, data volume, and elapsed time.
  * Helps prevent excessive event updates during high-volume message consumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->