### PR TITLE
Fix topic analysis percentiles to match partition percentiles

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/analyze/TopicAnalysisService.java
+++ b/api/src/main/java/io/kafbat/ui/service/analyze/TopicAnalysisService.java
@@ -76,7 +76,6 @@ public class TopicAnalysisService {
 
     private final TopicIdentity topicId;
 
-    private final TopicAnalysisStats totalStats = new TopicAnalysisStats();
     private final Map<Integer, TopicAnalysisStats> partitionStats = new HashMap<>();
 
     private final EnhancedConsumer consumer;
@@ -112,13 +111,11 @@ public class TopicAnalysisService {
 
         while (!seekOperations.assignedPartitionsFullyPolled()) {
           var polled = consumer.pollEnhanced(Duration.ofSeconds(3));
-          polled.forEach(r -> {
-            totalStats.apply(r);
-            partitionStats.get(r.partition()).apply(r);
-          });
+          polled.forEach(r -> partitionStats.get(r.partition()).apply(r));
           updateProgress(seekOperations.offsetsProcessedFromSeek(), summaryOffsetsRange);
         }
-        analysisTasksStore.setAnalysisResult(topicId, startedAt, totalStats, partitionStats);
+        analysisTasksStore.setAnalysisResult(
+            topicId, startedAt, TopicAnalysisStats.merge(partitionStats.values()), partitionStats);
         log.info("{} topic analysis finished", topicId);
       } catch (WakeupException | InterruptException cancelException) {
         log.info("{} topic analysis stopped", topicId);
@@ -134,10 +131,16 @@ public class TopicAnalysisService {
 
     private void updateProgress(long processedOffsets, long summaryOffsetsRange) {
       if (processedOffsets > 0 && summaryOffsetsRange != 0) {
+        long msgsScanned = 0;
+        long bytesScanned = 0;
+        for (TopicAnalysisStats stats : partitionStats.values()) {
+          msgsScanned += stats.totalMsgs;
+          bytesScanned += stats.keysSize.sum + stats.valuesSize.sum;
+        }
         analysisTasksStore.updateProgress(
             topicId,
-            totalStats.totalMsgs,
-            totalStats.keysSize.sum + totalStats.valuesSize.sum,
+            msgsScanned,
+            bytesScanned,
             Math.min(100.0, (((double) processedOffsets) / summaryOffsetsRange) * 100)
         );
       }

--- a/api/src/main/java/io/kafbat/ui/service/analyze/TopicAnalysisStats.java
+++ b/api/src/main/java/io/kafbat/ui/service/analyze/TopicAnalysisStats.java
@@ -5,6 +5,7 @@ import io.kafbat.ui.model.TopicAnalysisStatsDTO;
 import io.kafbat.ui.model.TopicAnalysisStatsHourlyMsgCountsInnerDTO;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +13,9 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.datasketches.hll.HllSketch;
+import org.apache.datasketches.hll.Union;
 import org.apache.datasketches.quantiles.DoublesSketch;
+import org.apache.datasketches.quantiles.DoublesUnion;
 import org.apache.datasketches.quantiles.UpdateDoublesSketch;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.utils.Bytes;
@@ -32,8 +35,8 @@ class TopicAnalysisStats {
   final SizeStats keysSize = new SizeStats();
   final SizeStats valuesSize = new SizeStats();
 
-  final HllSketch uniqKeys = new HllSketch();
-  final HllSketch uniqValues = new HllSketch();
+  HllSketch uniqKeys = new HllSketch();
+  HllSketch uniqValues = new HllSketch();
 
   final HourlyCounts hourlyCounts = new HourlyCounts();
 
@@ -41,13 +44,23 @@ class TopicAnalysisStats {
     long sum = 0;
     Long min;
     Long max;
-    final UpdateDoublesSketch sizeSketch = DoublesSketch.builder().build();
+    UpdateDoublesSketch sizeSketch = DoublesSketch.builder().build();
 
     void apply(int len) {
       sum += len;
       min = minNullable(min, len);
       max = maxNullable(max, len);
       sizeSketch.update(len);
+    }
+
+    void merge(SizeStats other) {
+      sum += other.sum;
+      min = minNullable(min, other.min);
+      max = maxNullable(max, other.max);
+      var union = DoublesUnion.builder().build();
+      union.update(sizeSketch);
+      union.update(other.sizeSketch);
+      sizeSketch = union.getResult();
     }
 
     TopicAnalysisSizeStatsDTO toDto() {
@@ -77,6 +90,11 @@ class TopicAnalysisStats {
       }
     }
 
+    void merge(HourlyCounts other) {
+      // counts collected by the source are already filtered by its own minTs, so no cut-off is re-applied here
+      other.hourlyStats.forEach((hourStart, cnt) -> hourlyStats.merge(hourStart, cnt, Long::sum));
+    }
+
     List<TopicAnalysisStatsHourlyMsgCountsInnerDTO> toDto() {
       return hourlyStats.entrySet().stream()
           .sorted(Comparator.comparingLong(Map.Entry::getKey))
@@ -85,6 +103,32 @@ class TopicAnalysisStats {
               .count(e.getValue()))
           .collect(Collectors.toList());
     }
+  }
+
+  /**
+   * Aggregates per-partition stats into topic-wide stats. Sketches are combined with their unions instead of
+   * being fed the same records twice: quantile sketches are probabilistic, so two sketches built from identical
+   * input can still disagree - most visibly on sparse tails like the 99.9th percentile.
+   */
+  static TopicAnalysisStats merge(Collection<TopicAnalysisStats> stats) {
+    var merged = new TopicAnalysisStats();
+    stats.forEach(merged::merge);
+    return merged;
+  }
+
+  private void merge(TopicAnalysisStats other) {
+    totalMsgs += other.totalMsgs;
+    minOffset = minNullable(minOffset, other.minOffset);
+    maxOffset = maxNullable(maxOffset, other.maxOffset);
+    minTimestamp = minNullable(minTimestamp, other.minTimestamp);
+    maxTimestamp = maxNullable(maxTimestamp, other.maxTimestamp);
+    nullKeys += other.nullKeys;
+    nullValues += other.nullValues;
+    keysSize.merge(other.keysSize);
+    valuesSize.merge(other.valuesSize);
+    uniqKeys = union(uniqKeys, other.uniqKeys);
+    uniqValues = union(uniqValues, other.uniqValues);
+    hourlyCounts.merge(other.hourlyCounts);
   }
 
   void apply(ConsumerRecord<Bytes, Bytes> rec) {
@@ -130,11 +174,27 @@ class TopicAnalysisStats {
         .hourlyMsgCounts(hourlyCounts.toDto());
   }
 
+  private static HllSketch union(HllSketch s1, HllSketch s2) {
+    var union = new Union(HllSketch.DEFAULT_LG_K);
+    union.update(s1);
+    union.update(s2);
+    return union.getResult();
+  }
+
   private static Long maxNullable(@Nullable Long v1, long v2) {
     return v1 == null ? v2 : Math.max(v1, v2);
   }
 
+  // partitions that were never written to contribute no bounds at all
+  private static Long maxNullable(@Nullable Long v1, @Nullable Long v2) {
+    return v2 == null ? v1 : maxNullable(v1, (long) v2);
+  }
+
   private static Long minNullable(@Nullable Long v1, long v2) {
     return v1 == null ? v2 : Math.min(v1, v2);
+  }
+
+  private static Long minNullable(@Nullable Long v1, @Nullable Long v2) {
+    return v2 == null ? v1 : minNullable(v1, (long) v2);
   }
 }

--- a/api/src/test/java/io/kafbat/ui/service/analyze/TopicAnalysisServiceTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/analyze/TopicAnalysisServiceTest.java
@@ -6,7 +6,9 @@ import io.kafbat.ui.AbstractIntegrationTest;
 import io.kafbat.ui.producer.KafkaTestProducer;
 import io.kafbat.ui.service.ClustersStorage;
 import java.time.Duration;
+import java.util.Random;
 import java.util.UUID;
+import java.util.function.IntSupplier;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -44,17 +46,46 @@ class TopicAnalysisServiceTest extends AbstractIntegrationTest {
             }));
   }
 
+  @Test
+  void topicStatsMatchPartitionStatsForSinglePartitionTopic() {
+    String topic = "analyze_test_" + UUID.randomUUID();
+    createTopic(new NewTopic(topic, 1, (short) 1));
+    var rnd = new Random();
+    fillTopic(topic, 1_000, () -> 1 + rnd.nextInt(2_048));
+
+    var cluster = clustersStorage.getClusterByName(LOCAL).orElseThrow();
+    topicAnalysisService.analyze(cluster, topic).block();
+
+    Awaitility.await()
+        .atMost(Duration.ofSeconds(20))
+        .untilAsserted(() -> assertThat(topicAnalysisService.getTopicAnalysis(cluster, topic))
+            .hasValueSatisfying(state -> {
+              assertThat(state.getResult()).isNotNull();
+              var completedAnalyze = state.getResult();
+              assertThat(completedAnalyze.getPartitionStats()).hasSize(1);
+              // the only partition holds every message, so topic-wide stats must repeat it exactly -
+              // percentiles included, see https://github.com/kafbat/kafka-ui/issues/374
+              assertThat(completedAnalyze.getTotalStats())
+                  .usingRecursiveComparison()
+                  .ignoringFields("partition")
+                  .isEqualTo(completedAnalyze.getPartitionStats().get(0));
+            }));
+  }
+
   private void fillTopic(String topic, int cnt) {
+    fillTopic(topic, cnt, () -> 10);
+  }
+
+  private void fillTopic(String topic, int cnt, IntSupplier valueLength) {
     try (var producer = KafkaTestProducer.forKafka(kafka)) {
       for (int i = 0; i < cnt; i++) {
         producer.send(
             new ProducerRecord<>(
                 topic,
                 RandomStringUtils.secure().nextAlphabetic(5),
-                RandomStringUtils.secure().nextAlphabetic(10)));
+                RandomStringUtils.secure().nextAlphabetic(valueLength.getAsInt())));
       }
     }
   }
