### PR TITLE
Add predefined message filters via cluster config

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We extend our gratitude to Provectus for their past support in groundbreaking wo
 * **Metrics Dashboard** – Track key Kafka metrics in real time with a streamlined, lightweight dashboard.
 * **Kafka Brokers Overview** – Inspect brokers, including partition assignments and controller status.
 * **Consumer Group Details** – Analyze parked offsets per partition, and monitor both combined and partition-specific lag.
-* **Message Browser** – Explore messages in JSON, plain text, or Avro encoding formats. Live view is supported, enriched with user-defined CEL message filters.
+* **Message Browser** – Explore messages in JSON, plain text, or Avro encoding formats. Live view is supported, enriched with user-defined CEL message filters and optional cluster-config predefined filters.
 * **Dynamic Topic Management** – Create and configure new topics with flexible, real-time settings.
 * **Pluggable Authentication** – Secure your UI using OAuth 2.0 (GitHub, GitLab, Google), LDAP, or basic authentication.
 * **Cloud IAM Support** – Integrate with **GCP IAM**, **Azure IAM**, and **AWS IAM** for cloud-native identity and access management.

--- a/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/ClustersProperties.java
@@ -102,6 +102,8 @@ public class ClustersProperties {
 
     List<@Valid Masking> masking;
 
+    List<@Valid MessageFilterConfig> messageFilters;
+
     AuditProperties audit;
   }
 
@@ -231,6 +233,15 @@ public class ClustersProperties {
     public enum Type {
       REMOVE, MASK, REPLACE
     }
+  }
+
+  @Data
+  public static class MessageFilterConfig {
+    @NotBlank
+    String displayName;
+    @NotBlank
+    String filterCode;
+    boolean enabledByDefault = false;
   }
 
   @Data

--- a/api/src/main/java/io/kafbat/ui/controller/ClustersController.java
+++ b/api/src/main/java/io/kafbat/ui/controller/ClustersController.java
@@ -2,6 +2,7 @@ package io.kafbat.ui.controller;
 
 import io.kafbat.ui.api.ClustersApi;
 import io.kafbat.ui.model.ClusterDTO;
+import io.kafbat.ui.model.ClusterMessageFilterDTO;
 import io.kafbat.ui.model.ClusterMetricsDTO;
 import io.kafbat.ui.model.ClusterStatsDTO;
 import io.kafbat.ui.model.rbac.AccessContext;
@@ -74,6 +75,23 @@ public class ClustersController extends AbstractController implements ClustersAp
 
     return validateAccess(context)
         .then(clusterService.updateCluster(getCluster(clusterName)).map(ResponseEntity::ok))
+        .doOnEach(sig -> audit(context, sig));
+  }
+
+  @Override
+  public Mono<ResponseEntity<Flux<ClusterMessageFilterDTO>>> getClusterMessageFilters(
+      String clusterName,
+      ServerWebExchange exchange) {
+
+    AccessContext context = AccessContext.builder()
+        .cluster(clusterName)
+        .operationName("getClusterMessageFilters")
+        .build();
+
+    return validateAccess(context)
+        .thenReturn(ResponseEntity.ok(
+            Flux.fromIterable(clusterService.getMessageFilters(getCluster(clusterName)))
+        ))
         .doOnEach(sig -> audit(context, sig));
   }
 }

--- a/api/src/main/java/io/kafbat/ui/controller/ClustersController.java
+++ b/api/src/main/java/io/kafbat/ui/controller/ClustersController.java
@@ -89,9 +89,9 @@ public class ClustersController extends AbstractController implements ClustersAp
         .build();
 
     return validateAccess(context)
-        .thenReturn(ResponseEntity.ok(
+        .then(Mono.fromSupplier(() -> ResponseEntity.ok(
             Flux.fromIterable(clusterService.getMessageFilters(getCluster(clusterName)))
-        ))
+        )))
         .doOnEach(sig -> audit(context, sig));
   }
 }

