### PR TITLE
Add collapsible tree view with Code/Tree toggle for JSON/AVRO schema values

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -126,7 +126,16 @@
         "@typescript-eslint/parser": "8.39.0",
         "@typescript-eslint/eslint-plugin": "8.39.0"
       }
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@nestjs/core",
+      "@openapitools/openapi-generator-cli",
+      "@parcel/watcher",
+      "@swc/core",
+      "core-js",
+      "esbuild",
+      "unrs-resolver"
+    ]
   },
   "packageManager": "pnpm@10.26.1"
 }

--- a/frontend/src/components/common/EditorViewer/EditorViewer.styled.ts
+++ b/frontend/src/components/common/EditorViewer/EditorViewer.styled.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 
 export const Wrapper = styled.div`
   background-color: ${({ theme }) => theme.viewer.wrapper.backgroundColor};
@@ -11,3 +11,36 @@ export const Wrapper = styled.div`
     color: ${({ theme }) => theme.viewer.wrapper.color} !important;
   }
 `;
+
+export const ViewToggle = styled.nav`
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 8px;
+`;
+
+export const ViewToggleButton = styled.button<{ $active?: boolean }>(
+  ({ theme, $active }) => css`
+    background-color: ${theme.secondaryTab.backgroundColor[
+      $active ? 'active' : 'normal'
+    ]};
+    color: ${theme.secondaryTab.color[$active ? 'active' : 'normal']};
+    padding: 4px 12px;
+    height: 28px;
+    font-size: 12px;
+    border: 1px solid ${theme.layout.stuffBorderColor};
+    cursor: pointer;
+    &:hover {
+      background-color: ${theme.secondaryTab.backgroundColor.hover};
+      color: ${theme.secondaryTab.color.hover};
+    }
+    &:first-child {
+      border-radius: 4px 0 0 4px;
+    }
+    &:last-child {
+      border-radius: 0 4px 4px 0;
+    }
+    &:not(:last-child) {
+      border-right: 0;
+    }
+  `
+);

--- a/frontend/src/components/common/EditorViewer/EditorViewer.tsx
+++ b/frontend/src/components/common/EditorViewer/EditorViewer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Editor from 'components/common/Editor/Editor';
+import JsonTreeView from 'components/common/JsonTreeView/JsonTreeView';
 import { SchemaType } from 'generated-sources';
 import { parse, stringify } from 'lossless-json';
 
@@ -10,32 +11,63 @@ export interface EditorViewerProps {
   schemaType?: string;
   maxLines?: number;
 }
-const getSchemaValue = (data: string, schemaType?: string) => {
-  if (schemaType === SchemaType.JSON || schemaType === SchemaType.AVRO) {
-    return stringify(parse(data), undefined, '\t');
-  }
-  return data;
-};
+
+type ViewMode = 'code' | 'tree';
+
+const isTreeableType = (schemaType?: string) =>
+  schemaType === SchemaType.JSON || schemaType === SchemaType.AVRO;
+
 const EditorViewer: React.FC<EditorViewerProps> = ({
   data,
   schemaType,
   maxLines,
 }) => {
+  const [viewMode, setViewMode] = React.useState<ViewMode>('code');
+
   try {
+    const isTreeable = isTreeableType(schemaType);
+    const parsedData = isTreeable ? parse(data) : undefined;
+    const codeValue = isTreeable
+      ? stringify(parsedData, undefined, '\t')
+      : data;
+    const canShowTree = isTreeable && parsedData !== undefined;
+
     return (
       <S.Wrapper>
-        <Editor
-          isFixedHeight
-          schemaType={schemaType}
-          name="schema"
-          value={getSchemaValue(data, schemaType)}
-          setOptions={{
-            showLineNumbers: false,
-            maxLines,
-            showGutter: false,
-          }}
-          readOnly
-        />
+        {canShowTree && (
+          <S.ViewToggle>
+            <S.ViewToggleButton
+              type="button"
+              $active={viewMode === 'code'}
+              onClick={() => setViewMode('code')}
+            >
+              Code
+            </S.ViewToggleButton>
+            <S.ViewToggleButton
+              type="button"
+              $active={viewMode === 'tree'}
+              onClick={() => setViewMode('tree')}
+            >
+              Tree
+            </S.ViewToggleButton>
+          </S.ViewToggle>
+        )}
+        {canShowTree && viewMode === 'tree' ? (
+          <JsonTreeView data={parsedData} />
+        ) : (
+          <Editor
+            isFixedHeight
+            schemaType={schemaType}
+            name="schema"
+            value={codeValue}
+            setOptions={{
+              showLineNumbers: false,
+              maxLines,
+              showGutter: false,
+            }}
+            readOnly
+          />
+        )}
       </S.Wrapper>
     );
   } catch {

--- a/frontend/src/components/common/EditorViewer/__test__/EditorViewer.spec.tsx
+++ b/frontend/src/components/common/EditorViewer/__test__/EditorViewer.spec.tsx
@@ -4,6 +4,7 @@ import EditorViewer, {
 } from 'components/common/EditorViewer/EditorViewer';
 import { render } from 'lib/testHelpers';
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 const data = { a: 1 };
 const maxLines = 28;
@@ -28,5 +29,41 @@ describe('EditorViewer component', () => {
       maxLines,
       schemaType,
     });
+  });
+
+  it('shows a Code/Tree toggle for JSON data, defaulting to Code view', () => {
+    setupComponent({
+      data: JSON.stringify(data),
+      maxLines,
+      schemaType,
+    });
+    expect(screen.getByRole('button', { name: 'Code' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Tree' })).toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('switches to the tree view when Tree is clicked', async () => {
+    setupComponent({
+      data: JSON.stringify(data),
+      maxLines,
+      schemaType,
+    });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Tree' }));
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('does not show the toggle for non-JSON/AVRO schema types', () => {
+    setupComponent({
+      data: 'syntax Foo {}',
+      maxLines,
+      schemaType: 'PROTOBUF',
+    });
+    expect(
+      screen.queryByRole('button', { name: 'Tree' })
+    ).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/common/JsonTreeView/JsonTreeView.styled.ts
+++ b/frontend/src/components/common/JsonTreeView/JsonTreeView.styled.ts
@@ -1,0 +1,70 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  font-family: Inconsolata, monospace;
+  font-size: 14px;
+  line-height: 19px;
+  overflow: auto;
+`;
+
+export const Row = styled.div`
+  display: flex;
+  align-items: flex-start;
+  white-space: pre;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.viewer.tree.rowHover};
+  }
+`;
+
+export const Indent = styled.span<{ $depth: number }>`
+  flex-shrink: 0;
+  width: ${({ $depth }) => $depth * 16 + 16}px;
+`;
+
+export const ToggleRow = styled.button`
+  display: flex;
+  align-items: flex-start;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+
+  &:focus-visible {
+    outline: 1px solid ${({ theme }) => theme.viewer.tree.key};
+  }
+`;
+
+export const Arrow = styled.span<{ $isOpen: boolean }>`
+  flex-shrink: 0;
+  width: 16px;
+  display: inline-block;
+  color: ${({ theme }) => theme.viewer.tree.muted};
+  transform: rotate(${({ $isOpen }) => ($isOpen ? 90 : 0)}deg);
+  transition: transform 0.1s ease-in-out;
+`;
+
+export const Key = styled.span`
+  color: ${({ theme }) => theme.viewer.tree.key};
+`;
+
+export const Punctuation = styled.span`
+  color: ${({ theme }) => theme.viewer.tree.punctuation};
+`;
+
+export const Muted = styled.span`
+  color: ${({ theme }) => theme.viewer.tree.muted};
+  font-style: italic;
+`;
+
+export const StringValue = styled.span`
+  color: ${({ theme }) => theme.viewer.tree.string};
+`;
+
+export const NumberValue = styled.span`
+  color: ${({ theme }) => theme.viewer.tree.number};
+`;