-
 
 }

--- a/api/src/test/java/io/kafbat/ui/service/analyze/TopicAnalysisStatsTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/analyze/TopicAnalysisStatsTest.java
@@ -1,0 +1,156 @@
+package io.kafbat.ui.service.analyze;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Percentage.withPercentage;
+
+import io.kafbat.ui.model.TopicAnalysisStatsHourlyMsgCountsInnerDTO;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.Test;
+
+class TopicAnalysisStatsTest {
+
+  private static final String TOPIC = "analysis-stats-test";
+
+  /**
+   * Guards https://github.com/kafbat/kafka-ui/issues/374 - a single-partition topic has to report exactly what
+   * its only partition reports, the sparse 99.9th percentile included.
+   */
+  @Test
+  void mergeOfSinglePartitionProducesStatsIdenticalToThatPartition() {
+    var partitionStats = new TopicAnalysisStats();
+    generateRecords(0, 100_000, new Random(7)).forEach(partitionStats::apply);
+
+    var totalDto = TopicAnalysisStats.merge(List.of(partitionStats)).toDto(null);
+    var partitionDto = partitionStats.toDto(0);
+
+    assertThat(totalDto.getValueSize().getPrctl999()).isEqualTo(partitionDto.getValueSize().getPrctl999());
+    assertThat(totalDto)
+        .usingRecursiveComparison()
+        .ignoringFields("partition")
+        .isEqualTo(partitionDto);
+  }
+
+  @Test
+  void mergeAggregatesStatsOfAllPartitions() {
+    var partition0Records = generateRecords(0, 1_000, new Random(1));
+    var partition1Records = generateRecords(1, 500, new Random(2));
+
+    var partition0Stats = new TopicAnalysisStats();
+    var partition1Stats = new TopicAnalysisStats();
+    partition0Records.forEach(partition0Stats::apply);
+    partition1Records.forEach(partition1Stats::apply);
+
+    var totalDto = TopicAnalysisStats.merge(List.of(partition0Stats, partition1Stats)).toDto(null);
+    var dto0 = partition0Stats.toDto(0);
+    var dto1 = partition1Stats.toDto(1);
+
+    assertThat(totalDto.getPartition()).isNull();
+    assertThat(totalDto.getTotalMsgs()).isEqualTo(1_500);
+    assertThat(totalDto.getMinOffset()).isEqualTo(Math.min(dto0.getMinOffset(), dto1.getMinOffset()));
+    assertThat(totalDto.getMaxOffset()).isEqualTo(Math.max(dto0.getMaxOffset(), dto1.getMaxOffset()));
+    assertThat(totalDto.getMinTimestamp()).isEqualTo(Math.min(dto0.getMinTimestamp(), dto1.getMinTimestamp()));
+    assertThat(totalDto.getMaxTimestamp()).isEqualTo(Math.max(dto0.getMaxTimestamp(), dto1.getMaxTimestamp()));
+    assertThat(totalDto.getNullKeys()).isEqualTo(dto0.getNullKeys() + dto1.getNullKeys());
+    assertThat(totalDto.getNullValues()).isEqualTo(dto0.getNullValues() + dto1.getNullValues());
+
+    assertThat(totalDto.getValueSize().getSum()).isEqualTo(dto0.getValueSize().getSum() + dto1.getValueSize().getSum());
+    assertThat(totalDto.getValueSize().getMin())
+        .isEqualTo(Math.min(dto0.getValueSize().getMin(), dto1.getValueSize().getMin()));
+    assertThat(totalDto.getValueSize().getMax())
+        .isEqualTo(Math.max(dto0.getValueSize().getMax(), dto1.getValueSize().getMax()));
+
+    assertThat(totalDto.getHourlyMsgCounts().stream()
+        .mapToLong(TopicAnalysisStatsHourlyMsgCountsInnerDTO::getCount).sum()).isEqualTo(1_500);
+
+    // both partitions reuse the same key/value alphabet, so the merged sketches must deduplicate across them
+    var allRecords = Stream.concat(partition0Records.stream(), partition1Records.stream()).toList();
+    assertThat(totalDto.getApproxUniqKeys())
+        .isCloseTo(distinctCount(allRecords, ConsumerRecord::key), withPercentage(10));
+    assertThat(totalDto.getApproxUniqValues())
+        .isCloseTo(distinctCount(allRecords, ConsumerRecord::value), withPercentage(10));
+  }
+
+  /**
+   * The analysis creates a stats holder for every partition upfront, so untouched partitions join the merge empty.
+   */
+  @Test
+  void mergeIgnoresPartitionsWithoutRecords() {
+    var writtenPartition = new TopicAnalysisStats();
+    generateRecords(1, 10_000, new Random(3)).forEach(writtenPartition::apply);
+
+    var totalDto = TopicAnalysisStats
+        .merge(List.of(new TopicAnalysisStats(), writtenPartition, new TopicAnalysisStats()))
+        .toDto(null);
+
+    assertThat(totalDto)
+        .usingRecursiveComparison()
+        .ignoringFields("partition")
+        .isEqualTo(writtenPartition.toDto(1));
+  }
+
+  @Test
+  void mergeOfTopicWithoutAnyRecordsReportsEmptyStats() {
+    var totalDto = TopicAnalysisStats.merge(List.of(new TopicAnalysisStats(), new TopicAnalysisStats())).toDto(null);
+
+    assertThat(totalDto.getTotalMsgs()).isZero();
+    assertThat(totalDto.getMinOffset()).isNull();
+    assertThat(totalDto.getMaxOffset()).isNull();
+    assertThat(totalDto.getMinTimestamp()).isNull();
+    assertThat(totalDto.getMaxTimestamp()).isNull();
+    assertThat(totalDto.getHourlyMsgCounts()).isEmpty();
+    // an untouched topic has to look exactly like it did before the stats were merged from partitions
+    assertThat(totalDto)
+        .usingRecursiveComparison()
+        .ignoringFields("partition")
+        .isEqualTo(new TopicAnalysisStats().toDto(null));
+  }
+
+  private static long distinctCount(List<ConsumerRecord<Bytes, Bytes>> records,
+                                    Function<ConsumerRecord<Bytes, Bytes>, Bytes> extractor) {
+    return records.stream()
+        .map(extractor)
+        .filter(Objects::nonNull)
+        .distinct()
+        .count();
+  }
+
+  private static List<ConsumerRecord<Bytes, Bytes>> generateRecords(int partition, int count, Random rnd) {
+    long baseTs = Instant.now().minus(Duration.ofDays(3)).toEpochMilli();
+    List<ConsumerRecord<Bytes, Bytes>> records = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      // most messages are of a similar size, with a sparse tail of much bigger ones - the shape that makes
+      // the 99.9th percentile diverge between two independently built sketches
+      int valueSize = rnd.nextDouble() < 0.995 ? 512 + rnd.nextInt(3) : 4096 + rnd.nextInt(60_000);
+      Bytes key = i % 10 == 0 ? null : Bytes.wrap(("key-" + i).getBytes(StandardCharsets.UTF_8));
+      Bytes value = i % 20 == 0 ? null : Bytes.wrap(("value-" + i).getBytes(StandardCharsets.UTF_8));
+      records.add(new ConsumerRecord<>(
+          TOPIC,
+          partition,
+          i,
+          baseTs + i * 1_000L,
+          TimestampType.CREATE_TIME,
+          key == null ? -1 : key.get().length,
+          value == null ? -1 : valueSize,
+          key,
+          value,
+          new RecordHeaders(),
+          Optional.empty()
+      ));
+    }
+    return records;
+  }
+
+}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Closes #374.

