### PR TITLE
Fix Flux serialization in ResponseEntity for MCP tools

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/mcp/McpSpecificationGenerator.java
+++ b/api/src/main/java/io/kafbat/ui/service/mcp/McpSpecificationGenerator.java
@@ -151,7 +151,7 @@ public class McpSpecificationGenerator {
   private Mono<CallToolResult> reponseToCallResult(ResponseEntity<?> response) {
     HttpStatusCode statusCode = response.getStatusCode();
     if (statusCode.is2xxSuccessful() || statusCode.is1xxInformational()) {
-      return Mono.just(this.callToolResult(response.getBody()));
+      return this.toCallResult(response.getBody());
     } else {
       try {
         return Mono.just(toErrorResult(objectMapper.writeValueAsString(response.getBody())));

--- a/api/src/test/java/io/kafbat/ui/service/mcp/McpSpecificationGeneratorTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/mcp/McpSpecificationGeneratorTest.java
@@ -11,17 +11,21 @@ import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 import io.kafbat.ui.config.ClustersProperties;
+import io.kafbat.ui.controller.ClustersController;
 import io.kafbat.ui.controller.TopicsController;
 import io.kafbat.ui.mapper.ClusterMapper;
+import io.kafbat.ui.model.ClusterDTO;
 import io.kafbat.ui.model.KafkaCluster;
 import io.kafbat.ui.model.SortOrderDTO;
 import io.kafbat.ui.model.TopicColumnsToSortDTO;
 import io.kafbat.ui.model.TopicUpdateDTO;
+import io.kafbat.ui.service.ClusterService;
 import io.kafbat.ui.service.ClustersStorage;
 import io.kafbat.ui.service.KafkaConnectService;
 import io.kafbat.ui.service.TopicsService;
 import io.kafbat.ui.service.acl.AclsService;
 import io.kafbat.ui.service.analyze.TopicAnalysisService;
+import io.kafbat.ui.service.rbac.AccessControlService;
 import io.modelcontextprotocol.server.McpAsyncServerExchange;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.spec.McpSchema;
@@ -227,6 +231,37 @@ class McpSpecificationGeneratorTest {
           assertThat(result.isError()).isTrue();
           assertThat(((McpSchema.TextContent) result.content().get(0)).text())
               .contains("clusterName is required");
+        })
+        .verifyComplete();
+  }
+
+  @Test
+  void toolBackedByResponseEntityOfFluxReturnsCollectedDataNotReactorInternals() {
+    ClusterDTO cluster = new ClusterDTO();
+    cluster.setName("test-cluster");
+
+    ClusterService clusterService = mock(ClusterService.class);
+    when(clusterService.getClusters()).thenReturn(List.of(cluster));
+
+    ClustersController controller = new ClustersController(clusterService);
+    controller.setClustersStorage(mock(ClustersStorage.class));
+    AccessControlService accessControlService = mock(AccessControlService.class);
+    when(accessControlService.isClusterAccessible(cluster)).thenReturn(Mono.just(true));
+    controller.setAccessControlService(accessControlService);
+
+    McpSpecificationGenerator generator = generatorWith(mock(ClustersStorage.class));
+    AsyncToolSpecification getClusters = findTool(generator.convertTool(controller), "getClusters");
+
+    StepVerifier.create(invokeTool(getClusters, Map.of()))
+        .assertNext(result -> {
+          String text = ((McpSchema.TextContent) result.content().get(0)).text();
+          // Regression check for https://github.com/kafbat/kafka-ui/issues/1454 :
+          // a Flux nested inside a ResponseEntity body used to be serialized via its
+          // Reactor internals ({"scanAvailable":true,"prefetch":-1}) instead of being
+          // collected into the actual list of results.
+          assertThat(text).doesNotContain("scanAvailable", "prefetch");
+          assertThat(text).contains("test-cluster");
+          assertThat(result.isError()).isFalse();
         })
         .verifyComplete();
   }


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)

<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Fixes #1454.

`McpSpecificationGenerator.toCallResult()` already handles a bare `Flux<?>` correctly by calling `.collectList()` before serializing. But controllers like `ClustersController#getClusters`, `AclsController#listAcls`, `KafkaConnectController#getAllConnectors`, and `MessagesController#getTopicMessagesV2` return `Mono<ResponseEntity<Flux<T>>>` — the `Flux` is nested *inside* the `ResponseEntity` body.

`reponseToCallResult()` unwraps the `ResponseEntity` and passes its body straight to `callToolResult()`, skipping the `Flux`-aware branch in `toCallResult()` entirely. Jackson then introspects the live, unresolved `Flux` object graph and serializes its internal Reactor fields instead of its contents, e.g. `{"scanAvailable":true,"prefetch":-1}` instead of the actual list of clusters/ACLs/connectors/messages. The tool call reports `isError:false`, so an MCP client gets silently wrong data rather than a visible failure.

Fix: `reponseToCallResult()` now delegates the response body to `toCallResult()` instead of calling `callToolResult()` directly, so the existing `Flux` branch (`flux.collectList()`) applies uniformly whether the `Flux` is top-level or nested inside a `ResponseEntity`.

**Is there anything you'd like reviewers to focus on?**

None — it's a one-line change (see diff), the risk is in the surrounding reasoning rather than the code itself, which the added regression test should make easy to check.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Added `toolBackedByResponseEntityOfFluxReturnsCollectedDataNotReactorInternals`, exercising `ClustersController#getClusters` through the real `McpSpecificationGenerator`. Verified it fails on unpatched code (reproduces `{"scanAvailable":...}`) and passes after the fix. Also manually reproduced the bug against a live deployment across `getClusters`, `listAcls`, `getAllConnectors`, and `getTopicMessagesV2` (all `ResponseEntity<Flux<T>>>`-shaped, all affected) before the fix, and confirmed `getTopics`/`getConsumerGroupsPage`/`getSchemas`/`getLatestSchema` (which return `Page<T>`/plain DTOs, not `Flux`) were unaffected — confirming the bug is specific to the `ResponseEntity<Flux<T>>` shape. After the fix, built the full application (including frontend) and smoke-tested the resulting image standalone: opened a real MCP SSE session and called `getClusters`, which returned `[]` (correct, no clusters configured) instead of the Reactor-internals payload.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**

🦫

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MCP tool responses backed by reactive data streams to return collected data correctly instead of exposing internal serialization details.
  * Improved consistency when processing successful API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->