### PR TITLE
Fix Flux serialization in nested ResponseEntity for MCP tool results

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/mcp/McpSpecificationGenerator.java
+++ b/api/src/main/java/io/kafbat/ui/service/mcp/McpSpecificationGenerator.java
@@ -151,7 +151,7 @@ public class McpSpecificationGenerator {
   private Mono<CallToolResult> reponseToCallResult(ResponseEntity<?> response) {
     HttpStatusCode statusCode = response.getStatusCode();
     if (statusCode.is2xxSuccessful() || statusCode.is1xxInformational()) {
-      return Mono.just(this.callToolResult(response.getBody()));
+      return this.toCallResult(response.getBody());
     } else {
       try {
         return Mono.just(toErrorResult(objectMapper.writeValueAsString(response.getBody())));

--- a/api/src/test/java/io/kafbat/ui/service/mcp/McpSpecificationGeneratorTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/mcp/McpSpecificationGeneratorTest.java
@@ -11,17 +11,21 @@ import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import io.kafbat.ui.config.ClustersProperties;
+import io.kafbat.ui.controller.ClustersController;
 import io.kafbat.ui.controller.TopicsController;
 import io.kafbat.ui.mapper.ClusterMapper;
+import io.kafbat.ui.model.ClusterDTO;
 import io.kafbat.ui.model.KafkaCluster;
 import io.kafbat.ui.model.SortOrderDTO;
 import io.kafbat.ui.model.TopicColumnsToSortDTO;
 import io.kafbat.ui.model.TopicUpdateDTO;
+import io.kafbat.ui.service.ClusterService;
 import io.kafbat.ui.service.ClustersStorage;
 import io.kafbat.ui.service.KafkaConnectService;
 import io.kafbat.ui.service.TopicsService;
 import io.kafbat.ui.service.acl.AclsService;
 import io.kafbat.ui.service.analyze.TopicAnalysisService;
+import io.kafbat.ui.service.rbac.AccessControlService;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -227,6 +231,37 @@ class McpSpecificationGeneratorTest {
           assertThat(result.isError()).isTrue();
           assertThat(((McpSchema.TextContent) result.content().get(0)).text())
               .contains("clusterName is required");
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  void toolBackedByResponseEntityOfFluxReturnsCollectedDataNotReactorInternals() {
+    ClusterDTO cluster = new ClusterDTO();
+    cluster.setName("test-cluster");
+
+    ClusterService clusterService = mock(ClusterService.class);
+    when(clusterService.getClusters()).thenReturn(List.of(cluster));
+
+    ClustersController controller = new ClustersController(clusterService);
+    controller.setClustersStorage(mock(ClustersStorage.class));
+    AccessControlService accessControlService = mock(AccessControlService.class);
+    when(accessControlService.isClusterAccessible(cluster)).thenReturn(Mono.just(true));
+    controller.setAccessControlService(accessControlService);
+
+    McpSpecificationGenerator generator = generatorWith(mock(ClustersStorage.class));
+    AsyncToolSpecification getClusters = findTool(generator.convertTool(controller), "getClusters");
+
+    StepVerifier.create(invokeTool(getClusters, Map.of()))
+        .assertNext(result -> {
+          String text = ((McpSchema.TextContent) result.content().get(0)).text();
+          // Regression check for https://github.com/kafbat/kafka-ui/issues/1454 :
+          // a Flux nested inside a ResponseEntity body used to be serialized via its
+          // Reactor internals ({"scanAvailable":true,"prefetch":-1}) instead of being
+          // collected into the actual list of results.
+          assertThat(text).doesNotContain("scanAvailable", "prefetch");
+          assertThat(text).contains("test-cluster");
+          assertThat(result.isError()).isFalse();
         })
         .verifyComplete();
   }


### PR DESCRIPTION
## Summary

Fixes #1454.

`McpSpecificationGenerator.toCallResult()` already handles a bare `Flux<?>` correctly by calling `.collectList()` before serializing. But controllers like `ClustersController#getClusters`, `AclsController#listAcls`, `KafkaConnectController#getAllConnectors`, and `MessagesController#getTopicMessagesV2` return `Mono<ResponseEntity<Flux<T>>>` — the `Flux` is nested *inside* the `ResponseEntity` body.

`reponseToCallResult()` unwraps the `ResponseEntity` and passes its body straight to `callToolResult()`, skipping the `Flux`-aware branch in `toCallResult()` entirely. Jackson then introspects the live, unresolved `Flux` object graph and serializes its internal Reactor fields instead of its contents, e.g.:

```json
{"scanAvailable":true,"prefetch":-1}
```

instead of the actual list of clusters/ACLs/connectors/messages. The tool call reports `isError:false`, so an MCP client gets silently wrong data rather than a visible failure.

### Fix

`reponseToCallResult()` now delegates the response body to `toCallResult()` instead of calling `callToolResult()` directly, so the existing `Flux` branch (`flux.collectList()`) applies uniformly whether the `Flux` is top-level or nested inside a `ResponseEntity`.

### Verification

- Reproduced against a live deployment: `getClusters`, `listAcls`, `getAllConnectors`, and `getTopicMessagesV2` all returned the `{"scanAvailable":...}` garbage before the fix; `getTopics`, `getConsumerGroupsPage`, `getSchemas`, and `getLatestSchema` (which return `Page<T>`/plain DTOs, not `Flux`) were unaffected — confirming the bug is specific to the `ResponseEntity<Flux<T>>` shape.
- Added a regression test (`toolBackedByResponseEntityOfFluxReturnsCollectedDataNotReactorInternals`) exercising `ClustersController#getClusters` through the real `McpSpecificationGenerator`. Verified it fails on unpatched code and passes after the fix.
- Built the full application (including frontend) and smoke-tested the resulting image standalone: opened a real MCP SSE session and called `getClusters`, which returned `[]` (correct, no clusters configured) instead of the Reactor-internals payload.

## Test plan

- [x] `./gradlew :api:test --tests "io.kafbat.ui.service.mcp.McpSpecificationGeneratorTest"` — all 8 tests pass (7 pre-existing + 1 new regression test)
- [x] `./gradlew :api:checkstyleMain :api:checkstyleTest` — clean
- [x] Built `api` module + Docker image from source, ran it, confirmed `getClusters` over a live MCP SSE session returns valid JSON instead of Reactor internals

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MCP tool results backed by reactive responses to return the resolved data correctly.
  * Cluster data from streaming responses is now collected and displayed instead of exposing internal reactive-system details.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->