--- a/api/src/main/java/io/kafbat/ui/emitter/MessageFilters.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/MessageFilters.java
@@ -117,7 +117,7 @@ public class MessageFilters {
     return topicMessage -> {
       Object programResult;
       try {
-        programResult = program.eval(recordToArgs(topicMessage));
+        programResult = program.eval(evalArgs(topicMessage));
       } catch (CelEvaluationException e) {
         throw new CelException(originalScript, e);
       }
@@ -133,29 +133,32 @@ public class MessageFilters {
     };
   }
 
-  private static Map<String, Map<String, Object>> recordToArgs(TopicMessageDTO topicMessage) {
-    Map<String, Object> args = new HashMap<>();
+  private static Map<String, Object> evalArgs(TopicMessageDTO topicMessage) {
+    Map<String, Object> record = new HashMap<>();
 
-    args.put("partition", topicMessage.getPartition());
-    args.put("offset", topicMessage.getOffset());
+    record.put("partition", topicMessage.getPartition());
+    record.put("offset", topicMessage.getOffset());
 
     if (topicMessage.getTimestamp() != null) {
-      args.put("timestampMs", topicMessage.getTimestamp().toInstant().toEpochMilli());
+      record.put("timestampMs", topicMessage.getTimestamp().toInstant().toEpochMilli());
     }
 
     if (topicMessage.getKey() != null) {
-      args.put("key", parseToJsonOrReturnAsIs(topicMessage.getKey()));
-      args.put("keyAsText", topicMessage.getKey());
+      record.put("key", parseToJsonOrReturnAsIs(topicMessage.getKey()));
+      record.put("keyAsText", topicMessage.getKey());
     }
 
     if (topicMessage.getValue() != null) {
-      args.put("value", parseToJsonOrReturnAsIs(topicMessage.getValue()));
-      args.put("valueAsText", topicMessage.getValue());
+      record.put("value", parseToJsonOrReturnAsIs(topicMessage.getValue()));
+      record.put("valueAsText", topicMessage.getValue());
     }
 
-    args.put("headers", Objects.requireNonNullElse(topicMessage.getHeaders(), emptyMap()));
+    record.put("headers", Objects.requireNonNullElse(topicMessage.getHeaders(), emptyMap()));
 
-    return Map.of("record", args);
+    Map<String, Object> args = new HashMap<>();
+    args.put("record", record);
+    args.put("nowMs", System.currentTimeMillis());
+    return args;
   }
 
   private static CelCompiler createCompiler() {
@@ -186,6 +189,7 @@ public class MessageFilters {
         .setStandardMacros(CelStandardMacro.STANDARD_MACROS)
         .addLibraries(CelExtensions.strings(), CelExtensions.encoders())
         .addVar(CEL_RECORD_VAR_NAME, recordType)
+        .addVar("nowMs", SimpleType.INT)
         .setResultType(SimpleType.BOOL)
         .setTypeProvider(new CelTypeProvider() {
           @Override

--- a/api/src/main/java/io/kafbat/ui/emitter/MessageFilters.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/MessageFilters.java
@@ -134,29 +134,29 @@ public class MessageFilters {
   }
 
   private static Map<String, Object> evalArgs(TopicMessageDTO topicMessage) {
-    Map<String, Object> record = new HashMap<>();
+    Map<String, Object> recordBindings = new HashMap<>();
 
-    record.put("partition", topicMessage.getPartition());
-    record.put("offset", topicMessage.getOffset());
+    recordBindings.put("partition", topicMessage.getPartition());
+    recordBindings.put("offset", topicMessage.getOffset());
 
     if (topicMessage.getTimestamp() != null) {
-      record.put("timestampMs", topicMessage.getTimestamp().toInstant().toEpochMilli());
+      recordBindings.put("timestampMs", topicMessage.getTimestamp().toInstant().toEpochMilli());
     }
 
     if (topicMessage.getKey() != null) {
-      record.put("key", parseToJsonOrReturnAsIs(topicMessage.getKey()));
-      record.put("keyAsText", topicMessage.getKey());
+      recordBindings.put("key", parseToJsonOrReturnAsIs(topicMessage.getKey()));
+      recordBindings.put("keyAsText", topicMessage.getKey());
     }
 
     if (topicMessage.getValue() != null) {
-      record.put("value", parseToJsonOrReturnAsIs(topicMessage.getValue()));
-      record.put("valueAsText", topicMessage.getValue());
+      recordBindings.put("value", parseToJsonOrReturnAsIs(topicMessage.getValue()));
+      recordBindings.put("valueAsText", topicMessage.getValue());
     }
 
-    record.put("headers", Objects.requireNonNullElse(topicMessage.getHeaders(), emptyMap()));
+    recordBindings.put("headers", Objects.requireNonNullElse(topicMessage.getHeaders(), emptyMap()));
 
     Map<String, Object> args = new HashMap<>();
-    args.put("record", record);
+    args.put(CEL_RECORD_VAR_NAME, recordBindings);
     args.put("nowMs", System.currentTimeMillis());
     return args;
   }

--- a/api/src/main/java/io/kafbat/ui/model/KafkaCluster.java
+++ b/api/src/main/java/io/kafbat/ui/model/KafkaCluster.java
@@ -33,7 +33,7 @@ public class KafkaCluster {
   private final boolean exposeMetricsViaPrometheusEndpoint;
   private final DataMasking masking;
   @Builder.Default
-  private final ClusterMessageFilters messageFilters = ClusterMessageFilters.empty();
+  private final ClusterMessageFilters messageFilters = ClusterMessageFilters.EMPTY;
   private final PollingSettings pollingSettings;
   private final MetricsScraper metricsScrapping;
   private final ReactiveFailover<KafkaSrClientApi> schemaRegistryClient;

--- a/api/src/main/java/io/kafbat/ui/model/KafkaCluster.java
+++ b/api/src/main/java/io/kafbat/ui/model/KafkaCluster.java
@@ -4,6 +4,7 @@ import io.kafbat.ui.config.ClustersProperties;
 import io.kafbat.ui.connect.api.KafkaConnectClientApi;
 import io.kafbat.ui.emitter.PollingSettings;
 import io.kafbat.ui.prometheus.api.PrometheusClientApi;
+import io.kafbat.ui.service.filters.ClusterMessageFilters;
 import io.kafbat.ui.service.ksql.KsqlApiClient;
 import io.kafbat.ui.service.masking.DataMasking;
 import io.kafbat.ui.service.metrics.scrape.MetricsScraper;
@@ -31,6 +32,8 @@ public class KafkaCluster {
   private final boolean readOnly;
   private final boolean exposeMetricsViaPrometheusEndpoint;
   private final DataMasking masking;
+  @Builder.Default
+  private final ClusterMessageFilters messageFilters = ClusterMessageFilters.empty();
   private final PollingSettings pollingSettings;
   private final MetricsScraper metricsScrapping;
   private final ReactiveFailover<KafkaSrClientApi> schemaRegistryClient;

--- a/api/src/main/java/io/kafbat/ui/service/ClusterService.java
+++ b/api/src/main/java/io/kafbat/ui/service/ClusterService.java
@@ -2,6 +2,7 @@ package io.kafbat.ui.service;
 
 import io.kafbat.ui.mapper.ClusterMapper;
 import io.kafbat.ui.model.ClusterDTO;
+import io.kafbat.ui.model.ClusterMessageFilterDTO;
 import io.kafbat.ui.model.ClusterMetricsDTO;
 import io.kafbat.ui.model.ClusterStatsDTO;
 import io.kafbat.ui.model.InternalClusterState;
@@ -47,5 +48,19 @@ public class ClusterService {
   public Mono<ClusterDTO> updateCluster(KafkaCluster cluster) {
     return statisticsService.updateCache(cluster)
         .map(metrics -> clusterMapper.toCluster(new InternalClusterState(cluster, metrics)));
+  }
+
+  public List<ClusterMessageFilterDTO> getMessageFilters(KafkaCluster cluster) {
+    var filters = cluster.getMessageFilters();
+    if (filters == null) {
+      return List.of();
+    }
+    return filters.getFilters().stream()
+        .map(filter -> new ClusterMessageFilterDTO()
+            .id(filter.getId())
+            .displayName(filter.getDisplayName())
+            .filterCode(filter.getFilterCode())
+            .enabledByDefault(filter.isEnabledByDefault()))
+        .toList();
   }
 }

--- a/api/src/main/java/io/kafbat/ui/service/KafkaClusterFactory.java
+++ b/api/src/main/java/io/kafbat/ui/service/KafkaClusterFactory.java
@@ -16,6 +16,7 @@ import io.kafbat.ui.model.ApplicationPropertyValidationDTO;
 import io.kafbat.ui.model.ClusterConfigValidationDTO;
 import io.kafbat.ui.model.KafkaCluster;
 import io.kafbat.ui.prometheus.api.PrometheusClientApi;
+import io.kafbat.ui.service.filters.ClusterMessageFilters;
 import io.kafbat.ui.service.ksql.KsqlApiClient;
 import io.kafbat.ui.service.masking.DataMasking;
 import io.kafbat.ui.service.metrics.scrape.MetricsScraper;
@@ -83,6 +84,7 @@ public class KafkaClusterFactory {
     builder.readOnly(clusterProperties.isReadOnly());
     builder.exposeMetricsViaPrometheusEndpoint(exposeMetricsViaPrometheusEndpoint(clusterProperties));
     builder.masking(DataMasking.create(clusterProperties.getMasking()));
+    builder.messageFilters(ClusterMessageFilters.create(clusterProperties.getMessageFilters()));
     builder.pollingSettings(PollingSettings.create(clusterProperties, properties));
     builder.metricsScrapping(MetricsScraper.create(clusterProperties, jmxMetricsRetriever));
 

--- a/api/src/main/java/io/kafbat/ui/service/MessagesService.java
+++ b/api/src/main/java/io/kafbat/ui/service/MessagesService.java
@@ -230,7 +230,7 @@ public class MessagesService {
         topic,
         deserializationService.deserializerFor(cluster, topic, keySerde, valueSerde),
         consumerPosition,
-        getMsgFilter(containsStringFilter, filterId),
+        getMsgFilter(cluster, containsStringFilter, filterId),
         fixPageSize(limit)
     );
   }
@@ -298,18 +298,25 @@ public class MessagesService {
         .map(throttleUiPublish(consumerPosition.pollingMode()));
   }
 
-  private Predicate<TopicMessageDTO> getMsgFilter(@Nullable String containsStrFilter,
+  private Predicate<TopicMessageDTO> getMsgFilter(KafkaCluster cluster,
+                                                  @Nullable String containsStrFilter,
                                                   @Nullable String smartFilterId) {
     Predicate<TopicMessageDTO> messageFilter = MessageFilters.noop();
     if (containsStrFilter != null) {
       messageFilter = messageFilter.and(MessageFilters.containsStringFilter(containsStrFilter));
     }
     if (smartFilterId != null) {
-      var registered = registeredFilters.getIfPresent(smartFilterId);
-      if (registered == null) {
-        throw new ValidationException("No filter was registered with id " + smartFilterId);
+      var predefined = Optional.ofNullable(cluster.getMessageFilters())
+          .flatMap(filters -> filters.findById(smartFilterId));
+      if (predefined.isPresent()) {
+        messageFilter = messageFilter.and(predefined.get().getPredicate());
+      } else {
+        var registered = registeredFilters.getIfPresent(smartFilterId);
+        if (registered == null) {
+          throw new ValidationException("No filter was registered with id " + smartFilterId);
+        }
+        messageFilter = messageFilter.and(registered);
       }
-      messageFilter = messageFilter.and(registered);
     }
     return messageFilter;
   }

--- a/api/src/main/java/io/kafbat/ui/service/filters/ClusterMessageFilters.java
+++ b/api/src/main/java/io/kafbat/ui/service/filters/ClusterMessageFilters.java
@@ -23,14 +23,10 @@ public class ClusterMessageFilters {
   public static final ClusterMessageFilters EMPTY = new ClusterMessageFilters(List.of());
 
   private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^a-z0-9]+");
-  private static final Pattern LEADING_OR_TRAILING_DASH = Pattern.compile("^-+|-+$");
+  private static final Pattern LEADING_OR_TRAILING_DASH = Pattern.compile("(?:^-+)|(?:-+$)");
   private static final String ID_PREFIX = "cfg-";
 
   List<PredefinedFilter> filters;
-
-  public static ClusterMessageFilters empty() {
-    return EMPTY;
-  }
 
   public static ClusterMessageFilters create(
       @Nullable List<ClustersProperties.MessageFilterConfig> config) {

--- a/api/src/main/java/io/kafbat/ui/service/filters/ClusterMessageFilters.java
+++ b/api/src/main/java/io/kafbat/ui/service/filters/ClusterMessageFilters.java
@@ -1,0 +1,109 @@
+package io.kafbat.ui.service.filters;
+
+import io.kafbat.ui.config.ClustersProperties;
+import io.kafbat.ui.emitter.MessageFilters;
+import io.kafbat.ui.exception.CelException;
+import io.kafbat.ui.exception.ValidationException;
+import io.kafbat.ui.model.TopicMessageDTO;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import lombok.Value;
+import org.apache.commons.lang3.StringUtils;
+
+@Value
+public class ClusterMessageFilters {
+
+  public static final ClusterMessageFilters EMPTY = new ClusterMessageFilters(List.of());
+
+  private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^a-z0-9]+");
+  private static final Pattern LEADING_OR_TRAILING_DASH = Pattern.compile("^-+|-+$");
+  private static final String ID_PREFIX = "cfg-";
+
+  List<PredefinedFilter> filters;
+
+  public static ClusterMessageFilters empty() {
+    return EMPTY;
+  }
+
+  public static ClusterMessageFilters create(
+      @Nullable List<ClustersProperties.MessageFilterConfig> config) {
+    List<ClustersProperties.MessageFilterConfig> source = Optional.ofNullable(config).orElse(List.of());
+    Set<String> displayNames = new HashSet<>();
+    Set<String> ids = new HashSet<>();
+    List<PredefinedFilter> compiled = new ArrayList<>();
+
+    for (ClustersProperties.MessageFilterConfig property : source) {
+      if (StringUtils.isBlank(property.getDisplayName())) {
+        throw new ValidationException("message filter displayName must not be blank");
+      }
+      if (StringUtils.isBlank(property.getFilterCode())) {
+        throw new ValidationException(
+            "message filter filterCode must not be blank for '%s'".formatted(property.getDisplayName())
+        );
+      }
+      if (!displayNames.add(property.getDisplayName())) {
+        throw new ValidationException(
+            "duplicate message filter displayName '%s'".formatted(property.getDisplayName())
+        );
+      }
+
+      String id = toId(property.getDisplayName());
+      if (!ids.add(id)) {
+        throw new ValidationException(
+            "message filter displayName '%s' produces duplicate id '%s'".formatted(property.getDisplayName(), id)
+        );
+      }
+
+      Predicate<TopicMessageDTO> predicate;
+      try {
+        predicate = MessageFilters.celScriptFilter(property.getFilterCode());
+      } catch (CelException e) {
+        throw new ValidationException(
+            "invalid CEL in message filter '%s': %s".formatted(property.getDisplayName(), e.getMessage())
+        );
+      }
+
+      compiled.add(new PredefinedFilter(
+          id,
+          property.getDisplayName(),
+          property.getFilterCode(),
+          property.isEnabledByDefault(),
+          predicate
+      ));
+    }
+
+    return new ClusterMessageFilters(List.copyOf(compiled));
+  }
+
+  public Optional<PredefinedFilter> findById(String id) {
+    return filters.stream().filter(filter -> filter.getId().equals(id)).findFirst();
+  }
+
+  static String toId(String displayName) {
+    String slug = LEADING_OR_TRAILING_DASH.matcher(
+        NON_ALPHANUMERIC.matcher(displayName.toLowerCase(Locale.ROOT)).replaceAll("-")
+    ).replaceAll("");
+    if (slug.isBlank()) {
+      throw new ValidationException(
+          "message filter displayName '%s' does not produce a valid id".formatted(displayName)
+      );
+    }
+    return ID_PREFIX + slug;
+  }
+
+  @Value
+  public static class PredefinedFilter {
+    String id;
+    String displayName;
+    String filterCode;
+    boolean enabledByDefault;
+    Predicate<TopicMessageDTO> predicate;
+  }
+}

--- a/api/src/main/resources/application-local.yml
+++ b/api/src/main/resources/application-local.yml
@@ -34,6 +34,13 @@ kafka:
       metrics:
         port: 9997
         type: JMX
+      # Predefined CEL message filters (shown in the Messages sidebar).
+      # message-filters:
+      #   - display-name: Non-heartbeat
+      #     filter-code: has(record.value.after)
+      #     enabled-by-default: true
+      #   - display-name: Since yesterday
+      #     filter-code: has(record.timestampMs) && record.timestampMs > nowMs - 86400000
 
 dynamic.config.enabled: true
 

--- a/api/src/main/resources/static/openapi/kafbat-ui-api.yaml
+++ b/api/src/main/resources/static/openapi/kafbat-ui-api.yaml
@@ -1517,6 +1517,27 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/KsqlCommandV2'
+  /api/clusters/{clusterName}/message-filters:
+    get:
+      operationId: getClusterMessageFilters
+      summary: getClusterMessageFilters
+      parameters:
+        - name: clusterName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The request has succeeded.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ClusterMessageFilter'
+      tags:
+        - Clusters
   /api/clusters/{clusterName}/metrics:
     get:
       operationId: getClusterMetrics
@@ -3130,6 +3151,8 @@ components:
                             type: string
                           clientSecret:
                             type: string
+                          clientAuthenticationMethod:
+                            type: string
                           clientName:
                             type: string
                           redirectUri:
@@ -3306,6 +3329,29 @@ components:
                             type: string
                           password:
                             type: string
+                          oauth:
+                            type: object
+                            properties:
+                              tokenUrl:
+                                type: string
+                              clientId:
+                                type: string
+                              clientSecret:
+                                type: string
+                              scopes:
+                                type: array
+                                items:
+                                  type: string
+                              tokenCacheEnabled:
+                                type: boolean
+                                default: true
+                              tokenRefreshBuffer:
+                                type: string
+                                format: duration
+                              maxRetries:
+                                type: integer
+                                format: int32
+                                default: 1
                       schemaRegistrySsl:
                         type: object
                         properties:
@@ -3428,6 +3474,18 @@ components:
                               type: string
                             topicValuesPattern:
                               type: string
+                      messageFilters:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            displayName:
+                              type: string
+                            filterCode:
+                              type: string
+                            enabledByDefault:
+                              type: boolean
+                              default: false
                       pollingThrottleRate:
                         type: integer
                         format: int64
@@ -3749,6 +3807,22 @@ components:
           $ref: '#/components/schemas/ApplicationPropertyValidation'
         prometheusStorage:
           $ref: '#/components/schemas/ApplicationPropertyValidation'
+    ClusterMessageFilter:
+      type: object
+      required:
+        - id
+        - displayName
+        - filterCode
+      properties:
+        id:
+          type: string
+        displayName:
+          type: string
+        filterCode:
+          type: string
+        enabledByDefault:
+          type: boolean
+          default: false
     ClusterMetrics:
       type: object
       required:

--- a/api/src/test/java/io/kafbat/ui/emitter/MessageFiltersTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/MessageFiltersTest.java
@@ -175,6 +175,15 @@ class MessageFiltersTest {
     }
 
     @Test
+    void canCheckNowMsForRelativeTime() {
+      var recent = OffsetDateTime.now().minusHours(1);
+      var old = OffsetDateTime.now().minusDays(2);
+      var f = celScriptFilter("has(record.timestampMs) && record.timestampMs > nowMs - 86400000");
+      assertTrue(f.test(msg().timestamp(recent)));
+      assertFalse(f.test(msg().timestamp(old)));
+    }
+
+    @Test
     void canCheckValueAsText() {
       var f = celScriptFilter("record.valueAsText == 'some text'");
       assertTrue(f.test(msg().value("some text")));

--- a/api/src/test/java/io/kafbat/ui/service/filters/ClusterMessageFiltersTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/filters/ClusterMessageFiltersTest.java
@@ -1,0 +1,94 @@
+package io.kafbat.ui.service.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.kafbat.ui.config.ClustersProperties;
+import io.kafbat.ui.exception.ValidationException;
+import io.kafbat.ui.model.TopicMessageDTO;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ClusterMessageFiltersTest {
+
+  @Test
+  void emptyWhenConfigIsNull() {
+    assertThat(ClusterMessageFilters.create(null).getFilters()).isEmpty();
+  }
+
+  @Test
+  void compilesCelAndAssignsStableId() {
+    var config = filter("Non-heartbeat", "has(record.value.after)", true);
+
+    ClusterMessageFilters filters = ClusterMessageFilters.create(List.of(config));
+
+    assertThat(filters.getFilters()).hasSize(1);
+    var predefined = filters.getFilters().getFirst();
+    assertThat(predefined.getId()).isEqualTo("cfg-non-heartbeat");
+    assertThat(predefined.getDisplayName()).isEqualTo("Non-heartbeat");
+    assertThat(predefined.isEnabledByDefault()).isTrue();
+    assertTrue(predefined.getPredicate().test(msg().value("{\"after\":{}}")));
+    assertFalse(predefined.getPredicate().test(msg().value("{\"op\":\"r\"}")));
+  }
+
+  @Test
+  void findByIdReturnsCompiledFilter() {
+    var filters = ClusterMessageFilters.create(List.of(
+        filter("Since yesterday", "has(record.timestampMs) && record.timestampMs > nowMs - 86400000", false)
+    ));
+
+    assertThat(filters.findById("cfg-since-yesterday")).isPresent();
+    assertThat(filters.findById("unknown")).isEmpty();
+  }
+
+  @Test
+  void rejectsDuplicateDisplayNames() {
+    assertThatThrownBy(() -> ClusterMessageFilters.create(List.of(
+        filter("Same", "true", false),
+        filter("Same", "false", false)
+    ))).isInstanceOf(ValidationException.class)
+        .hasMessageContaining("duplicate message filter displayName");
+  }
+
+  @Test
+  void rejectsDisplayNamesThatCollideAfterSlug() {
+    assertThatThrownBy(() -> ClusterMessageFilters.create(List.of(
+        filter("Non heartbeat", "true", false),
+        filter("Non-heartbeat", "true", false)
+    ))).isInstanceOf(ValidationException.class)
+        .hasMessageContaining("duplicate id");
+  }
+
+  @Test
+  void rejectsInvalidCel() {
+    assertThatThrownBy(() -> ClusterMessageFilters.create(List.of(
+        filter("Broken", "this is not cel", false)
+    ))).isInstanceOf(ValidationException.class)
+        .hasMessageContaining("invalid CEL");
+  }
+
+  @Test
+  void rejectsBlankDisplayNameSlug() {
+    assertThatThrownBy(() -> ClusterMessageFilters.toId("!!!"))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("does not produce a valid id");
+  }
+
+  private static ClustersProperties.MessageFilterConfig filter(String name, String code, boolean enabledByDefault) {
+    var config = new ClustersProperties.MessageFilterConfig();
+    config.setDisplayName(name);
+    config.setFilterCode(code);
+    config.setEnabledByDefault(enabledByDefault);
+    return config;
+  }
+
+  private static TopicMessageDTO msg() {
+    return new TopicMessageDTO()
+        .partition(0)
+        .offset(0L)
+        .timestamp(OffsetDateTime.now());
+  }
+}

--- a/contract-typespec/api/clusters.tsp
+++ b/contract-typespec/api/clusters.tsp
@@ -31,6 +31,12 @@ interface ClustersApi {
   @operationId("getClusterStats")
   @summary("getClusterStats")
   getClusterStats(@path clusterName: string): ClusterStats;
+
+  @get
+  @route("/{clusterName}/message-filters")
+  @operationId("getClusterMessageFilters")
+  @summary("getClusterMessageFilters")
+  getClusterMessageFilters(@path clusterName: string): ClusterMessageFilter[];
 }
 
 model Cluster {
@@ -105,4 +111,11 @@ enum ControllerType {
     ZOOKEEPER,
     KRAFT,
     UNKNOWN
+}
+
+model ClusterMessageFilter {
+  id: string;
+  displayName: string;
+  filterCode: string;
+  enabledByDefault?: boolean = false;
 }

--- a/contract-typespec/api/config.tsp
+++ b/contract-typespec/api/config.tsp
@@ -219,6 +219,11 @@ model ApplicationConfig {
           topicKeysPattern?: string;
           topicValuesPattern?: string;
         }[];
+        messageFilters?: {
+          displayName?: string;
+          filterCode?: string;
+          enabledByDefault?: boolean = false;
+        }[];
         pollingThrottleRate?: int64;
         audit?: {
           level?: "ALL" | "ALTER_ONLY";

--- a/documentation/compose/DOCKER_COMPOSE.md
+++ b/documentation/compose/DOCKER_COMPOSE.md
@@ -11,3 +11,4 @@
 9. [kafka-ui-traefik-proxy.yaml](./traefik-proxy.yaml) - Traefik-specific proxy configuration.
 10. [kafka-ui-with-jmx-exporter.yaml](./ui-with-jmx-exporter.yaml) - A configuration with 2 Kafka clusters with enabled Prometheus JMX exporters instead of JMX.
 11. [kafka-with-zookeeper.yaml](./kafka-zookeeper.yaml) - An example of using Kafka with ZooKeeper.
+12. [ui-message-filters.yaml](./ui-message-filters.yaml) - Predefined CEL message filters (cluster-wide list, optional default filter).

--- a/documentation/compose/ui-message-filters.yaml
+++ b/documentation/compose/ui-message-filters.yaml
@@ -1,0 +1,34 @@
+---
+# Example: predefined CEL message filters (issue 1814).
+# Combine these environment variables with any compose file that already
+# defines a cluster (for example kafbat-ui.yaml), or mount this as YAML:
+#
+#   kafka:
+#     clusters:
+#       - name: local
+#         bootstrapServers: kafka0:29092
+#         message-filters:
+#           - display-name: Non-heartbeat
+#             filter-code: has(record.value.after)
+#             enabled-by-default: true
+#           - display-name: Since yesterday
+#             filter-code: has(record.timestampMs) && record.timestampMs > nowMs - 86400000
+#
+version: '2'
+services:
+  kafbat-ui:
+    container_name: kafbat-ui
+    image: ghcr.io/kafbat/kafka-ui:latest
+    ports:
+      - 8080:8080
+    environment:
+      kafka.clusters.0.name: local
+      kafka.clusters.0.bootstrapServers: kafka0:29092
+
+      kafka.clusters.0.messageFilters.0.displayName: Non-heartbeat
+      kafka.clusters.0.messageFilters.0.filterCode: has(record.value.after)
+      kafka.clusters.0.messageFilters.0.enabledByDefault: "true"
+
+      kafka.clusters.0.messageFilters.1.displayName: Since yesterday
+      kafka.clusters.0.messageFilters.1.filterCode: has(record.timestampMs) && record.timestampMs > nowMs - 86400000
+      kafka.clusters.0.messageFilters.1.enabledByDefault: "false"

--- a/frontend/src/components/Topics/Topic/Messages/Filters/Filters.styled.ts
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/Filters.styled.ts
@@ -135,6 +135,9 @@ export const SavedFiltersContainer = styled.div`
 `;
 
 export const SavedFilterName = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
   font-size: 14px;
   line-height: 20px;
   color: ${({ theme }) => theme.savedFilter.filterName};
@@ -202,6 +205,10 @@ export const SavedFilter = styled.div.attrs({
   background-color: ${({ selected, theme }) =>
     selected ? theme.layout.stuffColor : 'transparent'};
 `;
+
+export const PredefinedFilter = styled(SavedFilter).attrs({
+  role: 'predefinedFilter',
+})``;
 
 export const ActiveSmartFilter = styled.div`
   display: flex;
@@ -338,6 +345,16 @@ export const FilterModeTypeSelect = styled(Select<PollingMode>)`
 export const SavedFilterText = styled.div`
   font-weight: 600;
   color: ${({ theme }) => theme.default.color.normal};
+`;
+
+export const DefaultFilterBadge = styled.span`
+  font-weight: 500;
+  font-size: 11px;
+  line-height: 16px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  color: ${({ theme }) => theme.activeFilter.color};
+  background: ${({ theme }) => theme.activeFilter.backgroundColor};
 `;
 
 export const SavedFilterClearAll = styled.button`

--- a/frontend/src/components/Topics/Topic/Messages/Filters/Filters.styled.ts
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/Filters.styled.ts
@@ -207,8 +207,22 @@ export const SavedFilter = styled.div.attrs({
 `;
 
 export const PredefinedFilter = styled(SavedFilter).attrs({
-  role: 'predefinedFilter',
-})``;
+  as: 'button',
+  type: 'button',
+  role: 'button',
+})`
+  width: 100%;
+  border: none;
+  font: inherit;
+  text-align: left;
+  color: inherit;
+
+  &:focus-visible {
+    outline: 2px solid
+      ${({ theme }) => theme.button.primary.backgroundColor.normal};
+    outline-offset: 1px;
+  }
+`;
 
 export const ActiveSmartFilter = styled.div`
   display: flex;

--- a/frontend/src/components/Topics/Topic/Messages/Filters/Filters.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/Filters.tsx
@@ -111,6 +111,7 @@ const Filters: React.FC<FiltersProps> = ({
     setPartition,
     smartFilter,
     setSmartFilter,
+    predefinedFilters,
     refreshData,
   } = useMessagesFilters(topicName);
 
@@ -290,12 +291,14 @@ const Filters: React.FC<FiltersProps> = ({
         {smartFilter && (
           <S.ActiveSmartFilter data-testid="activeSmartFilter">
             <S.SmartFilterName>{smartFilter.id}</S.SmartFilterName>
-            <S.EditSmartFilterIcon
-              onClick={() => setCreatedEditedSmartId(smartFilter.id)}
-              disabled={!!createdEditedSmartId}
-            >
-              <EditIcon />
-            </S.EditSmartFilterIcon>
+            {!smartFilter.predefined && (
+              <S.EditSmartFilterIcon
+                onClick={() => setCreatedEditedSmartId(smartFilter.id)}
+                disabled={!!createdEditedSmartId}
+              >
+                <EditIcon />
+              </S.EditSmartFilterIcon>
+            )}
             <S.DeleteSmartFilterIcon
               onClick={() => {
                 setSmartFilter(null);
@@ -311,6 +314,7 @@ const Filters: React.FC<FiltersProps> = ({
         setClose={() => setCreatedEditedSmartId('')}
         smartFilter={smartFilter}
         setSmartFilter={setSmartFilter}
+        predefinedFilters={predefinedFilters}
         setFilterName={setCreatedEditedSmartId}
         filterName={createdEditedSmartId}
       />

--- a/frontend/src/components/Topics/Topic/Messages/Filters/FiltersSideBar.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/FiltersSideBar.tsx
@@ -17,6 +17,7 @@ export interface FilterModalProps {
   setFilterName: (filterId: string) => void;
   smartFilter?: AdvancedFilter;
   setSmartFilter: (filter: AdvancedFilter | null) => void;
+  predefinedFilters?: AdvancedFilter[];
 }
 
 const FiltersSideBar: React.FC<FilterModalProps> = ({
@@ -25,6 +26,7 @@ const FiltersSideBar: React.FC<FilterModalProps> = ({
   setFilterName,
   smartFilter,
   setSmartFilter,
+  predefinedFilters = [],
 }) => {
   const filters = useMessageFiltersStore((state) => state.filters);
   const filter = useMessageFiltersStore(selectFilter(filterName));
@@ -48,6 +50,7 @@ const FiltersSideBar: React.FC<FilterModalProps> = ({
         {!isEditing && (
           <SavedFilters
             filters={filters}
+            predefinedFilters={predefinedFilters}
             onEdit={(name) => {
               setFilterName(name);
             }}

--- a/frontend/src/components/Topics/Topic/Messages/Filters/InfoModal.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/InfoModal.tsx
@@ -22,6 +22,7 @@ const InfoModal: React.FC<InfoModalProps> = ({ toggleIsOpen }) => {
         <S.ListItem>header</S.ListItem>
         <S.ListItem>partition</S.ListItem>
         <S.ListItem>timestampMs</S.ListItem>
+        <S.ListItem>nowMs (current epoch millis at evaluation time)</S.ListItem>
       </ol>
       <S.InfoParagraph>
         <b>JSON parsing logic:</b>
@@ -53,6 +54,12 @@ const InfoModal: React.FC<InfoModalProps> = ({ toggleIsOpen }) => {
             record.headers.size() == 1 && !has(record.headers.k1) &&
             record.headers[&apos;k2&apos;] == &apos;v2&apos;
           </code>
+        </S.ListItem>
+        <S.ListItem>
+          <code>
+            has(record.timestampMs) && record.timestampMs &gt; nowMs - 86400000
+          </code>{' '}
+          - messages since yesterday
         </S.ListItem>
       </ol>
       <Flexbox justifyContent="center" margin="20px 0 0 0">

--- a/frontend/src/components/Topics/Topic/Messages/Filters/SavedFilters.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/SavedFilters.tsx
@@ -13,6 +13,7 @@ import * as S from './Filters.styled';
 
 export interface Props {
   filters: Record<string, AdvancedFilter>;
+  predefinedFilters?: AdvancedFilter[];
   smartFilter?: AdvancedFilter;
   setSmartFilter: (filter: AdvancedFilter | null) => void;
   onEdit: (id: string) => void;
@@ -21,6 +22,7 @@ export interface Props {
 
 const SavedFilters: FC<Props> = ({
   filters,
+  predefinedFilters = [],
   closeSideBar,
   smartFilter,
   setSmartFilter,
@@ -32,6 +34,13 @@ const SavedFilters: FC<Props> = ({
     findWhereFilterIsActive,
   } = useActiveFilters();
   const filtersList = React.useMemo(() => Object.values(filters), [filters]);
+  const predefinedList = React.useMemo(
+    () =>
+      [...predefinedFilters].sort(
+        (a, b) => Number(b.enabledByDefault) - Number(a.enabledByDefault)
+      ),
+    [predefinedFilters]
+  );
   const clearAll = useMessageFiltersStore((state) => state.removeAll);
   const remove = useMessageFiltersStore((state) => state.remove);
   const confirm = useConfirm();
@@ -68,6 +77,29 @@ const SavedFilters: FC<Props> = ({
 
   return (
     <>
+      {predefinedList.length > 0 && (
+        <>
+          <Flexbox margin="10px 0 0 0" justifyContent="space-between">
+            <S.SavedFilterText>Predefined</S.SavedFilterText>
+          </Flexbox>
+          <S.SavedFiltersContainer>
+            {predefinedList.map((filter) => (
+              <S.PredefinedFilter
+                key={filter.filterCode}
+                selected={smartFilter?.id === filter.id}
+                onClick={() => activateFilter(filter)}
+              >
+                <S.SavedFilterName>
+                  {filter.id}
+                  {filter.enabledByDefault && (
+                    <S.DefaultFilterBadge>Default</S.DefaultFilterBadge>
+                  )}
+                </S.SavedFilterName>
+              </S.PredefinedFilter>
+            ))}
+          </S.SavedFiltersContainer>
+        </>
+      )}
       <Flexbox margin="10px 0 0 0" justifyContent="space-between">
         <S.SavedFilterText>Saved Filters</S.SavedFilterText>
         <S.SavedFilterClearAll

--- a/frontend/src/components/Topics/Topic/Messages/Filters/SavedFilters.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/SavedFilters.tsx
@@ -86,7 +86,7 @@ const SavedFilters: FC<Props> = ({
             {predefinedList.map((filter) => (
               <S.PredefinedFilter
                 key={filter.filterCode}
-                selected={smartFilter?.id === filter.id}
+                selected={smartFilter?.filterCode === filter.filterCode}
                 onClick={() => activateFilter(filter)}
               >
                 <S.SavedFilterName>
@@ -119,7 +119,7 @@ const SavedFilters: FC<Props> = ({
         {filtersList.map((filter) => (
           <S.SavedFilter
             key={Symbol(filter.id).toString()}
-            selected={smartFilter?.id === filter.id}
+            selected={smartFilter?.filterCode === filter.filterCode}
             onClick={() => activateFilter(filter)}
           >
             <S.SavedFilterName>{filter.id}</S.SavedFilterName>

--- a/frontend/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
@@ -147,17 +147,20 @@ describe('SavedFilter Component', () => {
       expect(screen.getByText('Default')).toBeInTheDocument();
     });
 
+    const getPredefinedFilters = () => [
+      screen.getByRole('button', { name: /Non-heartbeat/ }),
+      screen.getByRole('button', { name: /Since yesterday/ }),
+    ];
+
     it('activates a predefined filter on click', async () => {
-      const predefinedFilters = screen.getAllByRole('predefinedFilter');
-      await userEvent.click(predefinedFilters[0]);
+      await userEvent.click(getPredefinedFilters()[0]);
 
       expect(setSmartFilterMock).toHaveBeenCalledWith(predefined[0]);
       expect(cancelMock).toHaveBeenCalled();
     });
 
     it('does not offer edit or delete for predefined filters', () => {
-      const predefinedFilters = screen.getAllByRole('predefinedFilter');
-      predefinedFilters.forEach((filter) => {
+      getPredefinedFilters().forEach((filter) => {
         expect(within(filter).queryByLabelText('edit')).not.toBeInTheDocument();
         expect(
           within(filter).queryByLabelText('delete')

--- a/frontend/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/__tests__/SavedFilters.spec.tsx
@@ -106,6 +106,66 @@ describe('SavedFilter Component', () => {
     });
   });
 
+  describe('Predefined Filters', () => {
+    const setSmartFilterMock = jest.fn();
+    const cancelMock = jest.fn();
+    const predefined = [
+      {
+        id: 'Non-heartbeat',
+        value: 'has(record.value.after)',
+        filterCode: 'cfg-non-heartbeat',
+        predefined: true,
+        enabledByDefault: true,
+      },
+      {
+        id: 'Since yesterday',
+        value:
+          'has(record.timestampMs) && record.timestampMs > nowMs - 86400000',
+        filterCode: 'cfg-since-yesterday',
+        predefined: true,
+        enabledByDefault: false,
+      },
+    ];
+
+    beforeEach(() => {
+      setUpComponent({
+        closeSideBar: cancelMock,
+        setSmartFilter: setSmartFilterMock,
+        predefinedFilters: predefined,
+      });
+    });
+
+    afterEach(() => {
+      setSmartFilterMock.mockClear();
+      cancelMock.mockClear();
+    });
+
+    it('renders predefined filters with a default badge', () => {
+      expect(screen.getByText('Predefined')).toBeInTheDocument();
+      expect(screen.getByText('Non-heartbeat')).toBeInTheDocument();
+      expect(screen.getByText('Since yesterday')).toBeInTheDocument();
+      expect(screen.getByText('Default')).toBeInTheDocument();
+    });
+
+    it('activates a predefined filter on click', async () => {
+      const predefinedFilters = screen.getAllByRole('predefinedFilter');
+      await userEvent.click(predefinedFilters[0]);
+
+      expect(setSmartFilterMock).toHaveBeenCalledWith(predefined[0]);
+      expect(cancelMock).toHaveBeenCalled();
+    });
+
+    it('does not offer edit or delete for predefined filters', () => {
+      const predefinedFilters = screen.getAllByRole('predefinedFilter');
+      predefinedFilters.forEach((filter) => {
+        expect(within(filter).queryByLabelText('edit')).not.toBeInTheDocument();
+        expect(
+          within(filter).queryByLabelText('delete')
+        ).not.toBeInTheDocument();
+      });
+    });
+  });
+
   describe('Saved Filters Deletion', () => {
     const setSmartFilterMock = jest.fn();
 

--- a/frontend/src/lib/hooks/__tests__/useMessagesFilters.spec.tsx
+++ b/frontend/src/lib/hooks/__tests__/useMessagesFilters.spec.tsx
@@ -1,0 +1,61 @@
+import React, { PropsWithChildren } from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { LOCAL_STORAGE_KEY_PREFIX } from 'lib/constants';
+import { useMessagesFilters } from 'lib/hooks/useMessagesFilters';
+
+const clusterName = 'local';
+const topicName = 'orders';
+const resourceName = `${topicName}:${clusterName}`;
+const fieldsStorageKey = `${LOCAL_STORAGE_KEY_PREFIX}-message-filters-fields`;
+
+jest.mock('lib/hooks/api/clusters', () => ({
+  useClusterMessageFilters: () => ({
+    data: [
+      {
+        id: 'cfg-non-heartbeat',
+        displayName: 'Non-heartbeat',
+        filterCode: 'has(record.value.after)',
+        enabledByDefault: true,
+      },
+    ],
+  }),
+}));
+
+describe('useMessagesFilters', () => {
+  const wrapper = ({ children }: PropsWithChildren) => (
+    <MemoryRouter
+      initialEntries={[
+        `/ui/clusters/${clusterName}/all-topics/${topicName}/messages?limit=100&mode=LATEST`,
+      ]}
+    >
+      <Routes>
+        <Route
+          path="/ui/clusters/:clusterName/all-topics/:topicName/messages"
+          element={children}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('does not reactivate a default filter after the user cleared it', async () => {
+    localStorage.setItem(
+      fieldsStorageKey,
+      JSON.stringify({ [resourceName]: { activeFilterId: '' } })
+    );
+
+    const { result } = renderHook(() => useMessagesFilters(topicName), {
+      wrapper,
+    });
+
+    await waitFor(() => {
+      expect(result.current.predefinedFilters).toHaveLength(1);
+    });
+
+    expect(result.current.smartFilter).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/hooks/__tests__/useMessagesFilters.spec.tsx
+++ b/frontend/src/lib/hooks/__tests__/useMessagesFilters.spec.tsx
@@ -1,13 +1,20 @@
 import React, { PropsWithChildren } from 'react';
 import { renderHook, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { LOCAL_STORAGE_KEY_PREFIX } from 'lib/constants';
+import { LOCAL_STORAGE_KEY_PREFIX, MessagesFilterKeys } from 'lib/constants';
 import { useMessagesFilters } from 'lib/hooks/useMessagesFilters';
+import { useMessageFiltersStore } from 'lib/hooks/useMessageFiltersStore';
 
 const clusterName = 'local';
 const topicName = 'orders';
 const resourceName = `${topicName}:${clusterName}`;
 const fieldsStorageKey = `${LOCAL_STORAGE_KEY_PREFIX}-message-filters-fields`;
+
+const collidingSavedFilter = {
+  id: 'Non-heartbeat',
+  value: 'record.partition == 1',
+  filterCode: 'abcd1234',
+};
 
 jest.mock('lib/hooks/api/clusters', () => ({
   useClusterMessageFilters: () => ({
@@ -22,11 +29,12 @@ jest.mock('lib/hooks/api/clusters', () => ({
   }),
 }));
 
-describe('useMessagesFilters', () => {
-  const wrapper = ({ children }: PropsWithChildren) => (
+const createWrapper =
+  (search = 'limit=100&mode=LATEST') =>
+  ({ children }: PropsWithChildren) => (
     <MemoryRouter
       initialEntries={[
-        `/ui/clusters/${clusterName}/all-topics/${topicName}/messages?limit=100&mode=LATEST`,
+        `/ui/clusters/${clusterName}/all-topics/${topicName}/messages?${search}`,
       ]}
     >
       <Routes>
@@ -38,8 +46,10 @@ describe('useMessagesFilters', () => {
     </MemoryRouter>
   );
 
+describe('useMessagesFilters', () => {
   beforeEach(() => {
     localStorage.clear();
+    useMessageFiltersStore.getState().removeAll();
   });
 
   it('does not reactivate a default filter after the user cleared it', async () => {
@@ -49,7 +59,7 @@ describe('useMessagesFilters', () => {
     );
 
     const { result } = renderHook(() => useMessagesFilters(topicName), {
-      wrapper,
+      wrapper: createWrapper(),
     });
 
     await waitFor(() => {
@@ -57,5 +67,37 @@ describe('useMessagesFilters', () => {
     });
 
     expect(result.current.smartFilter).toBeUndefined();
+  });
+
+  it('resolves a predefined filter when a saved filter shares the display name', async () => {
+    useMessageFiltersStore.getState().save(collidingSavedFilter);
+
+    const { result } = renderHook(() => useMessagesFilters(topicName), {
+      wrapper: createWrapper(
+        `limit=100&mode=LATEST&${MessagesFilterKeys.activeFilterId}=Non-heartbeat&${MessagesFilterKeys.smartFilterId}=cfg-non-heartbeat`
+      ),
+    });
+
+    await waitFor(() => {
+      expect(result.current.smartFilter?.predefined).toBe(true);
+    });
+
+    expect(result.current.smartFilter?.filterCode).toBe('cfg-non-heartbeat');
+  });
+
+  it('resolves a saved filter when a predefined filter shares the display name', async () => {
+    useMessageFiltersStore.getState().save(collidingSavedFilter);
+
+    const { result } = renderHook(() => useMessagesFilters(topicName), {
+      wrapper: createWrapper(
+        `limit=100&mode=LATEST&${MessagesFilterKeys.activeFilterId}=Non-heartbeat&${MessagesFilterKeys.smartFilterId}=abcd1234`
+      ),
+    });
+
+    await waitFor(() => {
+      expect(result.current.smartFilter?.predefined).toBeFalsy();
+    });
+
+    expect(result.current.smartFilter?.filterCode).toBe('abcd1234');
   });
 });

--- a/frontend/src/lib/hooks/__tests__/useMessagesFiltersFields.spec.ts
+++ b/frontend/src/lib/hooks/__tests__/useMessagesFiltersFields.spec.ts
@@ -1,0 +1,58 @@
+import { act, renderHook } from '@testing-library/react';
+import { LOCAL_STORAGE_KEY_PREFIX, MessagesFilterKeys } from 'lib/constants';
+import { useMessagesFiltersFields } from 'lib/hooks/useMessagesFiltersFields';
+
+const resourceName = 'orders:local';
+const fieldsStorageKey = `${LOCAL_STORAGE_KEY_PREFIX}-message-filters-fields`;
+
+describe('useMessagesFiltersFields', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('keeps a cleared smart filter preference when URL only has limit and mode', () => {
+    localStorage.setItem(
+      fieldsStorageKey,
+      JSON.stringify({ [resourceName]: { activeFilterId: '' } })
+    );
+
+    const { result } = renderHook(() => useMessagesFiltersFields(resourceName));
+
+    expect(result.current.hasSmartFilterPreference).toBe(true);
+
+    act(() => {
+      result.current.initMessagesFiltersFields(
+        new URLSearchParams('limit=100&mode=LATEST')
+      );
+    });
+
+    expect(result.current.hasSmartFilterPreference).toBe(true);
+    expect(
+      JSON.parse(localStorage.getItem(fieldsStorageKey) || '{}')[resourceName]
+        .activeFilterId
+    ).toBe('');
+  });
+
+  it('replaces a stored preference when the URL selects a filter', () => {
+    localStorage.setItem(
+      fieldsStorageKey,
+      JSON.stringify({ [resourceName]: { activeFilterId: '' } })
+    );
+
+    const { result } = renderHook(() => useMessagesFiltersFields(resourceName));
+
+    act(() => {
+      result.current.initMessagesFiltersFields(
+        new URLSearchParams(
+          `limit=100&mode=LATEST&${MessagesFilterKeys.activeFilterId}=Non-heartbeat&${MessagesFilterKeys.smartFilterId}=cfg-non-heartbeat`
+        )
+      );
+    });
+
+    expect(result.current.hasSmartFilterPreference).toBe(true);
+    expect(
+      JSON.parse(localStorage.getItem(fieldsStorageKey) || '{}')[resourceName]
+        .activeFilterId
+    ).toBe('Non-heartbeat');
+  });
+});

--- a/frontend/src/lib/hooks/api/__tests__/clusters.spec.ts
+++ b/frontend/src/lib/hooks/api/__tests__/clusters.spec.ts
@@ -26,4 +26,24 @@ describe('Clusters hooks', () => {
       await expectQueryWorks(mock, result);
     });
   });
+  describe('useClusterMessageFilters', () => {
+    it('returns the correct data', async () => {
+      const payload = [
+        {
+          id: 'cfg-non-heartbeat',
+          displayName: 'Non-heartbeat',
+          filterCode: 'has(record.value.after)',
+          enabledByDefault: true,
+        },
+      ];
+      const mock = fetchMock.getOnce(
+        `/api/clusters/${clusterName}/message-filters`,
+        payload
+      );
+      const { result } = renderQueryHook(() =>
+        hooks.useClusterMessageFilters(clusterName)
+      );
+      await expectQueryWorks(mock, result);
+    });
+  });
 });

--- a/frontend/src/lib/hooks/api/clusters.ts
+++ b/frontend/src/lib/hooks/api/clusters.ts
@@ -15,3 +15,10 @@ export function useClusterStats(clusterName: ClusterName) {
     refetchInterval: 5000,
   });
 }
+
+export function useClusterMessageFilters(clusterName: ClusterName) {
+  return useQuery({
+    queryKey: ['clusters', clusterName, 'messageFilters'],
+    queryFn: () => api.getClusterMessageFilters({ clusterName }),
+  });
+}

--- a/frontend/src/lib/hooks/useMessageFiltersStore.ts
+++ b/frontend/src/lib/hooks/useMessageFiltersStore.ts
@@ -1,3 +1,4 @@
+import { ClusterMessageFilter } from 'generated-sources';
 import { LOCAL_STORAGE_KEY_PREFIX } from 'lib/constants';
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
@@ -8,6 +9,8 @@ export interface AdvancedFilter {
   id: string;
   value: string;
   filterCode: string;
+  predefined?: boolean;
+  enabledByDefault?: boolean;
 }
 
 interface MessageFiltersState {
@@ -28,6 +31,18 @@ export const selectFilter =
     if (filters[id]) return filters[id];
     return undefined;
   };
+
+export function toPredefinedAdvancedFilter(
+  filter: ClusterMessageFilter
+): AdvancedFilter {
+  return {
+    id: filter.displayName,
+    value: filter.filterCode,
+    filterCode: filter.id,
+    predefined: true,
+    enabledByDefault: Boolean(filter.enabledByDefault),
+  };
+}
 
 export const useMessageFiltersStore = create<MessageFiltersState>()(
   persist(

--- a/frontend/src/lib/hooks/useMessagesFilters.ts
+++ b/frontend/src/lib/hooks/useMessagesFilters.ts
@@ -121,14 +121,21 @@ export function useMessagesFilters(topicName: string) {
     .split(',')
     .filter((v) => v);
 
-  const smartFilterId =
+  const activeFilterId =
     searchParams.get(MessagesFilterKeys.activeFilterId) || '';
+  const backendSmartFilterId =
+    searchParams.get(MessagesFilterKeys.smartFilterId) || '';
 
-  const savedSmartFilter = useMessageFiltersStore(selectFilter(smartFilterId));
-  const predefinedSmartFilter = predefinedFilters.find(
-    (filter) => filter.id === smartFilterId
+  const savedSmartFilter = useMessageFiltersStore(selectFilter(activeFilterId));
+  const predefinedByBackendId = predefinedFilters.find(
+    (filter) => filter.filterCode === backendSmartFilterId
   );
-  const smartFilter = savedSmartFilter ?? predefinedSmartFilter;
+  const predefinedByName = predefinedFilters.find(
+    (filter) => filter.id === activeFilterId
+  );
+  const smartFilter = backendSmartFilterId
+    ? (predefinedByBackendId ?? savedSmartFilter)
+    : (savedSmartFilter ?? predefinedByName);
 
   /**
    * @description

--- a/frontend/src/lib/hooks/useMessagesFilters.ts
+++ b/frontend/src/lib/hooks/useMessagesFilters.ts
@@ -1,14 +1,16 @@
 import { useSearchParams } from 'react-router-dom';
 import { PollingMode } from 'generated-sources';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Option } from 'react-multi-select-component';
 import { MessagesFilterKeys } from 'lib/constants';
+import { useClusterMessageFilters } from 'lib/hooks/api/clusters';
 import { ClusterName } from 'lib/interfaces/cluster';
 
 import { convertStrToPollingMode, ModeOptions } from './filterUtils';
 import {
   AdvancedFilter,
   selectFilter,
+  toPredefinedAdvancedFilter,
   useMessageFiltersStore,
 } from './useMessageFiltersStore';
 import { useMessagesFiltersFields } from './useMessagesFiltersFields';
@@ -71,7 +73,14 @@ export function useMessagesFilters(topicName: string) {
     initMessagesFiltersFields,
     setMessagesFiltersField,
     removeMessagesFiltersField,
+    hasSmartFilterPreference,
   } = useMessagesFiltersFields(storageKey);
+
+  const { data: clusterMessageFilters } = useClusterMessageFilters(clusterName);
+  const predefinedFilters = useMemo(
+    () => (clusterMessageFilters ?? []).map(toPredefinedAdvancedFilter),
+    [clusterMessageFilters]
+  );
 
   useEffect(() => {
     setSearchParams((params) => {
@@ -115,7 +124,11 @@ export function useMessagesFilters(topicName: string) {
   const smartFilterId =
     searchParams.get(MessagesFilterKeys.activeFilterId) || '';
 
-  const smartFilter = useMessageFiltersStore(selectFilter(smartFilterId));
+  const savedSmartFilter = useMessageFiltersStore(selectFilter(smartFilterId));
+  const predefinedSmartFilter = predefinedFilters.find(
+    (filter) => filter.id === smartFilterId
+  );
+  const smartFilter = savedSmartFilter ?? predefinedSmartFilter;
 
   /**
    * @description
@@ -220,19 +233,17 @@ export function useMessagesFilters(topicName: string) {
       });
 
       removeMessagesFiltersField(MessagesFilterKeys.smartFilterId);
-      removeMessagesFiltersField(MessagesFilterKeys.activeFilterId);
+      setMessagesFiltersField(MessagesFilterKeys.activeFilterId, '');
 
       return;
     }
 
     const { id } = newFilter;
-    // callback should always capture the latest states not rely on rendering
-
-    const filter = selectFilter(newFilter.id)(
+    const storedFilter = selectFilter(newFilter.id)(
       useMessageFiltersStore.getState()
     );
+    const filter = newFilter.predefined ? newFilter : storedFilter;
 
-    // setting something that is not in the state
     if (!filter) return;
 
     setMessagesFiltersField(MessagesFilterKeys.activeFilterId, filter.id);
@@ -242,11 +253,25 @@ export function useMessagesFilters(topicName: string) {
     );
 
     setSearchParams((params) => {
-      params.set(MessagesFilterKeys.smartFilterId, filter.filterCode); // hash code, i.e. 3de77452
-      params.set(MessagesFilterKeys.activeFilterId, id); // sllug name, i.e. MyFancyFilter
+      params.set(MessagesFilterKeys.smartFilterId, filter.filterCode);
+      params.set(MessagesFilterKeys.activeFilterId, id);
       return params;
     });
   };
+
+  useEffect(() => {
+    if (!predefinedFilters.length) return;
+    if (searchParams.get(MessagesFilterKeys.smartFilterId)) return;
+    if (searchParams.get(MessagesFilterKeys.activeFilterId)) return;
+    if (hasSmartFilterPreference) return;
+
+    const defaultFilter = predefinedFilters.find(
+      (filter) => filter.enabledByDefault
+    );
+    if (defaultFilter) {
+      setSmartFilter(defaultFilter);
+    }
+  }, [predefinedFilters, hasSmartFilterPreference, searchParams]);
 
   return {
     mode,
@@ -265,6 +290,7 @@ export function useMessagesFilters(topicName: string) {
     setPartition,
     smartFilter,
     setSmartFilter,
+    predefinedFilters,
     refreshData,
   };
 }

--- a/frontend/src/lib/hooks/useMessagesFiltersFields.ts
+++ b/frontend/src/lib/hooks/useMessagesFiltersFields.ts
@@ -107,6 +107,18 @@ export function useMessagesFiltersFields(resourceName: string) {
       }
     };
 
+    const urlHasFilterSelection =
+      params.has(MessagesFilterKeys.activeFilterId) ||
+      params.has(MessagesFilterKeys.smartFilterId);
+    const storedActiveFilterId =
+      topicMessagesFilters?.[MessagesFilterKeys.activeFilterId];
+    const keepStoredSmartFilterPreference =
+      !urlHasFilterSelection &&
+      Object.prototype.hasOwnProperty.call(
+        topicMessagesFilters || {},
+        MessagesFilterKeys.activeFilterId
+      );
+
     // if url params are empty and topicMessagesFilters from local storage are existing then we apply them
     if (params.size === 0 && !!topicMessagesFilters) {
       setTopicMessageFiltersFromLocalStorage(MessagesFilterKeys.mode);
@@ -128,6 +140,12 @@ export function useMessagesFiltersFields(resourceName: string) {
       setTopicMessageFiltersFromUrlParams(MessagesFilterKeys.valueSerde);
       setTopicMessageFiltersFromUrlParams(MessagesFilterKeys.activeFilterId);
       setTopicMessageFiltersFromUrlParams(MessagesFilterKeys.smartFilterId);
+      if (keepStoredSmartFilterPreference) {
+        setMessagesFiltersField(
+          MessagesFilterKeys.activeFilterId,
+          storedActiveFilterId ?? ''
+        );
+      }
     }
   };
 

--- a/frontend/src/lib/hooks/useMessagesFiltersFields.ts
+++ b/frontend/src/lib/hooks/useMessagesFiltersFields.ts
@@ -131,9 +131,15 @@ export function useMessagesFiltersFields(resourceName: string) {
     }
   };
 
+  const hasSmartFilterPreference = Object.prototype.hasOwnProperty.call(
+    messageFilters[resourceName] || {},
+    MessagesFilterKeys.activeFilterId
+  );
+
   return {
     initMessagesFiltersFields,
     removeMessagesFiltersField,
     setMessagesFiltersField,
+    hasSmartFilterPreference,
   };
 }

--- a/frontend/src/widgets/ClusterConfigForm/Sections/MessageFilters.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/Sections/MessageFilters.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import * as S from 'widgets/ClusterConfigForm/ClusterConfigForm.styled';
+import { Button } from 'components/common/Button/Button';
+import Input from 'components/common/Input/Input';
+import { useFieldArray, useFormContext } from 'react-hook-form';
+import PlusIcon from 'components/common/Icons/PlusIcon';
+import IconButtonWrapper from 'components/common/Icons/IconButtonWrapper';
+import CloseCircleIcon from 'components/common/Icons/CloseCircleIcon';
+import {
+  FlexGrow1,
+  FlexRow,
+} from 'widgets/ClusterConfigForm/ClusterConfigForm.styled';
+import SectionHeader from 'widgets/ClusterConfigForm/common/SectionHeader';
+import Checkbox from 'components/common/Checkbox/Checkbox';
+
+const MessageFilters = () => {
+  const { control } = useFormContext();
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'messageFilters',
+  });
+  const handleAppend = () =>
+    append({
+      displayName: '',
+      filterCode: '',
+      enabledByDefault: false,
+    });
+  const toggleConfig = () => (fields.length === 0 ? handleAppend() : remove());
+
+  const hasFields = fields.length > 0;
+
+  return (
+    <>
+      <SectionHeader
+        title="Message Filters"
+        addButtonText="Configure Message Filters"
+        adding={!hasFields}
+        onClick={toggleConfig}
+      />
+      {hasFields && (
+        <S.GroupFieldWrapper>
+          {fields.map((item, index) => (
+            <div key={item.id}>
+              <FlexRow>
+                <FlexGrow1>
+                  <Input
+                    label="Display Name *"
+                    name={`messageFilters.${index}.displayName`}
+                    placeholder="Non-heartbeat"
+                    type="text"
+                    withError
+                  />
+                  <Input
+                    label="Filter Code (CEL) *"
+                    name={`messageFilters.${index}.filterCode`}
+                    placeholder="has(record.value.after)"
+                    type="text"
+                    withError
+                    hint="CEL expression evaluated for each message. nowMs is the current epoch millis."
+                  />
+                  <Checkbox
+                    name={`messageFilters.${index}.enabledByDefault`}
+                    label="Enabled by default on every topic"
+                    hint="Users can still clear the filter in the UI. The choice is remembered per topic."
+                  />
+                </FlexGrow1>
+                <S.RemoveButton onClick={() => remove(index)}>
+                  <IconButtonWrapper aria-label="deleteMessageFilter">
+                    <CloseCircleIcon aria-hidden />
+                  </IconButtonWrapper>
+                </S.RemoveButton>
+              </FlexRow>
+              <hr />
+            </div>
+          ))}
+          <Button
+            type="button"
+            buttonSize="M"
+            buttonType="secondary"
+            onClick={handleAppend}
+          >
+            <PlusIcon />
+            Add Filter
+          </Button>
+        </S.GroupFieldWrapper>
+      )}
+    </>
+  );
+};
+
+export default MessageFilters;

--- a/frontend/src/widgets/ClusterConfigForm/index.tsx
+++ b/frontend/src/widgets/ClusterConfigForm/index.tsx
@@ -24,6 +24,7 @@ import CustomAuthentication from 'widgets/ClusterConfigForm/Sections/CustomAuthe
 import Authentication from 'widgets/ClusterConfigForm/Sections/Authentication/Authentication';
 import KSQL from 'widgets/ClusterConfigForm/Sections/KSQL';
 import Masking from 'widgets/ClusterConfigForm/Sections/Masking';
+import MessageFilters from 'widgets/ClusterConfigForm/Sections/MessageFilters';
 import { useConfirm } from 'lib/hooks/useConfirm';
 
 interface ClusterConfigFormProps {
@@ -150,6 +151,8 @@ const ClusterConfigForm: React.FC<ClusterConfigFormProps> = ({
           <Metrics />
           <hr />
           <Masking />
+          <hr />
+          <MessageFilters />
           <hr />
           <S.ButtonWrapper>
             <Button

--- a/frontend/src/widgets/ClusterConfigForm/schema.ts
+++ b/frontend/src/widgets/ClusterConfigForm/schema.ts
@@ -272,6 +272,19 @@ const maskingsSchema = lazy((value) => {
   return mixed().optional();
 });
 
+const messageFilterSchema = object({
+  displayName: requiredString,
+  filterCode: requiredString,
+  enabledByDefault: boolean(),
+});
+
+const messageFiltersSchema = lazy((value) => {
+  if (Array.isArray(value)) {
+    return array().of(messageFilterSchema);
+  }
+  return mixed().optional();
+});
+
 const formSchema = object({
   name: string()
     .required('required field')
@@ -285,6 +298,7 @@ const formSchema = object({
   serde: serdesSchema,
   kafkaConnect: kafkaConnectsSchema,
   masking: maskingsSchema,
+  messageFilters: messageFiltersSchema,
   metrics: metricsSchema,
 });
 

--- a/frontend/src/widgets/ClusterConfigForm/types.ts
+++ b/frontend/src/widgets/ClusterConfigForm/types.ts
@@ -80,4 +80,9 @@ export type ClusterConfigFormValues = {
     topicKeysPattern?: string;
     topicValuesPattern?: string;
   }[];
+  messageFilters?: {
+    displayName?: string;
+    filterCode?: string;
+    enabledByDefault?: boolean;
+  }[];
 };

--- a/frontend/src/widgets/ClusterConfigForm/utils/getInitialFormData.ts
+++ b/frontend/src/widgets/ClusterConfigForm/utils/getInitialFormData.ts
@@ -51,6 +51,7 @@ export const getInitialFormData = (
     ksqldbServerSsl,
     masking,
     serde,
+    messageFilters,
   } = payload;
 
   const initialValues: Partial<ClusterConfigFormValues> = {
@@ -125,6 +126,14 @@ export const getInitialFormData = (
       maskingCharsReplacement: (m.maskingCharsReplacement ?? []).map((f) => ({
         value: f,
       })),
+    }));
+  }
+
+  if (messageFilters && messageFilters.length > 0) {
+    initialValues.messageFilters = messageFilters.map((filter) => ({
+      displayName: filter.displayName,
+      filterCode: filter.filterCode,
+      enabledByDefault: Boolean(filter.enabledByDefault),
     }));
   }
 

--- a/frontend/src/widgets/ClusterConfigForm/utils/transformFormDataToPayload.ts
+++ b/frontend/src/widgets/ClusterConfigForm/utils/transformFormDataToPayload.ts
@@ -149,6 +149,15 @@ export const transformFormDataToPayload = (data: ClusterConfigFormValues) => {
     }));
   }
 
+  // Message filters
+  if (data.messageFilters && data.messageFilters.length > 0) {
+    config.messageFilters = data.messageFilters.map((formData) => ({
+      displayName: formData.displayName,
+      filterCode: formData.filterCode,
+      enabledByDefault: Boolean(formData.enabledByDefault),
+    }));
+  }
+
   config.properties = {
     ...transformCustomProps(data.customAuth),
   };


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Closes #1814. Operators can define named CEL message filters in cluster YAML so they appear for everyone in the Messages sidebar as a read-only Predefined list.

```yaml
kafka:
  clusters:
    - name: my-kafka-cluster
      message-filters:
        - display-name: Non-heartbeat
          filter-code: has(record.value.after)
          enabled-by-default: true
        - display-name: Since yesterday
          filter-code: has(record.timestampMs) && record.timestampMs > nowMs - 86400000
```

- `enabled-by-default` defaults to `false` (list only). When `true`, the filter is auto-applied on every topic unless the user already chose or cleared a filter for that topic.
- Predefined filters use stable `cfg-` ids compiled at cluster startup (no ephemeral hash cache).
- CEL now binds `nowMs` at evaluation time so relative filters like “Since yesterday” stay current.
- Config wizard includes a Message Filters section. User-created saved filters stay in browser localStorage.

**Is there anything you'd like reviewers to focus on?**

- Issue #1814 is labeled `type/feature` but does not yet have an `accepted` label or milestone. Please confirm this is ready to land.
- GitBook [configuration file](https://ui.docs.kafbat.io/configuration/configuration-file.md) lives outside this repo and still needs a `message-filters` example. Compose snippet: `documentation/compose/ui-message-filters.yaml`.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [ ] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

Check out [Contributing](https://github.com/kafbat/kafka-ui/blob/main/.github/CONTRIBUTING.md) and [Code of Conduct](https://github.com/kafbat/kafka-ui/blob/main/.github/CODE-OF-CONDUCT.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable, predefined message filters for clusters.
  * Predefined filters appear in a dedicated section, support default selection, and cannot be edited or deleted.
  * Added cluster configuration controls for creating, validating, enabling, and removing message filters.
  * Added relative-time filtering using the current timestamp, including “since yesterday” scenarios.
* **Bug Fixes**
  * Improved filter selection and persistence across configured and saved filters.
* **Documentation**
  * Added setup guides and examples for predefined filter configurations and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->