### PR TITLE
Cache topic configs with configurable expiry

### DIFF
--- a/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
@@ -41,6 +41,9 @@ public class ClustersProperties {
   MetricsStorage defaultMetricsStorage = new MetricsStorage();
 
   CacheProperties cache = new CacheProperties();
+
+  ScrapeProperties scrape = new ScrapeProperties();
+
   ClusterFtsProperties fts = new ClusterFtsProperties();
 
   AdminClient adminClient = new AdminClient();
@@ -103,6 +106,8 @@ public class ClustersProperties {
     List<@Valid Masking> masking;
 
     AuditProperties audit;
+
+    ScrapeProperties scrape;
   }
 
   @Data
@@ -254,6 +259,21 @@ public class ClustersProperties {
   @Data
   @NoArgsConstructor
   @AllArgsConstructor
+  public static class ScrapeProperties {
+    // How long topic configs scraped by ClustersStatisticsScheduler stay usable before being re-described.
+    // Topic configs are cold data - they only change by an explicit admin action - but describeConfigs() is
+    // charged per topic on managed Kafka (on AWS MSK every topic becomes its own
+    // DescribeTopicDynamicConfiguration CloudTrail event), so re-describing every topic every 30s is expensive.
+    // Zero or negative means re-describe on every scrape. Topics we have no configs for yet are always
+    // described, regardless of this setting, so a newly created topic never shows an unknown cleanup policy.
+    // Every on-demand path (the topics list, the topic details config tab, and the read-modify-write in
+    // updateTopicConfig) fetches configs live and is unaffected by this setting.
+    Duration topicConfigsExpiry = Duration.ZERO;
+  }
+
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class CacheProperties {
     boolean enabled = true;
     Duration connectClusterCacheExpiry = Duration.ofHours(24);
@@ -289,6 +309,18 @@ public class ClustersProperties {
       }
       return false;
     }
+  }
+
+  // Cluster-level scrape settings win over the global ones; a mixed fleet routinely fronts one managed cluster
+  // that needs a long topic-configs expiry alongside self-managed ones that do not.
+  public Duration resolveTopicConfigsExpiry(@Nullable Cluster cluster) {
+    if (cluster != null && cluster.getScrape() != null && cluster.getScrape().getTopicConfigsExpiry() != null) {
+      return cluster.getScrape().getTopicConfigsExpiry();
+    }
+    if (scrape != null && scrape.getTopicConfigsExpiry() != null) {
+      return scrape.getTopicConfigsExpiry();
+    }
+    return Duration.ZERO;
   }
 
   @PostConstruct

--- a/api/src/main/java/io/kafbat/ui/service/ReactiveAdminClient.java
+++ b/api/src/main/java/io/kafbat/ui/service/ReactiveAdminClient.java
@@ -276,10 +276,6 @@ public class ReactiveAdminClient implements Closeable {
         .then();
   }
 
-  public Mono<Map<String, List<ConfigEntry>>> getTopicsConfig() {
-    return listTopics(true).flatMap(topics -> getTopicsConfig(topics, false));
-  }
-
   /*
   NOTE: skips not-found topics (for which UnknownTopicOrPartitionException or UnknownServerException was thrown by
   AdminClient) and topics for which DESCRIBE_CONFIGS permission is not set (TopicAuthorizationException was thrown)
@@ -347,10 +343,6 @@ public class ReactiveAdminClient implements Closeable {
    */
   public Mono<Map<Integer, List<ConfigEntry>>> loadBrokersConfig(List<Integer> brokerIds) {
     return loadBrokersConfig(client, brokerIds);
-  }
-
-  public Mono<Map<String, TopicDescription>> describeTopics() {
-    return listTopics(true).flatMap(this::describeTopics);
   }
 
   public Mono<Map<String, TopicDescription>> describeTopics(Collection<String> topics) {

--- a/api/src/main/java/io/kafbat/ui/service/StatisticsService.java
+++ b/api/src/main/java/io/kafbat/ui/service/StatisticsService.java
@@ -53,7 +53,7 @@ public class StatisticsService {
                     .then(
                         Mono.zip(
                             featureService.getAvailableFeatures(ac, cluster, description),
-                            loadClusterState(description, ac),
+                            loadClusterState(cluster, description, ac),
                             loadKafkaConnects(cluster),
                             loadQuorumInfo(ac)
                                 .map(quorumInfo -> new LoadQuorumInfoResult(Optional.of(quorumInfo), KRAFT))
@@ -121,9 +121,16 @@ public class StatisticsService {
     return stats.build();
   }
 
-  private Mono<ScrapedClusterState> loadClusterState(ClusterDescription clusterDescription,
+  // Reads the cached state so the scrape can carry unexpired topic configs forward instead of re-describing every
+  // topic. Safe against the write in updateCache(): the scheduler's task pool is single-threaded and
+  // updateStatistics() blocks, so ticks for one cluster cannot overlap - this reads at subscribe, writes at complete.
+  private Mono<ScrapedClusterState> loadClusterState(KafkaCluster cluster,
+                                                     ClusterDescription clusterDescription,
                                                      ReactiveAdminClient ac) {
-    return ScrapedClusterState.scrape(clusterDescription, ac, clustersProperties);
+    ScrapedClusterState previous = Optional.ofNullable(cache.get(cluster).getClusterState())
+        .orElseGet(ScrapedClusterState::empty);
+    return ScrapedClusterState.scrape(clusterDescription, ac, clustersProperties, previous,
+        clustersProperties.resolveTopicConfigsExpiry(cluster.getOriginalProperties()));
   }
 
   private Mono<Metrics> scrapeMetrics(KafkaCluster cluster,

--- a/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
+++ b/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
@@ -15,8 +15,10 @@ import io.kafbat.ui.service.index.FilterTopicIndex;
 import io.kafbat.ui.service.index.LuceneTopicsIndex;
 import io.kafbat.ui.service.index.TopicsIndex;
 import jakarta.annotation.Nullable;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -43,6 +45,10 @@ import reactor.core.publisher.Mono;
 public class ScrapedClusterState implements AutoCloseable {
 
   Instant scrapeFinishedAt;
+  // When the topic configs held in topicStates were last fully re-described. Deliberately separate from
+  // scrapeFinishedAt, which create() refreshes on every scrape (and which ConsumerGroupService reads to report
+  // offset freshness) - reusing it would restart the expiry window every scrape and the refresh would never fire.
+  Instant topicConfigsRefreshedAt;
   Map<Integer, NodeState> nodesStates;
   Map<String, TopicState> topicStates;
   Map<String, ConsumerGroupState> consumerGroupsStates;
@@ -80,6 +86,8 @@ public class ScrapedClusterState implements AutoCloseable {
   public static ScrapedClusterState empty() {
     return ScrapedClusterState.builder()
         .scrapeFinishedAt(Instant.now())
+        // EPOCH rather than now(), so the very first real scrape always describes configs
+        .topicConfigsRefreshedAt(Instant.EPOCH)
         .nodesStates(Map.of())
         .topicStates(Map.of())
         .consumerGroupsStates(Map.of())
@@ -149,39 +157,75 @@ public class ScrapedClusterState implements AutoCloseable {
         .build();
   }
 
-  public static Mono<ScrapedClusterState> scrape(ClusterDescription clusterDescription,
-                                                 ReactiveAdminClient ac, ClustersProperties clustersProperties) {
-    // listing topics once and reusing the result for both describeTopics() and getTopicsConfig(): each of the
-    // no-arg overloads used to list topics on its own, so a topic created in between got no configs for a cycle
-    return ac.listTopics(true)
-        .flatMap(topics -> scrape(clusterDescription, ac, clustersProperties, topics));
+  // Which topics need a live describeConfigs on this scrape, and whether that amounts to a full refresh.
+  // Kept as a pure function of (previous state, current topics, expiry, now) so the policy can be tested
+  // without introducing a Clock seam into the scrape.
+  @VisibleForTesting
+  record TopicConfigsRefreshPlan(Set<String> topicsToDescribe, boolean fullRefresh) {
+
+    static TopicConfigsRefreshPlan plan(ScrapedClusterState previous,
+                                        Set<String> currentTopics,
+                                        Duration expiry,
+                                        Instant now) {
+      Instant refreshedAt = previous.getTopicConfigsRefreshedAt();
+      if (expiry == null || expiry.isZero() || expiry.isNegative()
+          || refreshedAt == null || !now.isBefore(refreshedAt.plus(expiry))) {
+        return new TopicConfigsRefreshPlan(currentTopics, true);
+      }
+      // Only topics we have not seen before. Keyed on presence in topicStates rather than on having non-empty
+      // configs: getTopicsConfigImpl() swallows TopicAuthorizationException, so keying on content would
+      // re-describe every DESCRIBE_CONFIGS-denied topic on every scrape - the storm this setting exists to stop.
+      Set<String> unseen = new HashSet<>(currentTopics);
+      unseen.removeAll(previous.getTopicStates().keySet());
+      return new TopicConfigsRefreshPlan(unseen, false);
+    }
+
+    Mono<Map<String, List<ConfigEntry>>> fetch(ReactiveAdminClient ac) {
+      return topicsToDescribe.isEmpty() ? Mono.just(Map.of()) : ac.getTopicsConfig(topicsToDescribe, false);
+    }
+
+    // An incremental fetch must not advance the clock, or a cluster with steady topic churn would keep
+    // postponing the full refresh forever.
+    Instant refreshedAt(Instant previousRefreshedAt, Instant now) {
+      return fullRefresh ? now : previousRefreshedAt;
+    }
   }
 
-  private static Mono<ScrapedClusterState> scrape(ClusterDescription clusterDescription,
-                                                  ReactiveAdminClient ac,
-                                                  ClustersProperties clustersProperties,
-                                                  Set<String> topics) {
-    return Mono.zip(
-        ac.describeLogDirs(clusterDescription.getNodes().stream().map(Node::id).toList())
-            .map(InternalLogDirStats::new),
-        ac.listConsumerGroups().map(l -> l.stream().map(ConsumerGroupListing::groupId).toList()),
-        ac.describeTopics(topics),
-        ac.getTopicsConfig(topics, false)
-    ).flatMap(phase1 ->
-        Mono.zip(
-            ac.listOffsets(phase1.getT3().values(), OffsetSpec.latest()),
-            ac.listOffsets(phase1.getT3().values(), OffsetSpec.earliest()),
-            ac.describeConsumerGroups(phase1.getT2()),
-            ac.listConsumerGroupOffsets(phase1.getT2(), null)
-        ).map(phase2 ->
-            create(
-                clusterDescription,
-                phase1.getT1(),
-                topicStateMap(phase1.getT1(), phase1.getT3(), phase1.getT4(), phase2.getT1(), phase2.getT2()),
-                phase2.getT3(),
-                phase2.getT4(),
-                clustersProperties
-            )));
+  public static Mono<ScrapedClusterState> scrape(ClusterDescription clusterDescription,
+                                                 ReactiveAdminClient ac,
+                                                 ClustersProperties clustersProperties,
+                                                 ScrapedClusterState previous,
+                                                 Duration topicConfigsExpiry) {
+    Instant now = Instant.now();
+    // One listTopics() for both describeTopics() and the config fetch, so a topic created mid-scrape cannot end
+    // up described but config-less, and so the refresh plan can be decided before anything is described.
+    return ac.listTopics(true).flatMap(topics -> {
+      TopicConfigsRefreshPlan plan = TopicConfigsRefreshPlan.plan(previous, topics, topicConfigsExpiry, now);
+      return Mono.zip(
+          ac.describeLogDirs(clusterDescription.getNodes().stream().map(Node::id).toList())
+              .map(InternalLogDirStats::new),
+          ac.listConsumerGroups().map(l -> l.stream().map(ConsumerGroupListing::groupId).toList()),
+          ac.describeTopics(topics),
+          plan.fetch(ac)
+      ).flatMap(phase1 ->
+          Mono.zip(
+              ac.listOffsets(phase1.getT3().values(), OffsetSpec.latest()),
+              ac.listOffsets(phase1.getT3().values(), OffsetSpec.earliest()),
+              ac.describeConsumerGroups(phase1.getT2()),
+              ac.listConsumerGroupOffsets(phase1.getT2(), null)
+          ).map(phase2 ->
+              create(
+                  clusterDescription,
+                  phase1.getT1(),
+                  topicStateMap(phase1.getT1(), phase1.getT3(),
+                      mergeTopicConfigs(previous.getTopicStates(), phase1.getT4()),
+                      phase2.getT1(), phase2.getT2()),
+                  phase2.getT3(),
+                  phase2.getT4(),
+                  clustersProperties,
+                  plan.refreshedAt(previous.getTopicConfigsRefreshedAt(), now)
+              )));
+    });
   }
 
   private static Map<String, TopicState> topicStateMap(
@@ -212,7 +256,8 @@ public class ScrapedClusterState implements AutoCloseable {
                                             Map<String, TopicState> topicStates,
                                             Map<String, ConsumerGroupDescription> consumerDescriptions,
                                             Table<String, TopicPartition, Long> consumerOffsets,
-                                            ClustersProperties clustersProperties) {
+                                            ClustersProperties clustersProperties,
+                                            Instant topicConfigsRefreshedAt) {
 
     Map<String, ConsumerGroupState> consumerGroupsStates = new HashMap<>();
     consumerDescriptions.forEach((name, desc) ->
@@ -237,6 +282,7 @@ public class ScrapedClusterState implements AutoCloseable {
 
     return new ScrapedClusterState(
         Instant.now(),
+        topicConfigsRefreshedAt,
         nodesStates,
         topicStates,
         consumerGroupsStates,

--- a/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
+++ b/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.Builder;
@@ -127,12 +128,22 @@ public class ScrapedClusterState implements AutoCloseable {
 
   public static Mono<ScrapedClusterState> scrape(ClusterDescription clusterDescription,
                                                  ReactiveAdminClient ac, ClustersProperties clustersProperties) {
+    // listing topics once and reusing the result for both describeTopics() and getTopicsConfig(): each of the
+    // no-arg overloads used to list topics on its own, so a topic created in between got no configs for a cycle
+    return ac.listTopics(true)
+        .flatMap(topics -> scrape(clusterDescription, ac, clustersProperties, topics));
+  }
+
+  private static Mono<ScrapedClusterState> scrape(ClusterDescription clusterDescription,
+                                                  ReactiveAdminClient ac,
+                                                  ClustersProperties clustersProperties,
+                                                  Set<String> topics) {
     return Mono.zip(
         ac.describeLogDirs(clusterDescription.getNodes().stream().map(Node::id).toList())
             .map(InternalLogDirStats::new),
         ac.listConsumerGroups().map(l -> l.stream().map(ConsumerGroupListing::groupId).toList()),
-        ac.describeTopics(),
-        ac.getTopicsConfig()
+        ac.describeTopics(topics),
+        ac.getTopicsConfig(topics, false)
     ).flatMap(phase1 ->
         Mono.zip(
             ac.listOffsets(phase1.getT3().values(), OffsetSpec.latest()),

--- a/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
+++ b/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
@@ -4,6 +4,7 @@ import static io.kafbat.ui.model.InternalLogDirStats.LogDirSpaceStats;
 import static io.kafbat.ui.model.InternalLogDirStats.SegmentStats;
 import static io.kafbat.ui.service.ReactiveAdminClient.ClusterDescription;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Table;
 import io.kafbat.ui.config.ClustersProperties;
 import io.kafbat.ui.model.InternalLogDirStats;
@@ -86,10 +87,32 @@ public class ScrapedClusterState implements AutoCloseable {
         .build();
   }
 
+  // Freshly fetched configs win, but a topic that is absent from (or empty in) the fetched map keeps whatever we
+  // already knew about it. getTopicsConfigImpl() deliberately swallows per-resource errors such as
+  // TopicAuthorizationException, so without this a partial failure blanks those topics' configs, which silently
+  // drops their cleanUpPolicy to UNKNOWN and nulls messagesCount in the topics list.
+  @VisibleForTesting
+  static Map<String, List<ConfigEntry>> mergeTopicConfigs(Map<String, TopicState> previousStates,
+                                                          Map<String, List<ConfigEntry>> fetched) {
+    Map<String, List<ConfigEntry>> merged = new HashMap<>();
+    previousStates.forEach((topic, state) -> {
+      if (state.configs() != null && !state.configs().isEmpty()) {
+        merged.put(topic, state.configs());
+      }
+    });
+    fetched.forEach((topic, configs) -> {
+      if (configs != null && !configs.isEmpty()) {
+        merged.put(topic, configs);
+      }
+    });
+    return merged;
+  }
+
   public ScrapedClusterState updateTopics(Map<String, TopicDescription> descriptions,
                                           Map<String, List<ConfigEntry>> configs,
                                           InternalPartitionsOffsets partitionsOffsets,
                                           ClustersProperties clustersProperties) {
+    Map<String, List<ConfigEntry>> mergedConfigs = mergeTopicConfigs(topicStates, configs);
     var updatedTopicStates = new HashMap<>(topicStates);
     descriptions.forEach((topic, description) -> {
       SegmentStats segmentStats = null;
@@ -103,7 +126,7 @@ public class ScrapedClusterState implements AutoCloseable {
           new TopicState(
               topic,
               description,
-              configs.getOrDefault(topic, List.of()),
+              mergedConfigs.getOrDefault(topic, List.of()),
               partitionsOffsets.topicOffsets(topic, true),
               partitionsOffsets.topicOffsets(topic, false),
               segmentStats,

--- a/api/src/test/java/io/kafbat/ui/config/ClustersPropertiesTest.java
+++ b/api/src/test/java/io/kafbat/ui/config/ClustersPropertiesTest.java
@@ -3,6 +3,7 @@ package io.kafbat.ui.config;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.time.Duration;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
@@ -46,6 +47,34 @@ class ClustersPropertiesTest {
         .element(0)
         .extracting("name")
         .isEqualTo("Default");
+  }
+
+  @Test
+  void topicConfigsExpiryDefaultsToZeroSoConfigsAreDescribedEveryScrape() {
+    ClustersProperties properties = new ClustersProperties();
+
+    assertThat(properties.getScrape().getTopicConfigsExpiry()).isEqualTo(Duration.ZERO);
+    assertThat(properties.resolveTopicConfigsExpiry(new ClustersProperties.Cluster())).isEqualTo(Duration.ZERO);
+    assertThat(properties.resolveTopicConfigsExpiry(null)).isEqualTo(Duration.ZERO);
+  }
+
+  @Test
+  void topicConfigsExpiryFallsBackToGlobalWhenClusterHasNoScrapeSection() {
+    ClustersProperties properties = new ClustersProperties();
+    properties.getScrape().setTopicConfigsExpiry(Duration.ofMinutes(5));
+
+    assertThat(properties.resolveTopicConfigsExpiry(new ClustersProperties.Cluster()))
+        .isEqualTo(Duration.ofMinutes(5));
+  }
+
+  @Test
+  void clusterLevelTopicConfigsExpiryOverridesGlobal() {
+    ClustersProperties properties = new ClustersProperties();
+    properties.getScrape().setTopicConfigsExpiry(Duration.ofMinutes(5));
+    var cluster = new ClustersProperties.Cluster();
+    cluster.setScrape(new ClustersProperties.ScrapeProperties(Duration.ofHours(1)));
+
+    assertThat(properties.resolveTopicConfigsExpiry(cluster)).isEqualTo(Duration.ofHours(1));
   }
 
 }

--- a/api/src/test/java/io/kafbat/ui/service/StatisticsServiceTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/StatisticsServiceTest.java
@@ -4,14 +4,18 @@ import static io.kafbat.ui.api.model.ControllerType.KRAFT;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kafbat.ui.AbstractIntegrationTest;
+import io.kafbat.ui.config.ClustersProperties;
 import io.kafbat.ui.model.CreateTopicMessageDTO;
 import io.kafbat.ui.model.Statistics;
 import io.kafbat.ui.service.metrics.scrape.inferred.InferredMetrics;
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot;
 import io.prometheus.metrics.model.snapshots.GaugeSnapshot.GaugeDataPointSnapshot;
 import io.prometheus.metrics.model.snapshots.Labels;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +30,9 @@ class StatisticsServiceTest extends AbstractIntegrationTest {
 
   @Autowired
   private StatisticsService statisticsService;
+
+  @Autowired
+  private ClustersProperties clustersProperties;
 
   @Test
   void testInferredMetricsCollected() {
@@ -66,6 +73,62 @@ class StatisticsServiceTest extends AbstractIntegrationTest {
     );
     assertThat(kafkaTopicPartitionNextOffset.getValue())
         .isEqualTo(4);
+  }
+
+  @Test
+  void topicConfigsSurviveSecondScrapeWithinExpiry() {
+    var cluster = clustersStorage.getClusterByName(LOCAL).get();
+    var topic = "configs_carried_forward_" + UUID.randomUUID();
+    createTopic(new NewTopic(topic, 1, (short) 1));
+
+    withTopicConfigsExpiry(Duration.ofHours(1), () -> {
+      Statistics first = statisticsService.updateCache(cluster).block();
+      Instant firstRefreshedAt = first.getClusterState().getTopicConfigsRefreshedAt();
+      assertThat(configsOf(first, topic)).isNotEmpty();
+
+      Statistics second = statisticsService.updateCache(cluster).block();
+
+      // the expiry has not elapsed, so nothing was re-described and the refresh window did not restart
+      assertThat(second.getClusterState().getTopicConfigsRefreshedAt()).isEqualTo(firstRefreshedAt);
+      // cleanup.policy is what InternalTopic.cleanUpPolicy is derived from, and messagesCount depends on that,
+      // so losing it here would show up as a null message count and a reordered MESSAGES_COUNT sort
+      assertThat(configsOf(second, topic))
+          .anyMatch(entry -> entry.name().equals("cleanup.policy") && entry.value() != null);
+    });
+  }
+
+  @Test
+  void topicCreatedBetweenScrapesGetsConfigsOnNextScrape() {
+    var cluster = clustersStorage.getClusterByName(LOCAL).get();
+
+    withTopicConfigsExpiry(Duration.ofHours(1), () -> {
+      Statistics first = statisticsService.updateCache(cluster).block();
+      Instant firstRefreshedAt = first.getClusterState().getTopicConfigsRefreshedAt();
+
+      var topic = "configs_for_new_topic_" + UUID.randomUUID();
+      createTopic(new NewTopic(topic, 1, (short) 1));
+
+      Statistics second = statisticsService.updateCache(cluster).block();
+
+      // a topic we have not seen before is always described, even inside the expiry window
+      assertThat(configsOf(second, topic)).isNotEmpty();
+      // ...but an incremental fetch must not restart the window, or topic churn would postpone full refreshes
+      assertThat(second.getClusterState().getTopicConfigsRefreshedAt()).isEqualTo(firstRefreshedAt);
+    });
+  }
+
+  private void withTopicConfigsExpiry(Duration expiry, Runnable body) {
+    Duration original = clustersProperties.getScrape().getTopicConfigsExpiry();
+    clustersProperties.getScrape().setTopicConfigsExpiry(expiry);
+    try {
+      body.run();
+    } finally {
+      clustersProperties.getScrape().setTopicConfigsExpiry(original);
+    }
+  }
+
+  private static List<ConfigEntry> configsOf(Statistics statistics, String topic) {
+    return statistics.getClusterState().getTopicStates().get(topic).configs();
   }
 
   @SuppressWarnings("unchecked")

--- a/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateScrapeTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateScrapeTest.java
@@ -1,0 +1,151 @@
+package io.kafbat.ui.service.metrics.scrape;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.HashBasedTable;
+import io.kafbat.ui.config.ClustersProperties;
+import io.kafbat.ui.service.ReactiveAdminClient;
+import io.kafbat.ui.service.ReactiveAdminClient.ClusterDescription;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import reactor.core.publisher.Mono;
+
+class ScrapedClusterStateScrapeTest {
+
+  private static final Node NODE = new Node(1, "node1", 9092);
+  private static final ConfigEntry CLEANUP_DELETE = new ConfigEntry("cleanup.policy", "delete");
+  private static final Duration ONE_HOUR = Duration.ofHours(1);
+
+  private final ClustersProperties properties = new ClustersProperties();
+  private final ClusterDescription clusterDescription =
+      new ClusterDescription(NODE, "cluster-id", List.of(NODE), Set.of());
+
+  @Test
+  void scrapeIssuesSingleListTopicsCall() throws Exception {
+    ReactiveAdminClient ac = adminClient(Set.of("t1"));
+    try (ScrapedClusterState scraped = scrape(ac, ScrapedClusterState.empty(), Duration.ZERO)) {
+      assertThat(scraped.getTopicStates()).containsOnlyKeys("t1");
+    }
+    verify(ac, times(1)).listTopics(true);
+  }
+
+  @Test
+  void scrapeSkipsConfigFetchOnSecondTickWithinExpiry() throws Exception {
+    ReactiveAdminClient ac = adminClient(Set.of("t1"));
+    try (ScrapedClusterState first = scrape(ac, ScrapedClusterState.empty(), ONE_HOUR)) {
+      verify(ac, times(1)).getTopicsConfig(anyCollection(), anyBoolean());
+      try (ScrapedClusterState second = scrape(ac, first, ONE_HOUR)) {
+        assertThat(second.getTopicStates()).containsOnlyKeys("t1");
+      }
+    }
+    // still exactly the one call from the first tick
+    verify(ac, times(1)).getTopicsConfig(anyCollection(), anyBoolean());
+  }
+
+  @Test
+  void scrapeCarriesTopicConfigsForwardOnSkippedTick() throws Exception {
+    ReactiveAdminClient ac = adminClient(Set.of("t1"));
+    try (ScrapedClusterState first = scrape(ac, ScrapedClusterState.empty(), ONE_HOUR);
+         ScrapedClusterState second = scrape(ac, first, ONE_HOUR)) {
+      assertThat(second.getTopicStates().get("t1").configs()).containsExactly(CLEANUP_DELETE);
+      assertThat(second.getTopicConfigsRefreshedAt()).isEqualTo(first.getTopicConfigsRefreshedAt());
+    }
+  }
+
+  @Test
+  void scrapeRequestsConfigsOnlyForNewTopicsWithinExpiry() throws Exception {
+    ReactiveAdminClient ac = adminClient(Set.of("t1"));
+    try (ScrapedClusterState first = scrape(ac, ScrapedClusterState.empty(), ONE_HOUR)) {
+      stubTopics(ac, Set.of("t1", "t2"));
+      try (ScrapedClusterState second = scrape(ac, first, ONE_HOUR)) {
+        assertThat(second.getTopicStates()).containsOnlyKeys("t1", "t2");
+        // t1's configs came from the previous state, t2's from the incremental fetch
+        assertThat(second.getTopicStates().get("t1").configs()).containsExactly(CLEANUP_DELETE);
+        assertThat(second.getTopicStates().get("t2").configs()).containsExactly(CLEANUP_DELETE);
+      }
+    }
+
+    ArgumentCaptor<Collection<String>> captor = ArgumentCaptor.captor();
+    verify(ac, times(2)).getTopicsConfig(captor.capture(), eq(false));
+    assertThat(captor.getAllValues().get(0)).containsExactly("t1");
+    assertThat(captor.getAllValues().get(1)).containsExactly("t2");
+  }
+
+  @Test
+  void scrapeMakesNoConfigCallAtAllWhenNothingIsStale() throws Exception {
+    ReactiveAdminClient ac = adminClient(Set.of("t1"));
+    try (ScrapedClusterState first = scrape(ac, ScrapedClusterState.empty(), ONE_HOUR)) {
+      ReactiveAdminClient fresh = adminClient(Set.of("t1"));
+      try (ScrapedClusterState second = scrape(fresh, first, ONE_HOUR)) {
+        assertThat(second.getTopicStates().get("t1").configs()).containsExactly(CLEANUP_DELETE);
+      }
+      verify(fresh, never()).getTopicsConfig(anyCollection(), anyBoolean());
+    }
+  }
+
+  @Test
+  void scrapeRefetchesAllConfigsWhenExpiryIsZero() throws Exception {
+    ReactiveAdminClient ac = adminClient(Set.of("t1"));
+    try (ScrapedClusterState first = scrape(ac, ScrapedClusterState.empty(), Duration.ZERO);
+         ScrapedClusterState second = scrape(ac, first, Duration.ZERO)) {
+      assertThat(second.getTopicStates()).containsOnlyKeys("t1");
+    }
+    verify(ac, times(2)).getTopicsConfig(anyCollection(), anyBoolean());
+  }
+
+  private ScrapedClusterState scrape(ReactiveAdminClient ac, ScrapedClusterState previous, Duration expiry) {
+    return ScrapedClusterState.scrape(clusterDescription, ac, properties, previous, expiry).block();
+  }
+
+  private static ReactiveAdminClient adminClient(Set<String> topics) {
+    ReactiveAdminClient ac = mock(ReactiveAdminClient.class);
+    // Mono.zip completes empty if any source is empty, so every method the scrape touches must be stubbed
+    when(ac.describeLogDirs(anyList())).thenReturn(Mono.just(Map.of()));
+    when(ac.listConsumerGroups()).thenReturn(Mono.just(List.of()));
+    when(ac.describeConsumerGroups(anyCollection())).thenReturn(Mono.just(Map.of()));
+    when(ac.listConsumerGroupOffsets(anyList(), isNull())).thenReturn(Mono.just(HashBasedTable.create()));
+    // listOffsets is overloaded, so the matcher has to be typed to pick the TopicDescription overload
+    when(ac.listOffsets(ArgumentMatchers.<Collection<TopicDescription>>any(), any()))
+        .thenReturn(Mono.just(Map.of()));
+    stubTopics(ac, topics);
+    return ac;
+  }
+
+  private static void stubTopics(ReactiveAdminClient ac, Set<String> topics) {
+    when(ac.listTopics(true)).thenReturn(Mono.just(topics));
+    when(ac.describeTopics(anyCollection())).thenAnswer(invocation -> {
+      Collection<String> requested = invocation.getArgument(0);
+      return Mono.just(requested.stream().collect(Collectors.toMap(t -> t, ScrapedClusterStateScrapeTest::describe)));
+    });
+    when(ac.getTopicsConfig(anyCollection(), anyBoolean())).thenAnswer(invocation -> {
+      Collection<String> requested = invocation.getArgument(0);
+      return Mono.just(requested.stream().collect(Collectors.toMap(t -> t, t -> List.of(CLEANUP_DELETE))));
+    });
+  }
+
+  private static TopicDescription describe(String topic) {
+    return new TopicDescription(topic, false, List.of(new TopicPartitionInfo(0, NODE, List.of(NODE), List.of(NODE))));
+  }
+}

--- a/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateTest.java
@@ -1,19 +1,25 @@
 package io.kafbat.ui.service.metrics.scrape;
 
+import static io.kafbat.ui.service.metrics.scrape.ScrapedClusterState.TopicConfigsRefreshPlan;
 import static io.kafbat.ui.service.metrics.scrape.ScrapedClusterState.TopicState;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kafbat.ui.config.ClustersProperties;
 import io.kafbat.ui.model.InternalPartitionsOffsets;
 import io.kafbat.ui.service.index.FilterTopicIndex;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ScrapedClusterStateTest {
 
@@ -69,13 +75,7 @@ class ScrapedClusterStateTest {
   @Test
   void updateTopicsKeepsExistingConfigsWhenConfigMapMissesTopic() throws Exception {
     ClustersProperties properties = new ClustersProperties();
-    try (ScrapedClusterState previous = ScrapedClusterState.builder()
-        .scrapeFinishedAt(Instant.now())
-        .nodesStates(Map.of())
-        .topicStates(topicStates("t1", List.of(RETENTION_1H)))
-        .consumerGroupsStates(Map.of())
-        .topicIndex(new FilterTopicIndex(List.of()))
-        .build()) {
+    try (ScrapedClusterState previous = state(Instant.now(), topicStates("t1", List.of(RETENTION_1H)))) {
 
       // configs deliberately empty: this is what a swallowed per-topic describeConfigs failure looks like
       try (ScrapedClusterState updated = previous.updateTopics(
@@ -86,6 +86,107 @@ class ScrapedClusterStateTest {
         assertThat(updated.getTopicStates().get("t1").configs()).containsExactly(RETENTION_1H);
       }
     }
+  }
+
+  @Test
+  void planDescribesEveryTopicOnFirstScrape() throws Exception {
+    try (ScrapedClusterState previous = ScrapedClusterState.empty()) {
+      var plan = TopicConfigsRefreshPlan.plan(previous, Set.of("t1", "t2"), Duration.ofHours(1), Instant.now());
+      assertThat(plan.fullRefresh()).isTrue();
+      assertThat(plan.topicsToDescribe()).containsExactlyInAnyOrder("t1", "t2");
+    }
+  }
+
+  @Test
+  void planDescribesNothingWhenExpiryNotElapsedAndNoNewTopics() throws Exception {
+    Instant now = Instant.now();
+    try (ScrapedClusterState previous = state(now.minus(Duration.ofMinutes(1)),
+        topicStates("t1", List.of(RETENTION_1H)))) {
+      var plan = TopicConfigsRefreshPlan.plan(previous, Set.of("t1"), Duration.ofHours(1), now);
+      assertThat(plan.fullRefresh()).isFalse();
+      assertThat(plan.topicsToDescribe()).isEmpty();
+    }
+  }
+
+  @Test
+  void planDescribesOnlyNewTopicsWhenExpiryNotElapsed() throws Exception {
+    Instant now = Instant.now();
+    try (ScrapedClusterState previous = state(now.minus(Duration.ofMinutes(1)),
+        topicStates("t1", List.of(RETENTION_1H)))) {
+      var plan = TopicConfigsRefreshPlan.plan(previous, Set.of("t1", "t2"), Duration.ofHours(1), now);
+      assertThat(plan.fullRefresh()).isFalse();
+      assertThat(plan.topicsToDescribe()).containsExactly("t2");
+    }
+  }
+
+  @Test
+  void planDoesNotAdvanceRefreshClockForIncrementalFetch() throws Exception {
+    Instant now = Instant.now();
+    Instant refreshedAt = now.minus(Duration.ofMinutes(1));
+    try (ScrapedClusterState previous = state(refreshedAt, topicStates("t1", List.of(RETENTION_1H)))) {
+      var plan = TopicConfigsRefreshPlan.plan(previous, Set.of("t1", "t2"), Duration.ofHours(1), now);
+      // steady topic churn must not keep postponing the full refresh
+      assertThat(plan.refreshedAt(refreshedAt, now)).isEqualTo(refreshedAt);
+    }
+  }
+
+  @Test
+  void planAdvancesRefreshClockOnFullRefresh() throws Exception {
+    Instant now = Instant.now();
+    Instant refreshedAt = now.minus(Duration.ofHours(2));
+    try (ScrapedClusterState previous = state(refreshedAt, topicStates("t1", List.of(RETENTION_1H)))) {
+      var plan = TopicConfigsRefreshPlan.plan(previous, Set.of("t1"), Duration.ofHours(1), now);
+      assertThat(plan.fullRefresh()).isTrue();
+      assertThat(plan.refreshedAt(refreshedAt, now)).isEqualTo(now);
+    }
+  }
+
+  @Test
+  void planDescribesEveryTopicWhenExpiryElapsed() throws Exception {
+    Instant now = Instant.now();
+    try (ScrapedClusterState previous = state(now.minus(Duration.ofHours(2)),
+        topicStates("t1", List.of(RETENTION_1H)))) {
+      var plan = TopicConfigsRefreshPlan.plan(previous, Set.of("t1"), Duration.ofHours(1), now);
+      assertThat(plan.fullRefresh()).isTrue();
+      assertThat(plan.topicsToDescribe()).containsExactly("t1");
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("nonPositiveExpiries")
+  void planDescribesEveryTopicWhenExpiryIsNotPositive(Duration expiry) throws Exception {
+    Instant now = Instant.now();
+    try (ScrapedClusterState previous = state(now, topicStates("t1", List.of(RETENTION_1H)))) {
+      var plan = TopicConfigsRefreshPlan.plan(previous, Set.of("t1"), expiry, now);
+      assertThat(plan.fullRefresh()).isTrue();
+      assertThat(plan.topicsToDescribe()).containsExactly("t1");
+    }
+  }
+
+  static Stream<Duration> nonPositiveExpiries() {
+    return Stream.of(Duration.ZERO, Duration.ofMinutes(-5), null);
+  }
+
+  @Test
+  void planDoesNotReDescribeTopicsWhoseConfigsAreDenied() throws Exception {
+    Instant now = Instant.now();
+    // a DESCRIBE_CONFIGS-denied topic is present in topicStates but with empty configs: it must not be
+    // re-described every scrape, which is what keying the plan on config content would do
+    try (ScrapedClusterState previous = state(now.minus(Duration.ofMinutes(1)), topicStates("t1", List.of()))) {
+      var plan = TopicConfigsRefreshPlan.plan(previous, Set.of("t1"), Duration.ofHours(1), now);
+      assertThat(plan.topicsToDescribe()).isEmpty();
+    }
+  }
+
+  private static ScrapedClusterState state(Instant topicConfigsRefreshedAt, Map<String, TopicState> topicStates) {
+    return ScrapedClusterState.builder()
+        .scrapeFinishedAt(Instant.now())
+        .topicConfigsRefreshedAt(topicConfigsRefreshedAt)
+        .nodesStates(Map.of())
+        .topicStates(topicStates)
+        .consumerGroupsStates(Map.of())
+        .topicIndex(new FilterTopicIndex(List.of()))
+        .build();
   }
 
   private static Map<String, TopicState> topicStates(String topic, List<ConfigEntry> configs) {

--- a/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterStateTest.java
@@ -1,10 +1,25 @@
 package io.kafbat.ui.service.metrics.scrape;
 
+import static io.kafbat.ui.service.metrics.scrape.ScrapedClusterState.TopicState;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.kafbat.ui.config.ClustersProperties;
+import io.kafbat.ui.model.InternalPartitionsOffsets;
+import io.kafbat.ui.service.index.FilterTopicIndex;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
 import org.junit.jupiter.api.Test;
 
 class ScrapedClusterStateTest {
+
+  private static final ConfigEntry RETENTION_1H = new ConfigEntry("retention.ms", "3600000");
+  private static final ConfigEntry RETENTION_2H = new ConfigEntry("retention.ms", "7200000");
+  private static final Node NODE = new Node(1, "node1", 9092);
 
   @Test
   void emptyStateHasNonNullTopicIndex() throws Exception {
@@ -13,5 +28,71 @@ class ScrapedClusterStateTest {
       assertThat(empty.getTopicIndex().find(null, null, false, null)).isEmpty();
       assertThat(empty.getTopicIndex().find("search", true, true, null)).isEmpty();
     }
+  }
+
+  @Test
+  void mergeKeepsPreviousConfigsWhenFetchOmitsKnownTopic() {
+    var merged = ScrapedClusterState.mergeTopicConfigs(topicStates("t1", List.of(RETENTION_1H)), Map.of());
+    assertThat(merged.get("t1")).containsExactly(RETENTION_1H);
+  }
+
+  @Test
+  void mergePrefersFreshlyFetchedConfigs() {
+    var merged = ScrapedClusterState.mergeTopicConfigs(
+        topicStates("t1", List.of(RETENTION_1H)),
+        Map.of("t1", List.of(RETENTION_2H))
+    );
+    assertThat(merged.get("t1")).containsExactly(RETENTION_2H);
+  }
+
+  @Test
+  void mergeIgnoresEmptyFetchedConfigList() {
+    var merged = ScrapedClusterState.mergeTopicConfigs(
+        topicStates("t1", List.of(RETENTION_1H)),
+        Map.of("t1", List.of())
+    );
+    assertThat(merged.get("t1")).containsExactly(RETENTION_1H);
+  }
+
+  @Test
+  void mergeAddsConfigsForTopicsAbsentFromPreviousState() {
+    var merged = ScrapedClusterState.mergeTopicConfigs(Map.of(), Map.of("t2", List.of(RETENTION_2H)));
+    assertThat(merged.get("t2")).containsExactly(RETENTION_2H);
+  }
+
+  @Test
+  void mergeSkipsTopicsWithNoConfigsOnEitherSide() {
+    var merged = ScrapedClusterState.mergeTopicConfigs(topicStates("t1", List.of()), Map.of());
+    assertThat(merged).isEmpty();
+  }
+
+  @Test
+  void updateTopicsKeepsExistingConfigsWhenConfigMapMissesTopic() throws Exception {
+    ClustersProperties properties = new ClustersProperties();
+    try (ScrapedClusterState previous = ScrapedClusterState.builder()
+        .scrapeFinishedAt(Instant.now())
+        .nodesStates(Map.of())
+        .topicStates(topicStates("t1", List.of(RETENTION_1H)))
+        .consumerGroupsStates(Map.of())
+        .topicIndex(new FilterTopicIndex(List.of()))
+        .build()) {
+
+      // configs deliberately empty: this is what a swallowed per-topic describeConfigs failure looks like
+      try (ScrapedClusterState updated = previous.updateTopics(
+          Map.of("t1", description("t1")),
+          Map.of(),
+          new InternalPartitionsOffsets(Map.of()),
+          properties)) {
+        assertThat(updated.getTopicStates().get("t1").configs()).containsExactly(RETENTION_1H);
+      }
+    }
+  }
+
+  private static Map<String, TopicState> topicStates(String topic, List<ConfigEntry> configs) {
+    return Map.of(topic, new TopicState(topic, description(topic), configs, Map.of(), Map.of(), null, null));
+  }
+
+  private static TopicDescription description(String topic) {
+    return new TopicDescription(topic, false, List.of(new TopicPartitionInfo(0, NODE, List.of(NODE), List.of(NODE))));
   }
 }

--- a/contract-typespec/api/config.tsp
+++ b/contract-typespec/api/config.tsp
@@ -141,6 +141,10 @@ model ApplicationConfig {
         @format("duration")
         connectClusterCacheExpiry?: string;
       };
+      scrape?: {
+        @format("duration")
+        topicConfigsExpiry?: string;
+      };
       clusters?: {
         name?: string;
         bootstrapServers?: string;
@@ -227,6 +231,10 @@ model ApplicationConfig {
           topicAuditEnabled?: boolean;
           consoleAuditEnabled?: boolean;
           auditTopicProperties?: Record<string>;
+        };
+        scrape?: {
+          @format("duration")
+          topicConfigsExpiry?: string;
         };
       }[];
     };


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
<!-- ignore-task-list-end -->

**What changes did you make?** (Give an overview)

Fixes #1717.

`ScrapedClusterState.scrape()` describes the configs of **every** topic on every scheduler tick (default 30s, per cluster). Topic configs are cold data — they only change by an explicit admin action — but `describeConfigs` is billed per topic on managed Kafka. On AWS MSK with IAM auth, each topic in the request becomes its own `DescribeTopicDynamicConfiguration` CloudTrail event, so volume is:

```
topics x (86_400_000 / interval_ms) x replicas   events/day/cluster
```

#1717 reports 10–23M events/day, paid for twice over in CloudTrail *and* GuardDuty. Today the only lever is `kafka.update-metrics-rate-millis`, which slows the **whole** scrape — so operators trade 30s consumer-lag freshness to fix a config-fetch problem. This decouples the two.

This is not a rerun of #1657 (`skipDescribeConfigs`, declined): nothing is disabled, no feature is lost, and every on-demand path stays live.

### There is already a precedent for this in the same class

`ReactiveAdminClient.ConfigRelatedInfo.extract()` ends with `.cache(UPDATE_DURATION)` where `UPDATE_DURATION = Duration.of(1, ChronoUnit.HOURS)`. `updateInternalStats()` runs on every scrape, but ~119 of every 120 calls replay from memory. So **broker** configs are already treated as hourly-cold, while **topic** configs are refetched every 30s. This change makes topic configs consistent with that.

### The change

New `kafka.scrape.topic-configs-expiry` (`Duration`), overridable per cluster:

```yaml
kafka:
  scrape:
    topic-configs-expiry: 0     # default: describe every scrape (today's behaviour)
  clusters:
    - name: msk-prod
      scrape:
        topic-configs-expiry: 1h
```

**It defaults to zero, so nothing changes until it is configured** — call counts at the default are byte-for-byte what they are today.

While the expiry has not elapsed, the scrape carries the previous state's configs forward and describes only topics it has not seen before, so a newly created topic never shows an unknown cleanup policy. A full re-describe resets the window; an incremental new-topic fetch deliberately does **not**, otherwise steady topic churn would postpone the full refresh forever.

New-topic detection is keyed on *presence* in `topicStates`, not on having non-empty configs. `getTopicsConfigImpl` deliberately swallows `TopicAuthorizationException`, so keying on content would re-describe every `DESCRIBE_CONFIGS`-denied topic on every scrape — the exact storm this setting exists to stop.

### Why the state, not a TTL in ReactiveAdminClient

`ScrapedClusterState.topicStates[*].configs()` already *is* the topic-config cache, so a second cache would mean two copies of truth to invalidate in lockstep. Keeping the memory in the state means **every existing write-back keeps working with no new invalidation hooks**: `TopicsService.loadTopics` already pushes fresh configs into the cached state on create/clone/recreate/alter, and `onTopicDelete` already removes them. A cache inside the admin client would be invisible to those, so a config edited in the UI would visibly revert on the next scrape until the TTL expired. It would also be dropped wholesale by `AdminClientServiceImpl.invalidate` on any Kafka error, causing precisely the full-cluster burst this is meant to avoid.

### Also included

- **One `listTopics` per scrape instead of two.** `describeTopics()` and `getTopicsConfig()` each listed topics on their own, so a topic created between the two calls was described but got an empty config list for that cycle. Hoisting the call is also a prerequisite — the refresh plan needs the name set before anything is described.
- **A pre-existing bug fix:** `updateTopics()` did `configs.getOrDefault(topic, List.of())`, so a partial `describeConfigs` failure (a swallowed per-resource `TopicAuthorizationException`) replaced configs we already had with an empty list. An empty config list drops `InternalTopic.cleanUpPolicy` to `UNKNOWN`, which nulls `messagesCount` in the topics list and reorders the server-side `MESSAGES_COUNT` sort. `mergeTopicConfigs()` now keeps what we knew.

### What can go stale, and what cannot

`cleanUpPolicy` is the only config-derived field in the OpenAPI spec (`Topic`, `TopicDetails`); `messagesCount` derives from it. `retention.*`, `max.message.bytes` and `segment.*` appear nowhere in the spec — they are served exclusively by the live `GET /topics/{name}/config`.

Unaffected: the Settings tab and Edit form (live endpoint), the topic list and details pages (`loadTopics` refetches live for the visible page), all metrics and consumer lag (`InferredMetricsScraper`/`MetricsScraper` never read `configs()`), and the read-modify-write in `updateTopicConfig` → `incrementalAlterConfig`, which calls `getTopicsConfigImpl` directly and bypasses the cache.

Can lag by up to the configured expiry, and **only** for config changes made outside kafka-ui: `config_*` search filters, the CSV export (which reads the cached index with no re-hydration), and the ODD exporter. Changes made *through* kafka-ui land in the cached state immediately.

### Deliberately not included

- **`describeLogDirs`** (the other half of #1657). It is O(brokers), not O(topics), so it has none of the per-topic CloudTrail amplification; and it is a *measurement*, not a *setting* — serving stale byte counts to the Prometheus endpoint would produce sawtooth series and corrupt `rate()`. Its problem is payload size and latency (#1776), which wants per-broker fan-out with concurrency limiting, not a TTL. `ScrapeProperties` is the seam a follow-up would extend with a `logDirsExpiry`.
- **Closing the displaced `Statistics` in `StatisticsCache.replace`.** `LuceneTopicsIndex.find()` takes a read lock but never re-checks a closed flag, so closing there would turn a rare `AlreadyClosedException` race into a per-tick one. Worth its own PR after the index gets a closed flag.
- The checked-in `api/src/main/resources/static/openapi/kafbat-ui-api.yaml` is **not** regenerated here, matching the precedent of every recent `config.tsp` change (#1812, #1645, #1541, #1551, #1518, #1418).

Happy to change the default, the property name (`kafka.scrape` vs reviving the currently-unused `kafka.cache`), or to split any commit out — the three commits are independent.

**Is there anything you'd like reviewers to focus on?**

1. **The property name and grouping.** I added a new `kafka.scrape` group rather than reviving `ClustersProperties.CacheProperties`, whose `enabled` and `connectClusterCacheExpiry` fields currently have zero usages — putting a per-cluster override on that group would drag dead config into the public surface. `kafka.clusters[].metrics` already means something else, so this naming is worth your call.
2. **The default.** Zero (no behaviour change) is the conservative choice. If you would rather it fix #1717 out of the box, note that this codebase already caches *broker* configs for an hour with no knob at all, so any topic-config default below that is strictly more conservative than what already ships.
3. **`scrape()` now takes the previous state.** It becomes `previous -> next`, which is what `updateTopics`/`topicDeleted` already are. `StatisticsService` consequently reads `StatisticsCache` before writing it; that is safe because the scheduler's task pool is single-threaded and `updateStatistics()` blocks, so ticks for one cluster cannot overlap — read at subscribe, write at complete.

**How Has This Been Tested?**
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit tests
- [ ] Integration tests
<!-- ignore-task-list-end -->

`./gradlew :api:check` — **715 tests, checkstyleMain and checkstyleTest clean.**

The only failures in my environment are 6 pre-existing ones that reproduce identically on unmodified `main`: three `nowsci/samba-domain:latest` container-startup failures (`ActiveDirectoryLdapTest`, `ActiveDirectoryLdapsTest`, `AuditRbacIntegrationTest`) and three `KafkaConnectServiceTests` Awaitility timeouts. The latter fail a *different* method set on every run, on `main` as well, so they are flaky timing rather than a regression. I run rootless Podman rather than Docker, which is the likely cause of both.

New coverage:

- `ScrapedClusterStateTest` — the refresh policy as a pure function of `(previous, currentTopics, expiry, now)`, so no `Clock` seam is needed: first scrape, expiry elapsed/not elapsed, zero and negative expiry, new-topics-only, that an incremental fetch does not advance the refresh clock, that `DESCRIBE_CONFIGS`-denied topics are not re-described every tick, and the `mergeTopicConfigs` rules.
- `ScrapedClusterStateScrapeTest` (new) — end to end over a mocked `ReactiveAdminClient` with call-count assertions: exactly one `listTopics` per scrape, no `getTopicsConfig` on a second tick inside the expiry, configs carried forward, an `ArgumentCaptor` proving only the new topic is requested, and a full re-describe when expiry is zero.
- `ClustersPropertiesTest` — the default and the cluster-overrides-global resolution.
- `StatisticsServiceTest` — against a real broker: configs and `cleanup.policy` survive a second scrape inside the expiry with `topicConfigsRefreshedAt` unchanged, and a topic created between scrapes gets its configs on the next tick.

One documentation note: the new property needs a line on the misc-configuration-properties page in `kafbat/ui-docs`. `README.md` has no property table (it links out to the docs site), so there is nothing to change here — happy to raise the docs PR alongside.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable topic-configuration refresh intervals at the global and cluster levels.
  * Newly created topics receive their configuration details without waiting for a full refresh.
* **Performance Improvements**
  * Reduced repeated configuration requests during statistics updates by reusing recently retrieved data.
* **Bug Fixes**
  * Preserved previously available topic configuration details when some configuration requests fail.
  * Ensured the first scrape always retrieves complete topic configuration data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->