### PR TITLE
Preserve message keys and values in Produce Message form

### DIFF
--- a/frontend/src/components/Topics/Topic/SendMessage/SendMessage.tsx
+++ b/frontend/src/components/Topics/Topic/SendMessage/SendMessage.tsx
@@ -80,11 +80,21 @@ const SendMessage: React.FC<SendMessageProps> = ({
     handleSubmit,
     formState: { isSubmitting },
     control,
+    reset,
     setValue,
   } = useForm<MessageFormData>({
     mode: 'onChange',
     defaultValues: formDefaults,
   });
+
+  // `defaultValues` are only read on mount. Reproduce actions can replace the
+  // message while the sidebar remains mounted, so synchronize the form with
+  // the newly selected message explicitly.
+  React.useEffect(() => {
+    if (messageData) {
+      reset(formDefaults);
+    }
+  }, [messageData, formDefaults, reset]);
 
   const keySerde = useWatch({ control, name: 'keySerde' });
   const valueSerde = useWatch({ control, name: 'valueSerde' });

--- a/frontend/src/components/Topics/Topic/SendMessage/SendMessage.tsx
+++ b/frontend/src/components/Topics/Topic/SendMessage/SendMessage.tsx
@@ -213,8 +213,8 @@ const SendMessage: React.FC<SendMessageProps> = ({
     }
     try {
       await sendMessage.mutateAsync({
-        key: key || null,
-        value: content || null,
+        key: key ?? null,
+        value: content ?? null,
         headers: parsedHeaders,
         partition: partition || 0,
         keySerde: formKeySerde,

--- a/frontend/src/lib/hooks/useProduceMessage.ts
+++ b/frontend/src/lib/hooks/useProduceMessage.ts
@@ -15,10 +15,10 @@ export const useProduceMessage = (): UseProduceMessageReturn => {
   const setMessage = useCallback((message: TopicMessage) => {
     const data: Partial<MessageFormData> = {
       keepContents: false,
-      content: message.value || '',
+      content: message.value ?? '',
     };
 
-    if (message.key) {
+    if (message.key !== undefined && message.key !== null) {
       data.key = message.key;
     }
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)
- Reset the Produce Message form when the selected message changes.
- Preserve empty message values by using nullish checks instead of falsy checks.
- Preserve message keys when the key is an empty string.
**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated message forms to display replacement message content correctly when the sidebar remains open.
  * Preserved valid empty or zero-valued message content and keys when creating or updating messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->