### PR TITLE
Handle invalid JSONPath in message preview filters

### DIFF
--- a/frontend/src/components/Topics/Topic/Messages/Message.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Message.tsx
@@ -90,14 +90,21 @@ const Message: React.FC<Props> = ({ message, keyFilters, contentFilters }) => {
     return (
       <>
         {filters.map((item) => {
-          return (
-            <div key={`${item.path}--${item.field}`}>
-              {item.field}:{' '}
-              {JSON.stringify(
-                JSONPath({ path: item.path, json: parsedJson, wrap: false })
-              )}
-            </div>
-          );
+          try {
+            const value = JSONPath({
+              path: item.path,
+              json: parsedJson,
+              wrap: false,
+            });
+
+            return (
+              <div key={`${item.path}--${item.field}`}>
+                {item.field}: {JSON.stringify(value)}
+              </div>
+            );
+          } catch {
+            return null;
+          }
         })}
       </>
     );

--- a/frontend/src/components/Topics/Topic/Messages/__test__/Message.spec.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/__test__/Message.spec.tsx
@@ -176,6 +176,17 @@ describe('Message component', () => {
     expect(keyFiltered).toBeInTheDocument();
   });
 
+  it('does not crash when a saved preview filter has an invalid JSONPath', () => {
+    const props = {
+      message: { ...mockMessage, value: mockMessageValue as string },
+      contentFilters: [{ field: 'author', path: '$..[' }],
+    };
+
+    renderComponent(props);
+
+    expect(screen.getByText(mockMessage.offset.toString())).toBeInTheDocument();
+  });
+
   it('shows action options in dropdown on click', async () => {
     renderComponent();
     const trElement = screen.getByRole('row');


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented malformed message preview filters from crashing the message list.
  * Messages now continue rendering when a saved JSONPath filter is invalid.

* **Tests**
  * Added coverage to verify messages remain visible when invalid filters are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
