### PR TITLE
feat(schema-registry): support custom BearerAuthCredentialProvider via properties map (#1912)

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
@@ -167,6 +167,32 @@ public class ClustersProperties {
     String username;
     String password;
     OauthConfig oauth;
+    /**
+     * Raw properties forwarded verbatim to the Confluent {@code CachedSchemaRegistryClient}.
+     * Use this to configure bearer auth via a ServiceLoader alias or a CUSTOM provider class
+     * without having to enumerate every possible credential source.
+     *
+     * <p>Example (ServiceLoader alias):
+     * <pre>
+     * schema-registry-auth:
+     *   properties:
+     *     bearer.auth.credentials.source: JWT_ASSERTION
+     *     bearer.auth.issuer.endpoint.url: https://idp.example.com/token
+     *     bearer.auth.client.assertion.location: /var/run/secrets/tokens/sa-token
+     *     bearer.auth.client.id: my-service-account
+     * </pre>
+     *
+     * <p>Example (CUSTOM class):
+     * <pre>
+     * schema-registry-auth:
+     *   properties:
+     *     bearer.auth.credentials.source: CUSTOM
+     *     bearer.auth.custom.provider.class: com.example.MyBearerAuthCredentialProvider
+     * </pre>
+     *
+     * <p>Cannot be combined with {@code username}/{@code password} or {@code oauth}.
+     */
+    Map<String, Object> properties;
   }
 
   @Data

--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerde.java
@@ -95,6 +95,11 @@ public class SchemaRegistrySerde implements BuiltInSerde {
 
     var formatterProperties = propertiesBuilder.build();
 
+    // Collect raw SR client properties from schemaRegistryAuth.properties.*
+    Map<String, Object> extraSrProperties =
+        kafkaClusterProperties.getMapProperty("schemaRegistryAuth.properties", String.class, Object.class)
+            .orElse(null);
+
     configure(
         urls,
         createSchemaRegistryClient(
@@ -105,7 +110,8 @@ public class SchemaRegistrySerde implements BuiltInSerde {
             kafkaClusterProperties.getProperty("schemaRegistrySsl.keystorePassword", String.class).orElse(null),
             kafkaClusterProperties.getProperty("ssl.truststoreLocation", String.class).orElse(null),
             kafkaClusterProperties.getProperty("ssl.truststorePassword", String.class).orElse(null),
-            kafkaClusterProperties.getProperty("ssl.verify", Boolean.class).orElse(true)
+            kafkaClusterProperties.getProperty("ssl.verify", Boolean.class).orElse(true),
+            extraSrProperties
         ),
         kafkaClusterProperties.getProperty("schemaRegistryKeySchemaNameTemplate", String.class).orElse("%s-key"),
         kafkaClusterProperties.getProperty("schemaRegistrySchemaNameTemplate", String.class).orElse("%s-value"),
@@ -146,7 +152,8 @@ public class SchemaRegistrySerde implements BuiltInSerde {
             serdeProperties.getProperty("keystorePassword", String.class).orElse(null),
             kafkaClusterProperties.getProperty("ssl.truststoreLocation", String.class).orElse(null),
             kafkaClusterProperties.getProperty("ssl.truststorePassword", String.class).orElse(null),
-            kafkaClusterProperties.getProperty("ssl.verify", Boolean.class).orElse(true)
+            kafkaClusterProperties.getProperty("ssl.verify", Boolean.class).orElse(true),
+            null
         ),
         serdeProperties.getProperty("keySchemaNameTemplate", String.class).orElse("%s-key"),
         serdeProperties.getProperty("schemaNameTemplate", String.class).orElse("%s-value"),
@@ -203,8 +210,20 @@ public class SchemaRegistrySerde implements BuiltInSerde {
                                                                  @Nullable String keyStorePassword,
                                                                  @Nullable String trustStoreLocation,
                                                                  @Nullable String trustStorePassword,
-                                                                 boolean verifySsl) {
+                                                                 boolean verifySsl,
+                                                                 @Nullable Map<String, Object> extraProperties) {
     Map<String, String> configs = new HashMap<>();
+
+    // Apply custom bearer-auth (or other raw SR client) properties first so that
+    // our explicit configs (basic-auth, SSL) always take precedence over them.
+    if (extraProperties != null) {
+      extraProperties.forEach((k, v) -> {
+        if (v != null) {
+          configs.put(k, v.toString());
+        }
+      });
+    }
+
     if (username != null && password != null) {
       configs.put(BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
       configs.put(USER_INFO_CONFIG, username + ":" + password);

--- a/api/src/main/java/io/kafbat/ui/service/KafkaClusterFactory.java
+++ b/api/src/main/java/io/kafbat/ui/service/KafkaClusterFactory.java
@@ -256,6 +256,8 @@ public class KafkaClusterFactory {
         && StringUtils.hasText(oauth.getClientSecret());
     boolean oauthPartiallyConfigured = StringUtils.hasText(oauth.getTokenUrl())
         || StringUtils.hasText(oauth.getClientId()) || StringUtils.hasText(oauth.getClientSecret());
+    boolean propertiesConfigured = basicAuth.getProperties() != null && !basicAuth.getProperties().isEmpty();
+
     if (oauthPartiallyConfigured && !oauthConfigured) {
       throw new ValidationException(
           "Schema Registry authentication misconfiguration: one of the OAuth Parameters are missing. "
@@ -265,6 +267,12 @@ public class KafkaClusterFactory {
       throw new ValidationException(
           "Schema Registry authentication misconfiguration: both basic auth and OAuth are configured. "
               + "Please configure only one authentication method."
+      );
+    }
+    if (propertiesConfigured && (basicAuthConfigured || oauthConfigured)) {
+      throw new ValidationException(
+          "Schema Registry authentication misconfiguration: 'properties' cannot be combined with "
+              + "basic auth (username/password) or OAuth. Please configure only one authentication method."
       );
     }
 

--- a/api/src/test/java/io/kafbat/ui/service/SchemaRegistryAuthValidationTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/SchemaRegistryAuthValidationTest.java
@@ -7,6 +7,7 @@ import io.kafbat.ui.config.ClustersProperties;
 import io.kafbat.ui.config.WebclientProperties;
 import io.kafbat.ui.exception.ValidationException;
 import io.kafbat.ui.service.metrics.scrape.jmx.JmxMetricsRetriever;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -109,5 +110,64 @@ class SchemaRegistryAuthValidationTest {
     cluster.setSchemaRegistry("http://localhost:8081");
 
     factory.create(new ClustersProperties(), cluster);
+  }
+
+  @Test
+  void shouldNotThrowExceptionWhenOnlyPropertiesConfigured() {
+    ClustersProperties.Cluster cluster = new ClustersProperties.Cluster();
+    cluster.setName("test");
+    cluster.setBootstrapServers("localhost:9092");
+    cluster.setSchemaRegistry("http://localhost:8081");
+
+    ClustersProperties.SchemaRegistryAuth auth = new ClustersProperties.SchemaRegistryAuth();
+    auth.setProperties(Map.of(
+        "bearer.auth.credentials.source", "JWT_ASSERTION",
+        "bearer.auth.client.id", "my-service-account"
+    ));
+    cluster.setSchemaRegistryAuth(auth);
+
+    factory.create(new ClustersProperties(), cluster);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenPropertiesAndBasicAuthConfigured() {
+    ClustersProperties.Cluster cluster = new ClustersProperties.Cluster();
+    cluster.setSchemaRegistry("http://localhost:8081");
+
+    ClustersProperties.SchemaRegistryAuth auth = new ClustersProperties.SchemaRegistryAuth();
+    auth.setUsername("user");
+    auth.setPassword("pass");
+    auth.setProperties(Map.of("bearer.auth.credentials.source", "CUSTOM"));
+    cluster.setSchemaRegistryAuth(auth);
+
+    ValidationException exception = assertThrows(
+        ValidationException.class,
+        () -> factory.create(new ClustersProperties(), cluster)
+    );
+
+    assertTrue(exception.getMessage().contains("'properties' cannot be combined with"));
+  }
+
+  @Test
+  void shouldThrowExceptionWhenPropertiesAndOAuthConfigured() {
+    ClustersProperties.Cluster cluster = new ClustersProperties.Cluster();
+    cluster.setSchemaRegistry("http://localhost:8081");
+
+    ClustersProperties.OauthConfig oauth = new ClustersProperties.OauthConfig();
+    oauth.setTokenUrl("http://localhost:8080/token");
+    oauth.setClientId("client-id");
+    oauth.setClientSecret("client-secret");
+
+    ClustersProperties.SchemaRegistryAuth auth = new ClustersProperties.SchemaRegistryAuth();
+    auth.setOauth(oauth);
+    auth.setProperties(Map.of("bearer.auth.credentials.source", "CUSTOM"));
+    cluster.setSchemaRegistryAuth(auth);
+
+    ValidationException exception = assertThrows(
+        ValidationException.class,
+        () -> factory.create(new ClustersProperties(), cluster)
+    );
+
+    assertTrue(exception.getMessage().contains("'properties' cannot be combined with"));
   }
 }

--- a/documentation/compose/ui-serdes.yaml
+++ b/documentation/compose/ui-serdes.yaml
@@ -25,6 +25,16 @@ services:
             #kafka.clusters.0.schemaRegistryAuth.username: "use"
             #kafka.clusters.0.schemaRegistryAuth.password: "pswrd"
 
+            # bearer auth via ServiceLoader alias (e.g. workload identity / JWT assertion):
+            #kafka.clusters.0.schemaRegistryAuth.properties.bearer.auth.credentials.source: JWT_ASSERTION
+            #kafka.clusters.0.schemaRegistryAuth.properties.bearer.auth.issuer.endpoint.url: https://idp.example.com/token
+            #kafka.clusters.0.schemaRegistryAuth.properties.bearer.auth.client.assertion.location: /var/run/secrets/tokens/sa-token
+            #kafka.clusters.0.schemaRegistryAuth.properties.bearer.auth.client.id: my-service-account
+
+            # bearer auth via a custom BearerAuthCredentialProvider class:
+            #kafka.clusters.0.schemaRegistryAuth.properties.bearer.auth.credentials.source: CUSTOM
+            #kafka.clusters.0.schemaRegistryAuth.properties.bearer.auth.custom.provider.class: com.example.MyBearerAuthCredentialProvider
+
             kafka.clusters.0.defaultKeySerde: Int32  #optional
             kafka.clusters.0.defaultValueSerde: String #optional
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
<!-- ignore-task-list-end -->

**What changes did you make?**

I added support for passing custom key-value configuration properties to Confluent's `CachedSchemaRegistryClient` through a new `properties` map under `schema-registry-auth`.

### Why this is needed
While working with Schema Registry setups that use custom bearer token authentication (such as Kubernetes Workload Identity, dynamic OIDC token projection, or custom `BearerAuthCredentialProvider` implementations), I noticed that Kafbat UI only supported Basic Auth (`username`/`password`) or standard OAuth.

Confluent's Schema Registry client supports pluggable bearer auth via properties like `bearer.auth.credentials.source=JWT_ASSERTION` or `bearer.auth.custom.provider.class=...`, but because there was no way to pass raw properties through the YAML config, users were forced to write custom serdes.

### What I did
1. **Added configuration mapping (`ClustersProperties.java`)**: Added a `Map<String, Object> properties` field to `SchemaRegistryAuth` so Spring can bind `schema-registry-auth.properties.*`.
2. **Passed properties to Schema Registry client (`SchemaRegistrySerde.java`)**: Updated `autoConfigure()` to read this map and merge it into `CachedSchemaRegistryClient`. I ensured explicit configurations (like SSL settings) take precedence over custom properties.
3. **Added validation (`KafkaClusterFactory.java`)**: Added startup checks so that `properties` cannot be combined with basic auth or OAuth, keeping the authentication configuration unambiguous.
4. **Added unit tests (`SchemaRegistryAuthValidationTest.java`)**: Wrote tests covering the valid properties setup as well as validation errors when auth options are mixed.
5. **Updated docs (`ui-serdes.yaml`)**: Included commented examples for both ServiceLoader alias (`JWT_ASSERTION`) and custom provider class options.

**Is there anything you'd like reviewers to focus on?**

- Please review the validation logic in `KafkaClusterFactory` to ensure the error message is clear.
- Verify the precedence handling in `SchemaRegistrySerde` where explicit SSL and basic auth settings override custom properties.

**How Has This Been Tested?**
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist**
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Closes #1912


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Schema Registry clients with arbitrary properties, including bearer-token authentication.
  * Added support for JWT assertion settings and custom bearer credential providers.

* **Bug Fixes**
  * Added validation to prevent incompatible combinations of custom properties with basic or OAuth authentication.

* **Documentation**
  * Added example Schema Registry bearer-authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->