Topic analysis kept two independent sets of sketches and fed every record to both of them:

```java
polled.forEach(r -> {
  totalStats.apply(r);                        // topic-wide sketches
  partitionStats.get(r.partition()).apply(r); // per-partition sketches
});
```

`DoublesSketch` is probabilistic — when its buffer fills up it draws randomly to decide which samples to
keep — so two sketches built from identical input in identical order still drift apart. Message sizes
normally cluster in a narrow band, which is why the 50/75/95/99 percentiles keep agreeing while the
sparse tail at 99.9 does not. That is exactly the symptom reported in the issue: on a single-partition
topic every value matches between topic and partition except `prctl999`.

Reproduced over 30 runs of 100k records (99.5% of the messages 512–514 bytes, 0.5% spread over
4096–64096 bytes — the shape of a real topic), counting how often the topic-wide value differs from the
single partition's:

| | p50 | p75 | p95 | p99 | **p999** |
|---|---|---|---|---|---|
| before | 0/30 | 0/30 | 0/30 | 0/30 | **30/30** |
| after | 0/30 | 0/30 | 0/30 | 0/30 | **0/30** |

One sample run: the partition reported `p999 = 5066` while the topic reported `514`.

**The fix** — stop accumulating topic-wide stats separately and derive them from the partitions instead
(`TopicAnalysisStats.merge`). Exact counters (`totalMsgs`, `sum`, `nullKeys`, offsets, timestamps, hourly
counts) are summed or min/maxed; the probabilistic ones are combined through their unions —
`DoublesUnion` for the size sketches, `hll.Union` for the unique-count sketches.