--- a/frontend/src/components/common/JsonTreeView/JsonTreeView.tsx
+++ b/frontend/src/components/common/JsonTreeView/JsonTreeView.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { isLosslessNumber } from 'lossless-json';
+
+import * as S from './JsonTreeView.styled';
+
+export interface JsonTreeViewProps {
+  data: unknown;
+  /**
+   * Nodes at a depth below this value start expanded, everything at or
+   * beyond it starts collapsed. Root is depth 0.
+   */
+  defaultExpandDepth?: number;
+}
+
+type Entry = [key: string | number, value: unknown];
+
+const isContainer = (value: unknown): value is object | unknown[] =>
+  typeof value === 'object' && value !== null && !isLosslessNumber(value);
+
+const getEntries = (value: object | unknown[]): Entry[] =>
+  Array.isArray(value)
+    ? value.map((item, index): Entry => [index, item])
+    : Object.entries(value);
+
+const formatPrimitive = (value: unknown) => {
+  if (isLosslessNumber(value)) {
+    return { type: 'number', text: value.toString() } as const;
+  }
+  if (value === null) {
+    return { type: 'null', text: 'null' } as const;
+  }
+  switch (typeof value) {
+    case 'string':
+      return { type: 'string', text: JSON.stringify(value) } as const;
+    case 'number':
+      return { type: 'number', text: String(value) } as const;
+    case 'boolean':
+      return { type: 'boolean', text: value ? 'true' : 'false' } as const;
+    default:
+      return { type: 'null', text: String(value) } as const;
+  }
+};
+
+interface JsonTreeNodeProps {
+  nodeKey?: string | number;
+  value: unknown;
+  depth: number;
+  path: string;
+  isLast: boolean;
+  defaultExpandDepth: number;
+}
+
+const NodeKey: React.FC<{ nodeKey?: string | number }> = ({ nodeKey }) => {
+  if (nodeKey === undefined) {
+    return null;
+  }
+  return (
+    <>
+      <S.Key>{typeof nodeKey === 'number' ? nodeKey : `"${nodeKey}"`}</S.Key>
+      <S.Punctuation>: </S.Punctuation>
+    </>
+  );
+};
+
+const JsonTreeNode: React.FC<JsonTreeNodeProps> = ({
+  nodeKey,
+  value,
+  depth,
+  path,
+  isLast,
+  defaultExpandDepth,
+}) => {
+  const [isOpen, setIsOpen] = React.useState(depth < defaultExpandDepth);
+
+  if (!isContainer(value)) {
+    const { type, text } = formatPrimitive(value);
+    const ValueComponent =
+      // eslint-disable-next-line no-nested-ternary
+      type === 'string'
+        ? S.StringValue
+        : type === 'number'
+          ? S.NumberValue
+          : S.Muted;
+
+    return (
+      <S.Row>
+        <S.Indent $depth={depth} />
+        <NodeKey nodeKey={nodeKey} />
+        <ValueComponent>{text}</ValueComponent>
+        {!isLast && <S.Punctuation>,</S.Punctuation>}
+      </S.Row>
+    );
+  }
+
+  const entries = getEntries(value);
+  const isArray = Array.isArray(value);
+  const openBracket = isArray ? '[' : '{';
+  const closeBracket = isArray ? ']' : '}';
+  const itemLabel = entries.length === 1 ? 'item' : 'items';
+
+  if (entries.length === 0) {
+    return (
+      <S.Row>
+        <S.Indent $depth={depth} />
+        <NodeKey nodeKey={nodeKey} />
+        <S.Punctuation>
+          {openBracket}
+          {closeBracket}
+        </S.Punctuation>
+        {!isLast && <S.Punctuation>,</S.Punctuation>}
+      </S.Row>
+    );
+  }
+
+  return (
+    <>
+      <S.Row>
+        <S.ToggleRow
+          type="button"
+          aria-expanded={isOpen}
+          aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${nodeKey ?? 'root'}`}
+          onClick={() => setIsOpen((prev) => !prev)}
+        >
+          <S.Indent $depth={depth}>
+            <S.Arrow $isOpen={isOpen}>▶</S.Arrow>
+          </S.Indent>
+          <NodeKey nodeKey={nodeKey} />
+          <S.Punctuation>{openBracket}</S.Punctuation>
+          {!isOpen && (
+            <S.Muted>
+              {' '}
+              … {entries.length} {itemLabel}{' '}
+            </S.Muted>
+          )}
+          {!isOpen && <S.Punctuation>{closeBracket}</S.Punctuation>}
+          {!isOpen && !isLast && <S.Punctuation>,</S.Punctuation>}
+        </S.ToggleRow>
+      </S.Row>
+      {isOpen && (
+        <>
+          {entries.map(([entryKey, entryValue], index) => (
+            <JsonTreeNode
+              key={`${path}.${entryKey}`}
+              nodeKey={entryKey}
+              value={entryValue}
+              depth={depth + 1}
+              path={`${path}.${entryKey}`}
+              isLast={index === entries.length - 1}
+              defaultExpandDepth={defaultExpandDepth}
+            />
+          ))}
+          <S.Row>
+            <S.Indent $depth={depth} />
+            <S.Punctuation>{closeBracket}</S.Punctuation>
+            {!isLast && <S.Punctuation>,</S.Punctuation>}
+          </S.Row>
+        </>
+      )}
+    </>
+  );
+};
+
+const JsonTreeView: React.FC<JsonTreeViewProps> = ({
+  data,
+  defaultExpandDepth = 2,
+}) => {
+  return (
+    <S.Wrapper>
+      <JsonTreeNode
+        value={data}
+        depth={0}
+        path="root"
+        isLast
+        defaultExpandDepth={defaultExpandDepth}
+      />
+    </S.Wrapper>
+  );
+};
+
+export default JsonTreeView;

--- a/frontend/src/components/common/JsonTreeView/__test__/JsonTreeView.spec.tsx
+++ b/frontend/src/components/common/JsonTreeView/__test__/JsonTreeView.spec.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'lib/testHelpers';
+import JsonTreeView from 'components/common/JsonTreeView/JsonTreeView';
+
+const data = {
+  name: 'kafbat',
+  version: 42,
+  isActive: true,
+  owner: null,
+  tags: ['ui', 'kafka'],
+  nested: {
+    value: 'hidden',
+  },
+};
+
+describe('JsonTreeView', () => {
+  it('renders primitive values and object/array brackets for expanded nodes', () => {
+    render(<JsonTreeView data={data} defaultExpandDepth={2} />);
+
+    expect(screen.getByText('"kafbat"')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('true')).toBeInTheDocument();
+    expect(screen.getByText('null')).toBeInTheDocument();
+    expect(screen.getByText('"ui"')).toBeInTheDocument();
+    expect(screen.getByText('"hidden"')).toBeInTheDocument();
+  });
+
+  it('collapses nodes past the default expand depth', () => {
+    render(<JsonTreeView data={data} defaultExpandDepth={1} />);
+
+    // "nested" itself is visible (depth 1) but its contents (depth 2) are not
+    expect(screen.getByText('"nested"')).toBeInTheDocument();
+    expect(screen.queryByText('"hidden"')).not.toBeInTheDocument();
+  });
+
+  it('expands a collapsed node on click', async () => {
+    render(<JsonTreeView data={data} defaultExpandDepth={1} />);
+
+    expect(screen.queryByText('"hidden"')).not.toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', { name: /expand nested/i })
+    );
+
+    expect(screen.getByText('"hidden"')).toBeInTheDocument();
+  });
+
+  it('collapses an expanded node back on second click', async () => {
+    render(<JsonTreeView data={data} defaultExpandDepth={2} />);
+
+    const toggle = screen.getByRole('button', { name: /collapse nested/i });
+    expect(screen.getByText('"hidden"')).toBeInTheDocument();
+
+    await userEvent.click(toggle);
+
+    expect(screen.queryByText('"hidden"')).not.toBeInTheDocument();
+  });
+
+  it('renders array items without quoted keys', () => {
+    render(<JsonTreeView data={['ui', 'kafka']} defaultExpandDepth={1} />);
+
+    expect(screen.getByText('"ui"')).toBeInTheDocument();
+    expect(screen.getByText('"kafka"')).toBeInTheDocument();
+  });
+
+  it('renders an empty object without a toggle', () => {
+    render(<JsonTreeView data={{}} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/theme/theme.ts
+++ b/frontend/src/theme/theme.ts
@@ -887,6 +887,14 @@ export const theme = {
       backgroundColor: Colors.neutral[3],
       color: Colors.neutral[80],
     },
+    tree: {
+      key: Colors.neutral[70],
+      string: Colors.green[70],
+      number: Colors.blue[50],
+      punctuation: Colors.neutral[40],
+      muted: Colors.neutral[40],
+      rowHover: Colors.neutral[5],
+    },
   },
   activeFilter: {
     color: Colors.neutral[70],
@@ -1495,6 +1503,14 @@ export const darkTheme: ThemeType = {
     wrapper: {
       backgroundColor: Colors.neutral[85],
       color: Colors.neutral[0],
+    },
+    tree: {
+      key: Colors.neutral[30],
+      string: Colors.green[40],
+      number: Colors.blue[30],
+      punctuation: Colors.neutral[50],
+      muted: Colors.neutral[50],
+      rowHover: Colors.neutral[80],
     },
   },
   activeFilter: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,7 +25,7 @@ export default defineConfig(({ mode }) => {
     checker({
       overlay: { initialIsOpen: false },
       typescript: true,
-      eslint: { lintCommand: 'eslint --ext .tsx,.ts src/' },
+      eslint: { lintCommand: 'eslint --ext .tsx,.ts src/', useFlatConfig: true },
     }),
   ];
 


### PR DESCRIPTION

Adds a Code/Tree toggle to EditorViewer, backed by a new recursive JsonTreeView component. Each object/array node collapses/expands independently, which makes large or deeply-nested schemas (and JSON messages) navigable instead of one long scrollable text blob.

- New JsonTreeView component with per-node collapse state, syntax coloring via new viewer.tree.* theme tokens (light + dark), and correct handling of lossless-json's LosslessNumber wrapper so large integers keep full precision in the tree, same as the code view.
- EditorViewer: adds the Code/Tree toggle (defaults to Code, so existing behavior is unchanged) for JSON/AVRO schema types; reuses the existing secondaryTab theme tokens for visual consistency with the Messages page's Key/Value/Headers tabs.
- Also fixes vite.config.ts's ESLint checker, which was still using pre-flat-config options and crashed `pnpm dev` outright under ESLint 9 (missed in the #1804 flat-config migration).

Closes #1380

**Breaking change?**
No. The toggle defaults to Code view, `EditorViewer`'s public props are unchanged, and the tree view only activates for `JSON`/`AVRO` schema types when the payload actually parses — everything else falls back to the pre-existing behavior untouched.

**What changes did you make?**
- Added `frontend/src/components/common/JsonTreeView/` — a self-contained recursive component that renders parsed JSON as a collapsible tree (own styles, own tests).
- `EditorViewer` now computes the parsed value once (reusing the existing `lossless-json` `parse`/`stringify` call it already made for the code view) and offers a small Code/Tree toggle above the value when the schema type is JSON or AVRO and the data parses successfully.
- Added `viewer.tree.*` tokens to both the light and dark theme for tree syntax coloring (key/string/number/punctuation/muted/row-hover).
- Fixed an unrelated but blocking local-dev bug in `vite.config.ts`: `vite-plugin-checker`'s ESLint integration was still being called with pre-flat-config options under ESLint 9. Adding `useFlatConfig: true` fixes it.

**Is there anything you'd like reviewers to focus on?**
- The default expand depth (`defaultExpandDepth = 2`) — root and its immediate children open, everything deeper starts collapsed. Want to double check this default feels right for typical Avro/JSON schemas (e.g. a `properties` object with many fields).
- Number handling: leaves use `isLosslessNumber()` to detect `lossless-json`'s wrapper type so big integers/decimals don't lose precision in the tree, matching the code view — want a second pair of eyes on that path specifically.
- Toggle buttons are real `<button>`s with `aria-expanded`/`aria-label` rather than clickable `div`s, for keyboard/screen-reader accessibility without extra ARIA plumbing.
- Since `EditorViewer` is shared, this also affects the Messages page's Key/Value/Headers viewer, not just Schema Registry — flagging in case that's considered out of scope for this issue.

**How Has This Been Tested?**
- [x] Manually
- [x] Unit checks

Manual: ran the app locally (backend + frontend from source against a local Kafka), produced a nested JSON message, and exercised the viewer end-to-end — switching Code↔Tree, expanding/collapsing nested objects and arrays at multiple depths, confirming string/number/boolean/null render and color correctly, and confirming collapsed containers show an item count. No new console errors.

Unit: added `JsonTreeView.spec.tsx` (rendering, depth-based collapsing, expand/collapse via click, array item rendering, empty-object edge case) and extended `EditorViewer.spec.tsx` (toggle visibility, switching views, toggle hidden for non-JSON/AVRO types). `pnpm tsc`, `pnpm eslint --max-warnings=0`, and the full Jest suite for both components pass.

**Checklist**: all 7 boxes checked.

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an expandable tree view for JSON and Avro data.
  * Added Code/Tree view controls with automatic fallback for unsupported or invalid data.
  * Added themed styling for tree keys, values, punctuation, indentation, and hover states.

* **Tests**
  * Added coverage for tree rendering, expansion and collapse, nested data, arrays, primitives, and view switching.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->