### PR TITLE
BE/FE: Allow selecting the protobuf message type when producing a message

### DIFF
--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
@@ -47,12 +47,14 @@ import io.kafbat.ui.serde.api.PropertyResolver;
 import io.kafbat.ui.serde.api.RecordHeaders;
 import io.kafbat.ui.serde.api.SchemaDescription;
 import io.kafbat.ui.serde.api.Serde;
+import io.kafbat.ui.serde.api.SerdeParameter;
 import io.kafbat.ui.serdes.BuiltInSerde;
 import io.kafbat.ui.util.jsonschema.ProtobufSchemaConverter;
 import java.io.ByteArrayInputStream;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -70,6 +72,8 @@ import org.jetbrains.annotations.NotNull;
 @Slf4j
 public class ProtobufFileSerde implements BuiltInSerde {
   public static final String NAME = "ProtobufFile";
+
+  private static final String MESSAGE_NAME_PARAMETER = "messageName";
 
   private static final ProtobufSchemaConverter SCHEMA_CONVERTER = new ProtobufSchemaConverter();
 
@@ -141,8 +145,38 @@ public class ProtobufFileSerde implements BuiltInSerde {
   @Override
   public Serde.Serializer serializer(String topic, Serde.Target type) {
     var descriptor = descriptorFor(topic, type).orElseThrow();
+    return serializerForDescriptor(descriptor);
+  }
+
+  @Override
+  public Serde.Serializer serializer(String topic, Serde.Target type, Map<String, Object> properties) {
+    if (properties != null) {
+      Object messageNameObj = properties.get(MESSAGE_NAME_PARAMETER);
+      if (messageNameObj instanceof String messageName && !messageName.isBlank()) {
+        return serializerForDescriptor(resolveDescriptor(topic, type, messageName));
+      }
+    }
+    return serializer(topic, type);
+  }
+
+  @Override
+  public List<SerdeParameter> getParameters(String topic, Serde.Target type) {
+    return descriptorFor(topic, type)
+        .map(descriptor -> List.of(
+            new SerdeParameter(
+                MESSAGE_NAME_PARAMETER,
+                MESSAGE_NAME_PARAMETER,
+                collectMessageNames(descriptor.getFile()))))
+        .orElse(List.of());
+  }
+
+  private Serde.Serializer serializerForDescriptor(Descriptor descriptor) {
+    // dedup by full name so the chosen descriptor doesn't clash with configured ones in the registry
+    Map<String, Descriptor> registryTypes = new HashMap<>();
+    descriptorPaths.keySet().forEach(d -> registryTypes.putIfAbsent(d.getFullName(), d));
+    registryTypes.putIfAbsent(descriptor.getFullName(), descriptor);
     TypeRegistry typeRegistry = TypeRegistry.newBuilder()
-        .add(descriptorPaths.keySet())
+        .add(registryTypes.values())
         .build();
 
     return new Serde.Serializer() {
@@ -158,6 +192,43 @@ public class ProtobufFileSerde implements BuiltInSerde {
     };
   }
 
+  // Resolves a message type chosen by the user, restricted to the proto file configured for this topic/target.
+  private Descriptor resolveDescriptor(String topic, Serde.Target type, String messageName) {
+    Descriptors.FileDescriptor file = descriptorFor(topic, type)
+        .orElseThrow(() -> new ValidationException(
+            "No protobuf descriptor configured for topic '" + topic + "' " + type))
+        .getFile();
+    return collectDescriptors(file).stream()
+        .filter(d -> d.getFullName().equals(messageName) || d.getName().equals(messageName))
+        .findFirst()
+        .orElseThrow(() -> new ValidationException(
+            "Message type '" + messageName + "' not found in proto file '"
+                + file.getName() + "' used for topic '" + topic + "'"));
+  }
+
+  private static List<String> collectMessageNames(Descriptors.FileDescriptor file) {
+    return collectDescriptors(file).stream()
+        .map(Descriptor::getFullName)
+        .distinct()
+        .sorted()
+        .toList();
+  }
+
+  private static List<Descriptor> collectDescriptors(Descriptors.FileDescriptor file) {
+    List<Descriptor> result = new ArrayList<>();
+    file.getMessageTypes().forEach(d -> collectNestedDescriptors(d, result));
+    return result;
+  }
+
+  private static void collectNestedDescriptors(Descriptor descriptor, List<Descriptor> acc) {
+    // skip synthetic map-entry types - they aren't real, producible message definitions
+    if (descriptor.getOptions().getMapEntry()) {
+      return;
+    }
+    acc.add(descriptor);
+    descriptor.getNestedTypes().forEach(nested -> collectNestedDescriptors(nested, acc));
+  }
+
   @Override
   public Serde.Deserializer deserializer(String topic, Serde.Target type) {
     var descriptor = descriptorFor(topic, type).orElseThrow();
@@ -171,7 +242,8 @@ public class ProtobufFileSerde implements BuiltInSerde {
         return new DeserializeResult(
             result,
             DeserializeResult.Type.JSON,
-            Map.of()
+            // expose the message type used so "reproduce message" can pre-select it in the UI
+            Map.of(MESSAGE_NAME_PARAMETER, descriptor.getFullName())
         );
       }
     };

--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerde.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.protobuf.Descriptors;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
@@ -38,6 +39,7 @@ import io.kafbat.ui.util.jsonschema.ProtobufSchemaConverter;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -54,6 +56,7 @@ public class SchemaRegistrySerde implements BuiltInSerde {
 
   public static final String NAME = "SchemaRegistry";
   public static final String SUBJECT_PARAMETER_NAME = "subject";
+  public static final String MESSAGE_NAME_PARAMETER = "messageName";
   private static final byte SR_PAYLOAD_MAGIC_BYTE = 0x0;
   private static final int SR_PAYLOAD_PREFIX_LENGTH = 5;
 
@@ -71,6 +74,7 @@ public class SchemaRegistrySerde implements BuiltInSerde {
 
   private Cache<Integer, List<String>> idToSubjectsCache;
   private Cache<String, Collection<String>> allSubjectsCache;
+  private Cache<String, List<String>> subjectMessageNamesCache;
 
   @Override
   public boolean canBeAutoConfigured(PropertyResolver kafkaClusterProperties,
@@ -193,6 +197,10 @@ public class SchemaRegistrySerde implements BuiltInSerde {
     this.allSubjectsCache = Caffeine.newBuilder()
         .expireAfterWrite(Duration.ofSeconds(allSubjectsCacheTtlSeconds))
         .maximumSize(1)
+        .build();
+    this.subjectMessageNamesCache = Caffeine.newBuilder()
+        .expireAfterWrite(Duration.ofSeconds(allSubjectsCacheTtlSeconds))
+        .maximumSize(maxSubjectsCacheSize)
         .build();
   }
 
@@ -359,41 +367,44 @@ public class SchemaRegistrySerde implements BuiltInSerde {
 
   @Override
   public Serializer serializer(String topic, Target type) {
-    String subject = schemaSubject(topic, type);
-    SchemaMetadata meta = getSchemaBySubject(subject)
-        .orElseThrow(() -> new ValidationException(
-            String.format("No schema for subject '%s' found", subject)));
-    ParsedSchema schema = getSchemaById(meta.getId())
-        .orElseThrow(() -> new IllegalStateException(
-            String.format("Schema found for id %s, subject '%s'", meta.getId(), subject)));
-    SchemaType schemaType = SchemaType.fromString(meta.getSchemaType())
-        .orElseThrow(() -> new UnknownSchemaTypeException(meta.getSchemaType()));
-    return switch (schemaType) {
-      case PROTOBUF -> input ->
-          serializeProto(schemaRegistryClient, topic, type, (ProtobufSchema) schema, meta.getId(), input);
-      case AVRO -> input ->
-          serializeAvro((AvroSchema) schema, meta.getId(), input);
-      case JSON -> input ->
-          serializeJson((JsonSchema) schema, meta.getId(), input);
-    };
+    return buildSerializer(topic, type, schemaSubject(topic, type), null);
   }
 
   @Override
   public Serializer serializer(String topic, Target type, Map<String, Object> properties) {
+    String subject = schemaSubject(topic, type);
+    String messageName = null;
     if (properties != null) {
       Object subjectObj = properties.get(SUBJECT_PARAMETER_NAME);
       if (subjectObj instanceof String explicitSubject && !explicitSubject.isEmpty()) {
-        return serializerWithSubject(topic, type, explicitSubject);
+        subject = explicitSubject;
+      }
+      Object messageNameObj = properties.get(MESSAGE_NAME_PARAMETER);
+      if (messageNameObj instanceof String explicitMessageName && !explicitMessageName.isBlank()) {
+        messageName = explicitMessageName;
       }
     }
-    return serializer(topic, type);
+    return buildSerializer(topic, type, subject, messageName);
   }
 
   @Override
   public List<SerdeParameter> getParameters(String topic, Target type) {
-    return List.of(
-        new SerdeParameter(SUBJECT_PARAMETER_NAME, SUBJECT_PARAMETER_NAME, getSchemaSubjects(topic, type))
-    );
+    List<SerdeParameter> parameters = new ArrayList<>();
+    List<String> subjects = getSchemaSubjects(topic, type);
+    parameters.add(new SerdeParameter(SUBJECT_PARAMETER_NAME, SUBJECT_PARAMETER_NAME, subjects));
+    // for protobuf schemas with multiple messages, let the user pick which message to produce.
+    // The subject is picked in the same form, so offer the messages of every selectable subject -
+    // limiting this to the default subject would hide the messages of any other subject the user can choose.
+    List<String> messageNames = subjects.stream()
+        .map(this::getProtobufMessageNames)
+        .flatMap(List::stream)
+        .distinct()
+        .sorted()
+        .toList();
+    if (!messageNames.isEmpty()) {
+      parameters.add(new SerdeParameter(MESSAGE_NAME_PARAMETER, MESSAGE_NAME_PARAMETER, messageNames));
+    }
+    return parameters;
   }
 
   @Override
@@ -401,23 +412,67 @@ public class SchemaRegistrySerde implements BuiltInSerde {
     return getSchemaSubjects(topic, type).contains(schemaSubject(topic, type));
   }
 
-  private Serializer serializerWithSubject(String topic, Target type, String explicitSubject) {
-    SchemaMetadata meta = getSchemaBySubject(explicitSubject)
+  private Serializer buildSerializer(String topic, Target type, String subject, @Nullable String messageName) {
+    SchemaMetadata meta = getSchemaBySubject(subject)
         .orElseThrow(() -> new ValidationException(
-            String.format("No schema for subject '%s' found", explicitSubject)));
+            String.format("No schema for subject '%s' found", subject)));
     ParsedSchema schema = getSchemaById(meta.getId())
         .orElseThrow(() -> new IllegalStateException(
-            String.format("Schema not found for id %s, subject '%s'", meta.getId(), explicitSubject)));
+            String.format("Schema not found for id %s, subject '%s'", meta.getId(), subject)));
     SchemaType schemaType = SchemaType.fromString(meta.getSchemaType())
         .orElseThrow(() -> new UnknownSchemaTypeException(meta.getSchemaType()));
     return switch (schemaType) {
       case PROTOBUF -> input ->
-          serializeProto(schemaRegistryClient, topic, type, (ProtobufSchema) schema, meta.getId(), input);
+          serializeProto(schemaRegistryClient, topic, type, (ProtobufSchema) schema, meta.getId(),
+              messageName, input);
       case AVRO -> input ->
           serializeAvro((AvroSchema) schema, meta.getId(), input);
       case JSON -> input ->
           serializeJson((JsonSchema) schema, meta.getId(), input);
     };
+  }
+
+  // Returns all message type names for a protobuf subject (empty for non-protobuf or missing subjects).
+  // Cached, since resolving them costs a schema registry round trip per subject.
+  private List<String> getProtobufMessageNames(String subject) {
+    return subjectMessageNamesCache.get(subject, this::loadProtobufMessageNames);
+  }
+
+  private List<String> loadProtobufMessageNames(String subject) {
+    try {
+      var metaOpt = getSchemaBySubject(subject);
+      if (metaOpt.isEmpty()
+          || SchemaType.fromString(metaOpt.get().getSchemaType()).orElse(null) != SchemaType.PROTOBUF) {
+        return List.of();
+      }
+      return getSchemaById(metaOpt.get().getId())
+          .filter(ProtobufSchema.class::isInstance)
+          .map(schema -> collectProtobufMessageNames((ProtobufSchema) schema))
+          .orElseGet(List::of);
+    } catch (Exception e) {
+      return List.of();
+    }
+  }
+
+  private static List<String> collectProtobufMessageNames(ProtobufSchema schema) {
+    Descriptors.Descriptor first = schema.toDescriptor();
+    if (first == null) {
+      return List.of();
+    }
+    List<String> names = new ArrayList<>();
+    collectProtobufMessages(first.getFile().getMessageTypes(), names);
+    return names.stream().distinct().sorted().toList();
+  }
+
+  private static void collectProtobufMessages(List<Descriptors.Descriptor> descriptors, List<String> acc) {
+    for (Descriptors.Descriptor descriptor : descriptors) {
+      // skip synthetic map-entry types - they aren't real, producible message definitions
+      if (descriptor.getOptions().getMapEntry()) {
+        continue;
+      }
+      acc.add(descriptor.getFullName());
+      collectProtobufMessages(descriptor.getNestedTypes(), acc);
+    }
   }
 
   @Override

--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/Serialize.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/sr/Serialize.java
@@ -23,6 +23,7 @@ import io.kafbat.ui.util.jsonschema.JsonAvroConversion;
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import javax.annotation.Nullable;
 import lombok.SneakyThrows;
 import org.apache.avro.Schema;
 import org.apache.avro.data.TimeConversions;
@@ -69,6 +70,7 @@ final class Serialize {
                                Serde.Target target,
                                ProtobufSchema schema,
                                int schemaId,
+                               @Nullable String messageName,
                                String input) {
     // flags are tuned like in ProtobufSerializer by default
     boolean normalizeSchema = false;
@@ -83,7 +85,15 @@ final class Serialize {
         topic, target == Serde.Target.KEY, schema
     );
 
-    DynamicMessage.Builder builder = schema.newMessageBuilder();
+    // when the schema defines multiple messages the user can pick which one to produce;
+    // no-arg newMessageBuilder() would always use the first message in the schema.
+    DynamicMessage.Builder builder = (messageName != null && !messageName.isBlank())
+        ? schema.newMessageBuilder(messageName)
+        : schema.newMessageBuilder();
+    if (builder == null) {
+      throw new ValidationException(
+          "Message type '" + messageName + "' not found in schema id " + schemaId);
+    }
     JsonFormat.parser().merge(input, builder);
     Message message = builder.build();
     MessageIndexes indexes = schema.toMessageIndexes(message.getDescriptorForType().getFullName(), normalizeSchema);

--- a/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
+++ b/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
@@ -376,6 +376,118 @@ class ProtobufFileSerdeTest {
     assertThat(booksBytes).isEqualTo(addressBookMessageBytes);
   }
 
+  @Test
+  void getParametersReturnsAllMessageTypesFromTopicsProtoFile() {
+    var serde = new ProtobufFileSerde();
+    serde.configure(
+        new Configuration(
+            personDescriptor,
+            null,
+            descriptorPaths,
+            Map.of(),
+            Map.of()
+        )
+    );
+
+    var parameters = serde.getParameters("persons", Serde.Target.VALUE);
+    assertThat(parameters).hasSize(1);
+    assertThat(parameters.get(0).getName()).isEqualTo("messageName");
+    // all real message definitions from address-book.proto (excluding synthetic map-entry types)
+    assertThat(parameters.get(0).getAllowedValues())
+        .contains("test.Person", "test.AnotherPerson", "test.AddressBook", "test.Person.PhoneNumber");
+  }
+
+  @Test
+  void getParametersReturnsEmptyWhenNoDescriptorApplies() {
+    var serde = new ProtobufFileSerde();
+    serde.configure(
+        new Configuration(
+            personDescriptor,
+            null,
+            descriptorPaths,
+            Map.of(),
+            Map.of()
+        )
+    );
+    // no default key descriptor and no per-topic key mapping -> nothing to offer
+    assertThat(serde.getParameters("persons", Serde.Target.KEY)).isEmpty();
+  }
+
+  @Test
+  void serializeUsesMessageNamePropertyToPickChosenType() {
+    var serde = new ProtobufFileSerde();
+    serde.configure(
+        new Configuration(
+            personDescriptor,
+            null,
+            descriptorPaths,
+            Map.of(),
+            Map.of()
+        )
+    );
+
+    // default for "persons" is test.Person, but the user explicitly picks test.AddressBook
+    var bytes = serde.serializer("persons", Serde.Target.VALUE, Map.of("messageName", "test.AddressBook"))
+        .serialize(sampleBookMsgJson);
+    assertThat(bytes).isEqualTo(addressBookMessageBytes);
+  }
+
+  @Test
+  void serializeFallsBackToDefaultWhenMessageNamePropertyMissingOrBlank() {
+    var serde = new ProtobufFileSerde();
+    serde.configure(
+        new Configuration(
+            personDescriptor,
+            null,
+            descriptorPaths,
+            Map.of(),
+            Map.of()
+        )
+    );
+
+    assertThat(serde.serializer("persons", Serde.Target.VALUE, Map.of())
+        .serialize(samplePersonMsgJson)).isEqualTo(personMessageBytes);
+    assertThat(serde.serializer("persons", Serde.Target.VALUE, Map.of("messageName", "  "))
+        .serialize(samplePersonMsgJson)).isEqualTo(personMessageBytes);
+  }
+
+  @Test
+  void serializeThrowsWhenChosenMessageNameNotInTopicsProtoFile() {
+    var serde = new ProtobufFileSerde();
+    serde.configure(
+        new Configuration(
+            personDescriptor,
+            null,
+            descriptorPaths,
+            Map.of(),
+            Map.of()
+        )
+    );
+
+    assertThatThrownBy(() ->
+        serde.serializer("persons", Serde.Target.VALUE, Map.of("messageName", "test.NotInFile")))
+        .isInstanceOf(io.kafbat.ui.exception.ValidationException.class)
+        .hasMessageContaining("test.NotInFile");
+  }
+
+  @Test
+  void deserializeExposesUsedMessageNameForReproduce() {
+    var serde = new ProtobufFileSerde();
+    serde.configure(
+        new Configuration(
+            personDescriptor,
+            null,
+            descriptorPaths,
+            Map.of(),
+            Map.of()
+        )
+    );
+
+    var result = serde.deserializer("persons", Serde.Target.VALUE)
+        .deserialize(null, personMessageBytes);
+    assertThat(result.getAdditionalProperties()).containsEntry("messageName", "test.Person");
+  }
+
   @SneakyThrows
   private void assertJsonEquals(String expectedJson, String actualJson) {
     var mapper = new JsonMapper();

--- a/api/src/test/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerdeTest.java
+++ b/api/src/test/java/io/kafbat/ui/serdes/builtin/sr/SchemaRegistrySerdeTest.java
@@ -840,6 +840,144 @@ class SchemaRegistrySerdeTest {
       )).isInstanceOf(io.kafbat.ui.exception.ValidationException.class)
           .hasMessageContaining(nonexistentSubject);
     }
+
+    // Schema with several message definitions (exercises multi-message protobuf handling).
+    private static final ProtobufSchema MULTI_MESSAGE_PROTOBUF_SCHEMA = new ProtobufSchema(
+        """
+            syntax = "proto3";
+            package test.events;
+            message OrderPlacedEvent { string order_id = 1; }
+            message OrderShippedEvent { string order_id = 1; }
+            message AccountUpdatedEvent { string customer_id = 1; string strategy_id = 2; }
+            """
+    );
+
+    @Test
+    @SneakyThrows
+    void getParametersExposesAllProtobufMessageTypes() {
+      String topic = "accounts";
+      registryClient.register(topic + "-value", MULTI_MESSAGE_PROTOBUF_SCHEMA);
+
+      var messageNameParam = serde.getParameters(topic, Serde.Target.VALUE).stream()
+          .filter(p -> p.getName().equals(SchemaRegistrySerde.MESSAGE_NAME_PARAMETER))
+          .findFirst().orElseThrow();
+
+      assertThat(messageNameParam.getAllowedValues()).containsExactlyInAnyOrder(
+          "test.events.OrderPlacedEvent",
+          "test.events.OrderShippedEvent",
+          "test.events.AccountUpdatedEvent");
+    }
+
+    @Test
+    @SneakyThrows
+    void serializerUsesChosenMessageTypeInsteadOfFirst() {
+      String topic = "accounts";
+      registryClient.register(topic + "-value", MULTI_MESSAGE_PROTOBUF_SCHEMA);
+      // this JSON only fits AccountUpdatedEvent, not the first message (OrderPlacedEvent)
+      String accountJson = "{\"customer_id\": \"c-1\", \"strategy_id\": \"s-1\"}";
+
+      var serializer = serde.serializer(topic, Serde.Target.VALUE,
+          java.util.Map.of(SchemaRegistrySerde.MESSAGE_NAME_PARAMETER, "test.events.AccountUpdatedEvent"));
+      byte[] result = serializer.serialize(accountJson);
+
+      assertThat(result).isNotEmpty();
+      assertThat(result[0]).isEqualTo((byte) 0); // magic byte
+    }
+
+    @Test
+    @SneakyThrows
+    void serializerWithoutMessageNameFailsForNonFirstMessage() {
+      String topic = "accounts";
+      registryClient.register(topic + "-value", MULTI_MESSAGE_PROTOBUF_SCHEMA);
+      String accountJson = "{\"customer_id\": \"c-1\", \"strategy_id\": \"s-1\"}";
+
+      // no messageName -> falls back to the first message (OrderPlacedEvent), which has no customer_id
+      var serializer = serde.serializer(topic, Serde.Target.VALUE);
+      assertThat(org.assertj.core.api.Assertions.catchThrowable(() -> serializer.serialize(accountJson)))
+          .hasMessageContaining("customer_id");
+    }
+
+    @Test
+    @SneakyThrows
+    void serializerThrowsForUnknownMessageName() {
+      String topic = "accounts";
+      registryClient.register(topic + "-value", MULTI_MESSAGE_PROTOBUF_SCHEMA);
+
+      var serializer = serde.serializer(topic, Serde.Target.VALUE,
+          java.util.Map.of(SchemaRegistrySerde.MESSAGE_NAME_PARAMETER, "test.events.NoSuchEvent"));
+      assertThat(org.assertj.core.api.Assertions.catchThrowable(() -> serializer.serialize("{}")))
+          .isInstanceOf(io.kafbat.ui.exception.ValidationException.class)
+          .hasMessageContaining("NoSuchEvent");
+    }
+
+    // Schema registered under a non-default subject, with messages the default subject doesn't define.
+    private static final ProtobufSchema OTHER_SUBJECT_PROTOBUF_SCHEMA = new ProtobufSchema(
+        """
+            syntax = "proto3";
+            package test.audit;
+            message AuditLogged { string audit_id = 1; }
+            message AuditReverted { string audit_id = 1; }
+            """
+    );
+
+    @Test
+    @SneakyThrows
+    void getParametersExposesMessageTypesOfSelectableNonDefaultSubjects() {
+      String topic = "accounts";
+      registryClient.register(topic + "-value", MULTI_MESSAGE_PROTOBUF_SCHEMA);
+      // selectable alongside the default subject (RecordNameStrategy: no -key/-value suffix)
+      registryClient.register("test.audit.AuditLogged", OTHER_SUBJECT_PROTOBUF_SCHEMA);
+
+      var parameters = serde.getParameters(topic, Serde.Target.VALUE);
+      var subjectParam = parameters.stream()
+          .filter(p -> p.getName().equals(SUBJECT_PARAMETER_NAME))
+          .findFirst().orElseThrow();
+      var messageNameParam = parameters.stream()
+          .filter(p -> p.getName().equals(SchemaRegistrySerde.MESSAGE_NAME_PARAMETER))
+          .findFirst().orElseThrow();
+
+      assertThat(subjectParam.getAllowedValues())
+          .contains(topic + "-value", "test.audit.AuditLogged");
+      assertThat(messageNameParam.getAllowedValues()).containsExactlyInAnyOrder(
+          "test.events.OrderPlacedEvent",
+          "test.events.OrderShippedEvent",
+          "test.events.AccountUpdatedEvent",
+          "test.audit.AuditLogged",
+          "test.audit.AuditReverted");
+    }
+
+    @Test
+    @SneakyThrows
+    void serializerUsesMessageTypeOfExplicitNonDefaultSubject() {
+      String topic = "accounts";
+      registryClient.register(topic + "-value", MULTI_MESSAGE_PROTOBUF_SCHEMA);
+      registryClient.register("test.audit.AuditLogged", OTHER_SUBJECT_PROTOBUF_SCHEMA);
+
+      var serializer = serde.serializer(topic, Serde.Target.VALUE, java.util.Map.of(
+          SchemaRegistrySerde.SUBJECT_PARAMETER_NAME, "test.audit.AuditLogged",
+          SchemaRegistrySerde.MESSAGE_NAME_PARAMETER, "test.audit.AuditReverted"));
+      byte[] result = serializer.serialize("{\"audit_id\": \"a-1\"}");
+
+      assertThat(result).isNotEmpty();
+      assertThat(result[0]).isEqualTo((byte) 0); // magic byte
+    }
+
+    @Test
+    @SneakyThrows
+    void serializerThrowsWhenMessageNameDoesNotBelongToChosenSubject() {
+      String topic = "accounts";
+      registryClient.register(topic + "-value", MULTI_MESSAGE_PROTOBUF_SCHEMA);
+      registryClient.register("test.audit.AuditLogged", OTHER_SUBJECT_PROTOBUF_SCHEMA);
+
+      // message name belongs to the default subject's schema, not to the chosen one
+      var serializer = serde.serializer(topic, Serde.Target.VALUE, java.util.Map.of(
+          SchemaRegistrySerde.SUBJECT_PARAMETER_NAME, "test.audit.AuditLogged",
+          SchemaRegistrySerde.MESSAGE_NAME_PARAMETER, "test.events.OrderPlacedEvent"));
+
+      assertThat(org.assertj.core.api.Assertions.catchThrowable(() -> serializer.serialize("{}")))
+          .isInstanceOf(io.kafbat.ui.exception.ValidationException.class)
+          .hasMessageContaining("test.events.OrderPlacedEvent");
+    }
   }
 
 }

--- a/frontend/src/components/Topics/Topic/SendMessage/SendMessage.tsx
+++ b/frontend/src/components/Topics/Topic/SendMessage/SendMessage.tsx
@@ -43,6 +43,13 @@ const getSerdeParameters = (
   return serde?.parameters ?? [];
 };
 
+// Params cleared back to "(default)" carry an empty value; drop them so an
+// unset parameter is indistinguishable from one that was never touched.
+const setParams = (
+  params: Record<string, string> | undefined
+): Record<string, string> =>
+  Object.fromEntries(Object.entries(params ?? {}).filter(([, v]) => v !== ''));
+
 const SendMessage: React.FC<SendMessageProps> = ({
   closeSidebar,
   messageData = null,
@@ -123,10 +130,15 @@ const SendMessage: React.FC<SendMessageProps> = ({
       if (!param.allowedValues || param.allowedValues.length === 0) return null;
       const fieldName = `${prefix}.${param.name}`;
       const label = param.visibleName || param.name;
-      const options = param.allowedValues.map((v) => ({
-        label: v,
-        value: v,
-      }));
+      // Serde parameters are optional: offer an explicit way back to "unset",
+      // otherwise a value can be picked but never cleared.
+      const options = [
+        { label: '(default)', value: '' },
+        ...param.allowedValues.map((v) => ({
+          label: v,
+          value: v,
+        })),
+      ];
       return (
         <div key={fieldName}>
           <InputLabel>{label}</InputLabel>
@@ -209,11 +221,11 @@ const SendMessage: React.FC<SendMessageProps> = ({
         partition: partition || 0,
         keySerde: formKeySerde,
         valueSerde: formValueSerde,
-        ...(keySerdeParams && Object.keys(keySerdeParams).length > 0
-          ? { keySerdeProperties: keySerdeParams }
+        ...(Object.keys(setParams(keySerdeParams)).length > 0
+          ? { keySerdeProperties: setParams(keySerdeParams) }
           : {}),
-        ...(valueSerdeParams && Object.keys(valueSerdeParams).length > 0
-          ? { valueSerdeProperties: valueSerdeParams }
+        ...(Object.keys(setParams(valueSerdeParams)).length > 0
+          ? { valueSerdeProperties: setParams(valueSerdeParams) }
           : {}),
       });
       if (!keepContents) {

--- a/frontend/src/components/common/InputWithOptions/InputWithOptions.tsx
+++ b/frontend/src/components/common/InputWithOptions/InputWithOptions.tsx
@@ -28,13 +28,22 @@ const InputWithOptions = ({
   const [selectedOption, setSelectedOption] = React.useState(value);
   const [showOptions, setShowOptions] = React.useState(false);
 
-  let filteredOptions = options.filter((option) =>
-    option.value.includes(selectedOption.toLowerCase())
+  // A blank-valued option means "clear the selection". It never matches the
+  // filter (''.includes(anything) is false), so keep it pinned to the top
+  // instead of letting it disappear as soon as something is selected.
+  const clearOptions = options.filter((option) => option.value === '');
+
+  const search = selectedOption.toLowerCase();
+  let matchedOptions = options.filter(
+    (option) =>
+      option.value !== '' && option.value.toLowerCase().includes(search)
   );
 
-  if (!filteredOptions.length && selectedOption) {
-    filteredOptions = [{ value: selectedOption, label: selectedOption }];
+  if (!matchedOptions.length && selectedOption) {
+    matchedOptions = [{ value: selectedOption, label: selectedOption }];
   }
+
+  const filteredOptions = [...clearOptions, ...matchedOptions];
 
   const updateSelectedOption = (option: SelectOption<string>) => {
     if (!option.disabled) {

--- a/frontend/src/components/common/InputWithOptions/__tests__/InputWithOptionsDeselect.spec.tsx
+++ b/frontend/src/components/common/InputWithOptions/__tests__/InputWithOptionsDeselect.spec.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render } from 'lib/testHelpers';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InputWithOptions from 'components/common/InputWithOptions/InputWithOptions';
+import { SelectOption } from 'components/common/Select/Select';
+
+// Mirrors what SendMessage builds for an optional serde parameter: a
+// "(default)" entry followed by the serde's allowedValues.
+const options: Array<SelectOption<string>> = [
+  { label: '(default)', value: '' },
+  {
+    label: 'test.events.OrderPlacedEvent',
+    value: 'test.events.OrderPlacedEvent',
+  },
+  {
+    label: 'test.events.AccountUpdatedEvent',
+    value: 'test.events.AccountUpdatedEvent',
+  },
+];
+
+const Harness = () => {
+  const [formValue, setFormValue] = React.useState('');
+  return (
+    <>
+      <span data-testid="form-value">
+        {formValue === '' ? '(unset)' : formValue}
+      </span>
+      <InputWithOptions
+        name="messageName"
+        options={options}
+        value={formValue}
+        onChange={setFormValue}
+      />
+    </>
+  );
+};
+
+describe('serde parameter deselection', () => {
+  const getInputBox = () => screen.getByRole('listitem');
+  const getListbox = () => screen.getByRole('listbox');
+  const getFormValue = () => screen.getByTestId('form-value');
+
+  beforeEach(() => {
+    render(<Harness />);
+  });
+
+  it('offers an option to clear the selection', async () => {
+    await userEvent.click(getInputBox());
+    expect(
+      screen.getAllByRole('option').map((o) => o.getAttribute('value'))
+    ).toContain('');
+  });
+
+  it('clears a chosen value when "(default)" is selected', async () => {
+    await userEvent.click(getInputBox());
+    await userEvent.selectOptions(getListbox(), [
+      'test.events.AccountUpdatedEvent',
+    ]);
+    expect(getFormValue()).toHaveTextContent('test.events.AccountUpdatedEvent');
+
+    await userEvent.click(getInputBox());
+    await userEvent.selectOptions(getListbox(), ['(default)']);
+
+    expect(getFormValue()).toHaveTextContent('(unset)');
+    expect(getInputBox()).toHaveValue('');
+  });
+
+  it('keeps the parameter unset after clicking outside', async () => {
+    await userEvent.click(getInputBox());
+    await userEvent.selectOptions(getListbox(), [
+      'test.events.AccountUpdatedEvent',
+    ]);
+    await userEvent.click(getInputBox());
+    await userEvent.selectOptions(getListbox(), ['(default)']);
+
+    await userEvent.click(getInputBox());
+    await userEvent.click(document.body);
+
+    expect(getFormValue()).toHaveTextContent('(unset)');
+  });
+});

--- a/frontend/src/lib/hooks/__tests__/useProduceMessage.spec.ts
+++ b/frontend/src/lib/hooks/__tests__/useProduceMessage.spec.ts
@@ -102,6 +102,28 @@ describe('useProduceMessage', () => {
     });
   });
 
+  it('should extract protobuf messageName from deserialize properties', () => {
+    const { result } = renderHook(() => useProduceMessage());
+    const messageWithMessageName: TopicMessage = {
+      ...mockMessage,
+      valueSerde: 'ProtobufFile',
+      keySerde: 'ProtobufFile',
+      valueDeserializeProperties: { messageName: 'test.AddressBook' },
+      keyDeserializeProperties: { messageName: 'test.Person' },
+    };
+
+    act(() => {
+      result.current.setMessage(messageWithMessageName);
+    });
+
+    expect(result.current.messageData?.keySerdeParams).toEqual({
+      messageName: 'test.Person',
+    });
+    expect(result.current.messageData?.valueSerdeParams).toEqual({
+      messageName: 'test.AddressBook',
+    });
+  });
+
   it('should handle empty subjects array in deserialize properties', () => {
     const { result } = renderHook(() => useProduceMessage());
     const messageWithEmptySubjects: TopicMessage = {

--- a/frontend/src/lib/hooks/useProduceMessage.ts
+++ b/frontend/src/lib/hooks/useProduceMessage.ts
@@ -38,16 +38,34 @@ export const useProduceMessage = (): UseProduceMessageReturn => {
       data.keySerde = message.keySerde;
     }
 
+    const keySerdeParams: Record<string, string> = {};
     if (message.keyDeserializeProperties?.subjects?.[0]) {
-      data.keySerdeParams = {
-        subject: String(message.keyDeserializeProperties.subjects[0]),
-      };
+      keySerdeParams.subject = String(
+        message.keyDeserializeProperties.subjects[0]
+      );
+    }
+    if (message.keyDeserializeProperties?.messageName) {
+      keySerdeParams.messageName = String(
+        message.keyDeserializeProperties.messageName
+      );
+    }
+    if (Object.keys(keySerdeParams).length > 0) {
+      data.keySerdeParams = keySerdeParams;
     }
 
+    const valueSerdeParams: Record<string, string> = {};
     if (message.valueDeserializeProperties?.subjects?.[0]) {
-      data.valueSerdeParams = {
-        subject: String(message.valueDeserializeProperties.subjects[0]),
-      };
+      valueSerdeParams.subject = String(
+        message.valueDeserializeProperties.subjects[0]
+      );
+    }
+    if (message.valueDeserializeProperties?.messageName) {
+      valueSerdeParams.messageName = String(
+        message.valueDeserializeProperties.messageName
+      );
+    }
+    if (Object.keys(valueSerdeParams).length > 0) {
+      data.valueSerdeParams = valueSerdeParams;
     }
 
     setMessageData(data);


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [X] Manually (please, describe, if necessary)
- [X] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [ ] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [ ] My changes generate no new warnings (e.g. Sonar is happy)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Protobuf serialization now supports selecting a specific top-level or nested message type.
  * Available message types are shown for selection, and deserialization retains the selected type.
  * Message type selection works with different schema subjects.

* **Bug Fixes**
  * Unset serialization options are omitted instead of sent as empty values.
  * Added a “(default)” option for clearing selections.
  * Improved case-insensitive option matching and handling of multi-message Protobuf schemas.

* **Tests**
  * Added coverage for selection, validation, defaults, subject handling, and clearing options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->