For a single-partition topic the merge is that partition itself, so the numbers now match exactly. For
several partitions a sketch union is the mathematically correct aggregation anyway. As a side effect
every record is fed to a sketch once instead of twice, so the analysis does roughly half the sketch work
it used to.

**Is there anything you'd like reviewers to focus on?**

- **The single-partition guarantee.** The fix only holds if unioning one sketch into an empty accumulator
  reproduces it exactly. Verified: the compact serialized form is byte-identical, and the quantiles agree
  across 10,001 evenly spaced ranks (`getN`, `getK`, min, max and retained-item count all match too).
  This is why the merge does not need a special case for single-partition topics.
- **Progress reporting.** `updateProgress` used to read the counters off `totalStats`, which no longer
  exists. It now sums them over `partitionStats`. Only plain counters are summed — never sketches — so the
  in-flight progress figures stay exact, and the loop runs once per poll rather than per record.
- **`approxUniqKeys` / `approxUniqValues` on multi-partition topics.** These now come from an HLL union of
  the per-partition sketches instead of one sketch fed every record. Both estimate the same quantity with
  the same error bound and dedupe across partitions correctly, but the reported estimate can differ
  slightly from before.
- **Empty partitions.** The analysis creates a stats holder for every partition upfront, so untouched
  partitions take part in the merge. They must not contribute bounds or samples — covered by a test.


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

