### PR TITLE
Fix empty custom topic parameter row removal

### DIFF
--- a/frontend/src/components/Topics/shared/Form/CustomParams/CustomParams.tsx
+++ b/frontend/src/components/Topics/shared/Form/CustomParams/CustomParams.tsx
@@ -44,13 +44,14 @@ const CustomParams: React.FC<CustomParamsProps> = ({
 
   const [existingFields, setExistingFields] = React.useState<string[]>([]);
   const removeField = (index: number): void => {
-    const itemIndex = existingFields.indexOf(controlledFields[index].name);
-    if (itemIndex !== -1) {
-      existingFields.splice(itemIndex, 1);
-      setExistingFields(existingFields);
-      remove(index);
-      trigger('customParams');
+    const fieldName = controlledFields[index].name;
+    if (fieldName) {
+      setExistingFields((currentFields) =>
+        currentFields.filter((name) => name !== fieldName)
+      );
     }
+    remove(index);
+    trigger('customParams');
   };
 
   return (

--- a/frontend/src/components/Topics/shared/Form/CustomParams/__test__/CustomParams.spec.tsx
+++ b/frontend/src/components/Topics/shared/Form/CustomParams/__test__/CustomParams.spec.tsx
@@ -146,6 +146,16 @@ describe('CustomParams', () => {
       expect(getAllValueInputs().length).toBe(3);
     });
 
+    it('removes an empty custom param fieldset', async () => {
+      await userEvent.click(getAddNewFieldButton());
+
+      expect(getAllCustomParamInputs().length).toBe(2);
+
+      await userEvent.click(screen.getByTitle('Delete customParam field 1'));
+
+      expect(getAllCustomParamInputs().length).toBe(1);
+    });
+
     it("can't select already selected option", async () => {
       await userEvent.click(getAddNewFieldButton());
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Fixed the custom topic parameter form so an empty custom parameter row can be removed after it is added.

Previously, the remove handler only removed a row when the selected parameter name already existed in `existingFields`. Empty rows do not have a selected parameter name, so clicking the remove button had no effect.

The updated handler now always removes the selected row, and only updates `existingFields` when the row has a selected parameter name. This keeps duplicate-option tracking intact while allowing empty rows to be deleted normally.

Added a regression test for removing an empty custom parameter row.

Fixes #1673

**Is there anything you'd like reviewers to focus on?**

Please verify the removal behavior for both empty custom parameter rows and rows with a selected parameter name.


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

Not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deletion of empty custom parameter fields so the selected fieldset is removed reliably.
  * Ensured custom parameter values refresh correctly after a field is deleted.

* **Tests**
  * Added coverage confirming that deleting a newly added empty custom parameter removes it from the form.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->