### PR TITLE
Allow OAuth2 resource-server auth without requiring a dummy client registration

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
@@ -114,7 +114,7 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
           .logout(spec -> spec.logoutSuccessHandler(logoutHandler));
     }
 
-    if (properties.getResourceServer() != null) {
+    if (isResourceServerUsable(properties.getResourceServer())) {
       OAuth2ResourceServerProperties resourceServer = properties.getResourceServer();
       if (resourceServer.getJwt() != null && resourceServer.getJwt().getJwkSetUri() != null) {
         builder.oauth2ResourceServer(c -> c.jwt(j ->
@@ -207,12 +207,29 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
     final List<ClientRegistration> registrations =
         new ArrayList<>(new OAuth2ClientPropertiesMapper(props).asClientRegistrations().values());
     if (registrations.isEmpty()) {
-      if (properties.getResourceServer() == null) {
-        throw new IllegalArgumentException("OAuth2 authentication is enabled but no providers specified.");
+      if (!isResourceServerUsable(properties.getResourceServer())) {
+        throw new IllegalArgumentException(
+            "OAuth2 authentication is enabled but neither a client registration nor a usable "
+                + "resource-server (jwt.jwk-set-uri or opaquetoken.introspection-uri) is configured.");
       }
       return null;
     }
     return new InMemoryReactiveClientRegistrationRepository(registrations);
+  }
+
+  /**
+   * True when {@code resourceServer} has enough configuration to actually authenticate a
+   * request (JWT decoder or opaque-token introspector) — as opposed to merely being a
+   * non-null but effectively empty configuration block.
+   */
+  private static boolean isResourceServerUsable(@Nullable OAuth2ResourceServerProperties resourceServer) {
+    if (resourceServer == null) {
+      return false;
+    }
+    boolean hasJwt = resourceServer.getJwt() != null && resourceServer.getJwt().getJwkSetUri() != null;
+    boolean hasOpaqueToken = resourceServer.getOpaquetoken() != null
+        && resourceServer.getOpaquetoken().getIntrospectionUri() != null;
+    return hasJwt || hasOpaqueToken;
   }
 
   @Bean

--- a/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/auth/OAuthSecurityConfig.java
@@ -19,6 +19,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.DelegatingReactiveAuthenticationManager;
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
@@ -78,23 +79,10 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
       ReactiveOAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> tokenResponseClient,
       ReactiveOAuth2UserService<OidcUserRequest, OidcUser> oidcUserService,
       ReactiveOAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserService,
+      @Nullable ReactiveClientRegistrationRepository clientRegistrationRepository,
       @Qualifier("oauthWebClient") WebClient webClient
   ) {
     log.info("Configuring OAUTH2 authentication.");
-
-    var oidcAuthManager =
-        new OidcAuthorizationCodeReactiveAuthenticationManager(tokenResponseClient, oidcUserService);
-
-    oidcAuthManager.setJwtDecoderFactory(clientRegistration ->
-        NimbusReactiveJwtDecoder.withJwkSetUri(clientRegistration.getProviderDetails().getJwkSetUri())
-            .webClient(webClient)
-            .build());
-
-    var oauth2AuthManager =
-        new OAuth2LoginReactiveAuthenticationManager(tokenResponseClient, oauth2UserService);
-
-    var delegatingAuthManager =
-        new DelegatingReactiveAuthenticationManager(oidcAuthManager, oauth2AuthManager);
 
     var builder = http.authorizeExchange(spec -> spec
             .pathMatchers(AUTH_WHITELIST)
@@ -102,9 +90,29 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
             .anyExchange()
             .authenticated()
         )
-        .oauth2Login(oauth2 -> oauth2.authenticationManager(delegatingAuthManager))
-        .logout(spec -> spec.logoutSuccessHandler(logoutHandler))
         .csrf(ServerHttpSecurity.CsrfSpec::disable);
+
+    // Interactive login (oauth2Login) only makes sense when at least one client
+    // registration is configured. Resource-server-only (bearer/JWT) setups have
+    // no client registrations at all, so this whole block is skipped for them.
+    if (clientRegistrationRepository != null) {
+      var oidcAuthManager =
+          new OidcAuthorizationCodeReactiveAuthenticationManager(tokenResponseClient, oidcUserService);
+
+      oidcAuthManager.setJwtDecoderFactory(clientRegistration ->
+          NimbusReactiveJwtDecoder.withJwkSetUri(clientRegistration.getProviderDetails().getJwkSetUri())
+              .webClient(webClient)
+              .build());
+
+      var oauth2AuthManager =
+          new OAuth2LoginReactiveAuthenticationManager(tokenResponseClient, oauth2UserService);
+
+      var delegatingAuthManager =
+          new DelegatingReactiveAuthenticationManager(oidcAuthManager, oauth2AuthManager);
+
+      builder.oauth2Login(oauth2 -> oauth2.authenticationManager(delegatingAuthManager))
+          .logout(spec -> spec.logoutSuccessHandler(logoutHandler));
+    }
 
     if (properties.getResourceServer() != null) {
       OAuth2ResourceServerProperties resourceServer = properties.getResourceServer();
@@ -185,20 +193,34 @@ public class OAuthSecurityConfig extends AbstractAuthSecurityConfig {
         });
   }
 
+  /**
+   * Absent (returns {@code null}) when only {@code auth.oauth2.resource-server} is configured
+   * and there are no {@code auth.oauth2.client.*} registrations — a valid setup for
+   * bearer/JWT-only (machine-to-machine) auth that doesn't need an interactive login client.
+   * Consumers that require interactive login (e.g. {@link #configure}) must treat a missing
+   * bean as "no client login configured", same as {@link AccessControlService} already does.
+   */
   @Bean
+  @Nullable
   public InMemoryReactiveClientRegistrationRepository clientRegistrationRepository() {
     final OAuth2ClientProperties props = OAuthPropertiesConverter.convertProperties(properties);
     final List<ClientRegistration> registrations =
         new ArrayList<>(new OAuth2ClientPropertiesMapper(props).asClientRegistrations().values());
     if (registrations.isEmpty()) {
-      throw new IllegalArgumentException("OAuth2 authentication is enabled but no providers specified.");
+      if (properties.getResourceServer() == null) {
+        throw new IllegalArgumentException("OAuth2 authentication is enabled but no providers specified.");
+      }
+      return null;
     }
     return new InMemoryReactiveClientRegistrationRepository(registrations);
   }
 
   @Bean
-  public ServerLogoutSuccessHandler defaultOidcLogoutHandler(final ReactiveClientRegistrationRepository repository) {
-    return new OidcClientInitiatedServerLogoutSuccessHandler(repository);
+  public ServerLogoutSuccessHandler defaultOidcLogoutHandler(
+      final @Nullable ReactiveClientRegistrationRepository repository) {
+    return repository != null
+        ? new OidcClientInitiatedServerLogoutSuccessHandler(repository)
+        : (exchange, authentication) -> Mono.empty();
   }
 
   private ProviderAuthorityExtractor getExtractor(final OAuthProperties.OAuth2Provider provider,

--- a/api/src/test/java/io/kafbat/ui/config/auth/OAuthResourceServerOnlyTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/OAuthResourceServerOnlyTest.java
@@ -1,6 +1,7 @@
 package io.kafbat.ui.config.auth;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -9,6 +10,7 @@ import io.kafbat.ui.service.rbac.AccessControlService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.OAuth2ResourceServerProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
@@ -53,6 +55,43 @@ class OAuthResourceServerOnlyTest {
     assertThat(filterChain).isNotNull();
     // no auth.oauth2.client.* configured -> the bean is legitimately absent
     assertThat(repository.getIfAvailable()).isNull();
+  }
+
+  /**
+   * Plain unit tests for {@link OAuthSecurityConfig#clientRegistrationRepository()} —
+   * no client registrations, exercised directly without booting a Spring context.
+   */
+  @Test
+  void throwsWhenNeitherClientNorUsableResourceServerConfigured() {
+    var properties = new OAuthProperties();
+    // no client, no resource-server at all
+    var config = new OAuthSecurityConfig(properties);
+
+    assertThatThrownBy(config::clientRegistrationRepository)
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void throwsWhenResourceServerPresentButEmpty() {
+    var properties = new OAuthProperties();
+    // resource-server block exists but has neither jwt.jwk-set-uri nor
+    // opaquetoken.introspection-uri configured -> not actually usable
+    properties.setResourceServer(new OAuth2ResourceServerProperties());
+    var config = new OAuthSecurityConfig(properties);
+
+    assertThatThrownBy(config::clientRegistrationRepository)
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void returnsNullWhenResourceServerHasJwt() {
+    var properties = new OAuthProperties();
+    var resourceServer = new OAuth2ResourceServerProperties();
+    resourceServer.getJwt().setJwkSetUri("http://localhost/.well-known/jwks.json");
+    properties.setResourceServer(resourceServer);
+    var config = new OAuthSecurityConfig(properties);
+
+    assertThat(config.clientRegistrationRepository()).isNull();
   }
 
   @TestConfiguration

--- a/api/src/test/java/io/kafbat/ui/config/auth/OAuthResourceServerOnlyTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/OAuthResourceServerOnlyTest.java
@@ -94,6 +94,17 @@ class OAuthResourceServerOnlyTest {
     assertThat(config.clientRegistrationRepository()).isNull();
   }
 
+  @Test
+  void returnsNullWhenResourceServerHasOpaqueToken() {
+    var properties = new OAuthProperties();
+    var resourceServer = new OAuth2ResourceServerProperties();
+    resourceServer.getOpaquetoken().setIntrospectionUri("http://localhost/introspect");
+    properties.setResourceServer(resourceServer);
+    var config = new OAuthSecurityConfig(properties);
+
+    assertThat(config.clientRegistrationRepository()).isNull();
+  }
+
   @TestConfiguration
   static class NoClientTestConfig {
 

--- a/api/src/test/java/io/kafbat/ui/config/auth/OAuthResourceServerOnlyTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/auth/OAuthResourceServerOnlyTest.java
@@ -1,0 +1,69 @@
+package io.kafbat.ui.config.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.kafbat.ui.config.auth.logout.OAuthLogoutSuccessHandler;
+import io.kafbat.ui.service.rbac.AccessControlService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.security.oauth2.client.registration.ReactiveClientRegistrationRepository;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.test.context.ActiveProfiles;
+
+/**
+ * Verifies that {@code auth.type=OAUTH2} can start with only
+ * {@code auth.oauth2.resource-server} configured and zero {@code auth.oauth2.client.*}
+ * registrations — a valid bearer/JWT-only (machine-to-machine) setup that previously
+ * failed at startup with "OAuth2 authentication is enabled but no providers specified."
+ *
+ * <p>{@link OAuthLogoutSuccessHandler} is a plain {@code @Component} (not a {@code @Bean}
+ * declared inside {@link OAuthSecurityConfig}), so it must be listed explicitly here —
+ * a bare {@code @SpringBootTest(classes = ...)} slice doesn't component-scan.
+ *
+ * @see <a href="https://github.com/kafbat/kafka-ui/issues/1929">#1929</a>
+ */
+@SpringBootTest(
+    classes = {
+        OAuthSecurityConfig.class,
+        OAuthLogoutSuccessHandler.class,
+        OAuthResourceServerOnlyTest.NoClientTestConfig.class
+    },
+    properties = {
+        "spring.main.allow-bean-definition-overriding=true",
+        "auth.type=OAUTH2",
+        "auth.oauth2.resource-server.jwt.jwk-set-uri=http://localhost/.well-known/jwks.json"
+    })
+@ActiveProfiles("test")
+class OAuthResourceServerOnlyTest {
+
+  @Autowired
+  private SecurityWebFilterChain filterChain;
+  @Autowired
+  private ObjectProvider<ReactiveClientRegistrationRepository> repository;
+
+  @Test
+  void contextLoadsWithoutClientRegistrations() {
+    assertThat(filterChain).isNotNull();
+    // no auth.oauth2.client.* configured -> the bean is legitimately absent
+    assertThat(repository.getIfAvailable()).isNull();
+  }
+
+  @TestConfiguration
+  static class NoClientTestConfig {
+
+    @Bean
+    @Primary
+    AccessControlService accessControlService() {
+      AccessControlService acs = mock(AccessControlService.class);
+      when(acs.getOauthExtractors()).thenReturn(java.util.Collections.emptySet());
+      return acs;
+    }
+  }
+}


### PR DESCRIPTION
### What / why

Currently, when `auth.type=OAUTH2` is set, kafka-ui refuses to start unless at least one `auth.oauth2.client.*` registration is configured, even if the goal is purely bearer/resource-server JWT auth for non-interactive (service/agent) clients. `OAuthSecurityConfig#clientRegistrationRepository()` throws if `registrations.isEmpty()`, regardless of whether a resource-server config is present.

This forces operators who only need machine-to-machine/bearer access to configure a full, unused dummy OAuth2 login client (client-id, secret, authorization/token/userinfo/jwk-set URIs) purely to satisfy this startup check.

### Solution

`clientRegistrationRepository()` now only throws when **both** client registrations and `auth.oauth2.resource-server` are absent (i.e. nothing configured at all). When there are no client registrations but a resource-server *is* configured, the bean is legitimately **absent** (`null`) instead of throwing.

This mirrors a pattern already used elsewhere in the codebase: `AccessControlService` already declares its `ReactiveClientRegistrationRepository` dependency as `@Nullable` and handles a missing repository gracefully. This PR extends that same convention to the two other places in `OAuthSecurityConfig` that assumed a repository always exists:

- `configure(...)`: the interactive `.oauth2Login(...)` / `.logout(...)` filter chain wiring is now skipped entirely when there's no client registration repository, only `.oauth2ResourceServer(...)` is wired for bearer/JWT-only setups.
- `defaultOidcLogoutHandler(...)`: falls back to a no-op `ServerLogoutSuccessHandler` when the repository is absent, instead of failing to construct `OidcClientInitiatedServerLogoutSuccessHandler` (which requires a non-null repository).

No changes were needed in `AccessControlService`, its existing `@Nullable` handling already covers this case correctly.

### Testing

- Added `OAuthResourceServerOnlyTest`: boots `OAuthSecurityConfig` with only `auth.oauth2.resource-server.jwt.jwk-set-uri` set and zero client registrations, asserts the context loads and `ReactiveClientRegistrationRepository` is legitimately absent.
- Ran the full existing `io.kafbat.ui.config.auth.*` test suite (proxy/without-proxy, Azure, Cognito, standard client-registration flow), all passing, no regressions.
- `checkstyleMain` / `checkstyleTest`, clean.

Fixes #1929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OAuth2 resource-server-only configurations can now start without client registrations.
  - Support includes JWT and opaque-token authentication setups.
  - Interactive OAuth login and OIDC logout are enabled only when OAuth clients are configured.

- **Bug Fixes**
  - Applications using resource-server authentication no longer require unnecessary OAuth client settings.
  - Startup validation remains in place when neither authentication configuration is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->