### PR TITLE
Fix CEL numeric comparison for JSON value fields

### DIFF
--- a/api/src/main/java/io/kafbat/ui/emitter/MessageFilters.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/MessageFilters.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.Strings.CS;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableSet;
@@ -50,7 +51,8 @@ public class MessageFilters {
   private static final CelRuntime CEL_RUNTIME = createRuntime();
   private static final Object CELL_NULL_VALUE = NullValue.NULL_VALUE;
 
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final ObjectMapper OBJECT_MAPPER =
+      new ObjectMapper().configure(DeserializationFeature.USE_LONG_FOR_INTS, true);
   private static final Pattern HEX_IN_UNICODE_ESCAPE = Pattern.compile("(?<=\\\\u)[0-9A-F]{4}");
 
   public static Predicate<TopicMessageDTO> noop() {

--- a/api/src/test/java/io/kafbat/ui/emitter/MessageFiltersTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/MessageFiltersTest.java
@@ -270,6 +270,17 @@ class MessageFiltersTest {
       assertFalse(f.test(msg().value(msg)));
     }
 
+    @Test
+    void canCompareNumericValueFields() {
+      String msg = "{ \"price\": 399 }";
+
+      assertTrue(celScriptFilter("record.value.price == 399").test(msg().value(msg)));
+      assertTrue(celScriptFilter("record.value.price > 300").test(msg().value(msg)));
+      assertTrue(celScriptFilter("record.value.price >= 399").test(msg().value(msg)));
+      assertTrue(celScriptFilter("record.value.price < 500").test(msg().value(msg)));
+      assertFalse(celScriptFilter("record.value.price > 400").test(msg().value(msg)));
+    }
+
   }
 
   @Test

--- a/api/src/test/java/io/kafbat/ui/emitter/MessageFiltersTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/MessageFiltersTest.java
@@ -270,17 +270,18 @@ class MessageFiltersTest {
       assertFalse(f.test(msg().value(msg)));
     }
 
-    @Test
+    `@Test`
     void canCompareNumericValueFields() {
       String msg = "{ \"price\": 399 }";
 
       assertTrue(celScriptFilter("record.value.price == 399").test(msg().value(msg)));
       assertTrue(celScriptFilter("record.value.price > 300").test(msg().value(msg)));
       assertTrue(celScriptFilter("record.value.price >= 399").test(msg().value(msg)));
+      assertTrue(celScriptFilter("record.value.price <= 399").test(msg().value(msg)));
+      assertFalse(celScriptFilter("record.value.price <= 398").test(msg().value(msg)));
       assertTrue(celScriptFilter("record.value.price < 500").test(msg().value(msg)));
       assertFalse(celScriptFilter("record.value.price > 400").test(msg().value(msg)));
     }
-
   }
 
   @Test

--- a/api/src/test/java/io/kafbat/ui/emitter/MessageFiltersTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/MessageFiltersTest.java
@@ -270,7 +270,7 @@ class MessageFiltersTest {
       assertFalse(f.test(msg().value(msg)));
     }
 
-    `@Test`
+    @Test
     void canCompareNumericValueFields() {
       String msg = "{ \"price\": 399 }";
 


### PR DESCRIPTION
Closes #1922

<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
<!-- ignore-task-list-end -->

**What changes did you make?** (Give an overview)

CEL smart filters couldn't use ordering operators (`>`, `<`, `>=`, `<=`) on a numeric field from a JSON message key/value. Small integers are read by Jackson as `Integer`, which CEL has no ordering overload for, so the filter matched nothing and showed no error. The filter's `ObjectMapper` now uses `USE_LONG_FOR_INTS`, so JSON integers are read as `long` (CEL `int64`). Equality and the other filters are unaffected.

**Is there anything you'd like reviewers to focus on?**

This `ObjectMapper` is only used to parse the key/value for CEL evaluation, so the change doesn't affect how messages are displayed.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Added a unit test that fails before the change (`No matching overload for function '_>_'. Overload candidates: greater_int64`) and passes after. Also checked against the `main` image: `record.value.price > 400` returned nothing before and matches after.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numeric JSON deserialization in message filters so integer values are handled consistently during numeric comparisons.
  * Helps ensure equality and range evaluations (e.g., < and <=) behave correctly when processing message content.

* **Tests**
  * Updated a unit test annotation to ensure the numeric comparison test suite is properly discovered and executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->