New `TopicAnalysisStatsTest` (unit):

- `mergeOfSinglePartitionProducesStatsIdenticalToThatPartition` — the issue itself; compares the whole DTO
- `mergeAggregatesStatsOfAllPartitions` — counters, bounds, hourly counts, and cross-partition dedup of the
  unique-count sketches checked against the real distinct count
- `mergeIgnoresPartitionsWithoutRecords` — empty partitions must not perturb the result
- `mergeOfTopicWithoutAnyRecordsReportsEmptyStats` — an untouched topic still reports what it did before

`TopicAnalysisServiceTest` gains `topicStatsMatchPartitionStatsForSinglePartitionTopic`, which runs the
whole analysis against a real single-partition topic — the issue's exact setup — and asserts the topic
stats equal the only partition's.

`./gradlew :api:test --tests "io.kafbat.ui.service.analyze.*" :api:checkstyleMain :api:checkstyleTest`
passes: 6 tests, no checkstyle violations.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved topic analysis aggregation across partitions.
  * Preserved accurate message counts, byte totals, offsets, timestamps, hourly counts, percentiles, and approximate distinct-value metrics.
  * Corrected handling of empty partitions and missing minimum or maximum values.
  * Ensured single-partition topic statistics match their partition-level results.

* **Tests**
  * Added comprehensive coverage for single- and multi-partition analysis, sparse data, varied message sizes, and null fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->