### PR TITLE
Return empty metrics list instead of 404 for known brokers

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/BrokerService.java
+++ b/api/src/main/java/io/kafbat/ui/service/BrokerService.java
@@ -140,7 +140,14 @@ public class BrokerService {
   }
 
   public Mono<List<MetricSnapshot>> getBrokerMetrics(KafkaCluster cluster, Integer brokerId) {
-    return Mono.justOrEmpty(statisticsCache.get(cluster).getMetrics().getPerBrokerScrapedMetrics().get(brokerId));
+    var statistics = statisticsCache.get(cluster);
+    if (statistics.getClusterDescription().getNodes()
+        .stream().noneMatch(node -> node.id() == brokerId)) {
+      return Mono.error(
+          new NotFoundException(String.format("Broker with id %s not found", brokerId)));
+    }
+    return Mono.justOrEmpty(statistics.getMetrics().getPerBrokerScrapedMetrics().get(brokerId))
+        .defaultIfEmpty(List.of());
   }
 
 }

--- a/api/src/test/java/io/kafbat/ui/service/BrokerServiceMetricsTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/BrokerServiceMetricsTest.java
@@ -1,0 +1,71 @@
+package io.kafbat.ui.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.kafbat.ui.exception.NotFoundException;
+import io.kafbat.ui.mapper.DescribeLogDirsMapper;
+import io.kafbat.ui.model.KafkaCluster;
+import io.kafbat.ui.model.Metrics;
+import io.kafbat.ui.model.Statistics;
+import io.prometheus.metrics.model.snapshots.MetricSnapshot;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.kafka.common.Node;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+class BrokerServiceMetricsTest {
+
+  private static final int BROKER_ID = 1;
+
+  private final StatisticsCache statisticsCache = mock(StatisticsCache.class);
+  private final KafkaCluster cluster = KafkaCluster.builder().name("local").build();
+  private final BrokerService brokerService = new BrokerService(
+      statisticsCache,
+      mock(AdminClientService.class),
+      mock(DescribeLogDirsMapper.class)
+  );
+
+  @Test
+  void getBrokerMetricsReturnsEmptyListWhenNoMetricsScraped() {
+    when(statisticsCache.get(cluster)).thenReturn(statistics(Map.of()));
+
+    StepVerifier.create(brokerService.getBrokerMetrics(cluster, BROKER_ID))
+        .expectNext(List.of())
+        .verifyComplete();
+  }
+
+  @Test
+  void getBrokerMetricsReturnsScrapedMetricsWhenPresent() {
+    List<MetricSnapshot> scraped = List.of(mock(MetricSnapshot.class));
+    when(statisticsCache.get(cluster)).thenReturn(statistics(Map.of(BROKER_ID, scraped)));
+
+    StepVerifier.create(brokerService.getBrokerMetrics(cluster, BROKER_ID))
+        .expectNext(scraped)
+        .verifyComplete();
+  }
+
+  @Test
+  void getBrokerMetricsFailsWithNotFoundForUnknownBroker() {
+    when(statisticsCache.get(cluster)).thenReturn(statistics(Map.of()));
+
+    StepVerifier.create(brokerService.getBrokerMetrics(cluster, 42))
+        .expectError(NotFoundException.class)
+        .verify();
+  }
+
+  private Statistics statistics(Map<Integer, List<MetricSnapshot>> perBrokerMetrics) {
+    Metrics emptyMetrics = Metrics.empty();
+    return Statistics.empty().toBuilder()
+        .clusterDescription(new ReactiveAdminClient.ClusterDescription(
+            null, "clusterId", List.of(new Node(BROKER_ID, "host", 9092)), Set.of()))
+        .metrics(Metrics.builder()
+            .ioRates(emptyMetrics.getIoRates())
+            .inferredMetrics(emptyMetrics.getInferredMetrics())
+            .perBrokerScrapedMetrics(perBrokerMetrics)
+            .build())
+        .build();
+  }
+}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)
<!-- ignore-task-list-end -->

**What changes did you make?** (Give an overview)

Resolves #1958 and #1942

`GET /api/clusters/{clusterName}/brokers/{id}/metrics` returned 404 for every broker when the cluster has no `metrics` section configured (and for brokers whose scrape yielded nothing), which crashes the frontend Metrics tab into a blank page (`useSuspenseQuery` throws, the Brokers route has no error boundary). This is a regression from the metrics rework #1208: up to v1.3.0 `MetricsCollector` kept an entry per live node (empty list when nothing was collected), so the endpoint returned `200 {"metrics":[]}`.

This PR restores those semantics at the service layer:
- a broker that exists in the cluster description but has no scraped metrics now yields an empty list (`200 {"metrics":[]}`), covering both the metrics-not-configured case and per-broker scrape gaps (related: #1630);
- an unknown broker id now consistently fails with `NotFoundException` (mirrors the existing check in `BrokerService#getBrokersConfig`), which the controller maps to 404.

No frontend changes needed: with a valid `200` response the Metrics tab renders the JSON as before.

**Is there anything you'd like reviewers to focus on?**

The chosen semantics: 404 is now reserved for unknown broker ids; a known broker always gets `200` with whatever has been scraped (possibly empty). An alternative was to populate per-node empty entries in `MetricsScraper#scrapeBrokers`, but the service-layer guard also covers scrape gaps for configured clusters.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Broker metrics requests now clearly report when the selected broker does not exist.
  * Metrics for valid brokers continue to load, including when no metrics are available.

* **Tests**
  * Added coverage for available metrics, empty results, and unknown broker requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->