### PR TITLE
BE: Bump Netty to 4.1.137.Final for CVE Resolution

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -17,7 +17,7 @@ configurations.all {
             // so we can safely exclude it from the resolution strategy
             if (details.requested.group == "io.netty" && !details.requested.name.startsWith("netty-tcnative-")) {
                 details.useVersion(libs.versions.netty.get())
-                details.because("Revert when Spring Boot manages Netty >= ${libs.versions.netty.get()}")
+                details.because("Revert when Spring Boot releases a version with the fix")
             }
         }
         capabilitiesResolution {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,6 +8,12 @@ plugins {
     alias(libs.plugins.spring.dependency.management)
 }
 
+// CVEs fixed in Netty 4.1.137.Final but not in the 4.1.135.Final managed by Spring Boot 3.5.16.
+// Scoped to dependencies whose affected artifact is actually on our runtime classpath
+def nettyDepsAffectedByCves = [
+        "netty-codec-http", "netty-codec-http2", "netty-codec"
+]
+
 configurations.all {
     resolutionStrategy {
         eachDependency { DependencyResolveDetails details ->
@@ -17,7 +23,8 @@ configurations.all {
             // so we can safely exclude it from the resolution strategy
             if (details.requested.group == "io.netty" && !details.requested.name.startsWith("netty-tcnative-")) {
                 details.useVersion(libs.versions.netty.get())
-                details.because("Fixes CVE-2026-42578 through CVE-2026-44248. Revert when Spring Boot releases a version with the fix")
+                details.because("Fixes ${nettyDepsAffectedByCves.join(', ')}. " +
+                        "Revert when Spring Boot manages Netty >= ${libs.versions.netty.get()}")
             }
         }
         capabilitiesResolution {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -8,12 +8,6 @@ plugins {
     alias(libs.plugins.spring.dependency.management)
 }
 
-// CVEs fixed in Netty 4.1.137.Final but not in the 4.1.135.Final managed by Spring Boot 3.5.16.
-// Scoped to dependencies whose affected artifact is actually on our runtime classpath
-def nettyDepsAffectedByCves = [
-        "netty-codec-http", "netty-codec-http2", "netty-codec"
-]
-
 configurations.all {
     resolutionStrategy {
         eachDependency { DependencyResolveDetails details ->
@@ -23,8 +17,7 @@ configurations.all {
             // so we can safely exclude it from the resolution strategy
             if (details.requested.group == "io.netty" && !details.requested.name.startsWith("netty-tcnative-")) {
                 details.useVersion(libs.versions.netty.get())
-                details.because("Fixes ${nettyDepsAffectedByCves.join(', ')}. " +
-                        "Revert when Spring Boot manages Netty >= ${libs.versions.netty.get()}")
+                details.because("Revert when Spring Boot manages Netty >= ${libs.versions.netty.get()}")
             }
         }
         capabilitiesResolution {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 spring-boot = '3.5.16'
 nimbus-jose-jwt = '10.8'
-netty = '4.1.135.Final'
+netty = '4.1.137.Final'
 
 aws-msk-auth = '2.3.0'
 azure-identity = '1.15.4'


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

**Is there anything you'd like reviewers to focus on?**


**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [ ] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works (Marked this but its not applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

**A picture of a cute animal (not mandatory but encouraged)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Updated Netty networking components to version 4.1.137.Final for improved security and stability.
- Improved dependency resolution to ensure the configured Netty version is applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->