### PR TITLE
Resolve google.protobuf.Any payloads in ProtobufFileSerde deserializer

### DIFF
--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
@@ -77,7 +77,7 @@ public class ProtobufFileSerde implements BuiltInSerde {
 
   private Map<Descriptor, Path> descriptorPaths = new HashMap<>();
 
-  private TypeRegistry typeRegistry = TypeRegistry.getEmptyTypeRegistry();
+  private Map<Descriptor, TypeRegistry> typeRegistries = new HashMap<>();
 
   @Nullable
   private Descriptor defaultMessageDescriptor;
@@ -117,12 +117,17 @@ public class ProtobufFileSerde implements BuiltInSerde {
     this.descriptorPaths = configuration.descriptorPaths();
     this.messageDescriptorMap = configuration.messageDescriptorMap();
     this.keyMessageDescriptorMap = configuration.keyMessageDescriptorMap();
-    // TypeRegistry.Builder#add pulls in the descriptor's whole file and its transitive
-    // dependencies, so this covers every type reachable from the configured messages -
-    // which is what google.protobuf.Any fields need to be resolved, in both directions.
-    this.typeRegistry = TypeRegistry.newBuilder()
-        .add(configuration.descriptorPaths().keySet())
-        .build();
+    // One registry per descriptor, rather than a single registry built from all of them.
+    // TypeRegistry.Builder#add pulls in the descriptor's whole file plus its transitive
+    // imports, which is what an Any field needs - but it skips a file whose name it has
+    // already seen, and ProtobufSchema names every FileDescriptor it synthesises
+    // "default". A shared registry would therefore keep only the first descriptor's
+    // types and silently drop the rest, picked in HashMap order.
+    this.typeRegistries = configuration.descriptorPaths().keySet().stream()
+        .collect(Collectors.toMap(
+            Function.identity(),
+            descriptor -> TypeRegistry.newBuilder().add(descriptor).build()
+        ));
   }
 
   private Optional<Descriptor> descriptorFor(String topic, Serde.Target type) {
@@ -133,6 +138,10 @@ public class ProtobufFileSerde implements BuiltInSerde {
         :
         Optional.ofNullable(messageDescriptorMap.get(topic))
             .or(() -> Optional.ofNullable(defaultMessageDescriptor));
+  }
+
+  private TypeRegistry typeRegistryFor(Descriptor descriptor) {
+    return typeRegistries.getOrDefault(descriptor, TypeRegistry.getEmptyTypeRegistry());
   }
 
   @Override
@@ -148,6 +157,7 @@ public class ProtobufFileSerde implements BuiltInSerde {
   @Override
   public Serde.Serializer serializer(String topic, Serde.Target type) {
     var descriptor = descriptorFor(topic, type).orElseThrow();
+    var typeRegistry = typeRegistryFor(descriptor);
     return new Serde.Serializer() {
       @SneakyThrows
       @Override
@@ -164,6 +174,7 @@ public class ProtobufFileSerde implements BuiltInSerde {
   @Override
   public Serde.Deserializer deserializer(String topic, Serde.Target type) {
     var descriptor = descriptorFor(topic, type).orElseThrow();
+    var typeRegistry = typeRegistryFor(descriptor);
     return new Serde.Deserializer() {
       @SneakyThrows
       @Override

--- a/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
+++ b/api/src/main/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerde.java
@@ -40,7 +40,6 @@ import com.squareup.wire.schema.ProtoFile;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ProtoParser;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
-import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaUtils;
 import io.kafbat.ui.exception.ValidationException;
 import io.kafbat.ui.serde.api.DeserializeResult;
 import io.kafbat.ui.serde.api.PropertyResolver;
@@ -77,6 +76,8 @@ public class ProtobufFileSerde implements BuiltInSerde {
   private Map<String, Descriptor> keyMessageDescriptorMap = new HashMap<>();
 
   private Map<Descriptor, Path> descriptorPaths = new HashMap<>();
+
+  private TypeRegistry typeRegistry = TypeRegistry.getEmptyTypeRegistry();
 
   @Nullable
   private Descriptor defaultMessageDescriptor;
@@ -116,6 +117,12 @@ public class ProtobufFileSerde implements BuiltInSerde {
     this.descriptorPaths = configuration.descriptorPaths();
     this.messageDescriptorMap = configuration.messageDescriptorMap();
     this.keyMessageDescriptorMap = configuration.keyMessageDescriptorMap();
+    // TypeRegistry.Builder#add pulls in the descriptor's whole file and its transitive
+    // dependencies, so this covers every type reachable from the configured messages -
+    // which is what google.protobuf.Any fields need to be resolved, in both directions.
+    this.typeRegistry = TypeRegistry.newBuilder()
+        .add(configuration.descriptorPaths().keySet())
+        .build();
   }
 
   private Optional<Descriptor> descriptorFor(String topic, Serde.Target type) {
@@ -141,10 +148,6 @@ public class ProtobufFileSerde implements BuiltInSerde {
   @Override
   public Serde.Serializer serializer(String topic, Serde.Target type) {
     var descriptor = descriptorFor(topic, type).orElseThrow();
-    TypeRegistry typeRegistry = TypeRegistry.newBuilder()
-        .add(descriptorPaths.keySet())
-        .build();
-
     return new Serde.Serializer() {
       @SneakyThrows
       @Override
@@ -166,8 +169,11 @@ public class ProtobufFileSerde implements BuiltInSerde {
       @Override
       public DeserializeResult deserialize(RecordHeaders headers, byte[] data) {
         var protoMsg = DynamicMessage.parseFrom(descriptor, new ByteArrayInputStream(data));
-        byte[] jsonFromProto = ProtobufSchemaUtils.toJson(protoMsg);
-        var result = new String(jsonFromProto);
+        var result = JsonFormat.printer()
+            .usingTypeRegistry(typeRegistry)
+            .includingDefaultValueFields()
+            .omittingInsignificantWhitespace()
+            .print(protoMsg);
         return new DeserializeResult(
             result,
             DeserializeResult.Type.JSON,

--- a/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
+++ b/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
@@ -81,7 +81,7 @@ class ProtobufFileSerdeTest {
   void loadsAllProtoFiledFromTargetDirectory() throws Exception {
     var protoDir = ResourceUtils.getFile("classpath:protobuf-serde/").getPath();
     List<ProtoFile> files = new ProtobufFileSerde.ProtoSchemaLoader(protoDir).load();
-    assertThat(files).hasSize(5);
+    assertThat(files).hasSize(6);
     assertThat(files)
         .map(f -> f.getLocation().getPath())
         .containsExactlyInAnyOrder(
@@ -89,7 +89,8 @@ class ProtobufFileSerdeTest {
             "sensor.proto",
             "address-book.proto",
             "lang-description.proto",
-            "messagewithany.proto"
+            "messagewithany.proto",
+            "messagewithany2.proto"
         );
   }
 
@@ -331,45 +332,65 @@ class ProtobufFileSerdeTest {
         Optional.empty(),
         Optional.of(protoFilesDir())
     );
-    Path messageWithAnyPath = ResourceUtils.getFile("classpath:protobuf-serde/messagewithany.proto").toPath();
-    var messageWithAnySchema = files.get(messageWithAnyPath);
-    var messageWithAnyDescriptor = messageWithAnySchema.toDescriptor("test.MessageWithAny");
 
-    var payloadBuilder = messageWithAnySchema.newMessageBuilder("test.PayloadMessage");
-    JsonFormat.parser().merge("{ \"id\": \"payload-1\" }", payloadBuilder);
+    // Two Any-carrying messages defined in separate proto files, mapped to separate topics.
+    // ProtobufSchema names every FileDescriptor it synthesises "default", so a TypeRegistry
+    // shared between the two descriptors keeps only the first file's types - which would
+    // leave one of these two topics unable to resolve its payload.
+    Path firstPath = ResourceUtils.getFile("classpath:protobuf-serde/messagewithany.proto").toPath();
+    Path secondPath = ResourceUtils.getFile("classpath:protobuf-serde/messagewithany2.proto").toPath();
+    var firstDescriptor = files.get(firstPath).toDescriptor("test.MessageWithAny");
+    var secondDescriptor = files.get(secondPath).toDescriptor("test2.MessageWithAny2");
 
-    var payloadField = messageWithAnyDescriptor.findFieldByName("payload");
-    var anyDescriptor = payloadField.getMessageType();
-    var anyMessage = DynamicMessage.newBuilder(anyDescriptor)
-        .setField(anyDescriptor.findFieldByName("type_url"), "type.googleapis.com/test.PayloadMessage")
-        .setField(anyDescriptor.findFieldByName("value"), payloadBuilder.build().toByteString())
-        .build();
-
-    byte[] messageWithAnyBytes = DynamicMessage.newBuilder(messageWithAnyDescriptor)
-        .setField(messageWithAnyDescriptor.findFieldByName("name"), "with any")
-        .setField(payloadField, anyMessage)
-        .build()
-        .toByteArray();
+    byte[] firstBytes = messageWithAny(
+        files.get(firstPath), firstDescriptor, "test.PayloadMessage", "payload-1");
+    byte[] secondBytes = messageWithAny(
+        files.get(secondPath), secondDescriptor, "test2.PayloadMessage2", "payload-2");
 
     var serde = new ProtobufFileSerde();
     serde.configure(
         new Configuration(
             null,
             null,
-            Map.of(messageWithAnyDescriptor, messageWithAnyPath),
-            Map.of("any-topic", messageWithAnyDescriptor),
+            Map.of(firstDescriptor, firstPath, secondDescriptor, secondPath),
+            Map.of("any-topic", firstDescriptor, "any-topic-2", secondDescriptor),
             Map.of()
         )
     );
 
-    var deserialized = serde.deserializer("any-topic", Serde.Target.VALUE)
-        .deserialize(null, messageWithAnyBytes);
-
     assertJsonEquals(
         "{\"name\": \"with any\", \"payload\": "
             + "{\"@type\": \"type.googleapis.com/test.PayloadMessage\", \"id\": \"payload-1\"}}",
-        deserialized.getResult()
+        serde.deserializer("any-topic", Serde.Target.VALUE).deserialize(null, firstBytes).getResult()
     );
+
+    assertJsonEquals(
+        "{\"name\": \"with any\", \"payload\": "
+            + "{\"@type\": \"type.googleapis.com/test2.PayloadMessage2\", \"id\": \"payload-2\"}}",
+        serde.deserializer("any-topic-2", Serde.Target.VALUE).deserialize(null, secondBytes).getResult()
+    );
+  }
+
+  @SneakyThrows
+  private byte[] messageWithAny(ProtobufSchema schema,
+                                Descriptors.Descriptor descriptor,
+                                String payloadTypeName,
+                                String payloadId) {
+    var payloadBuilder = schema.newMessageBuilder(payloadTypeName);
+    JsonFormat.parser().merge("{ \"id\": \"" + payloadId + "\" }", payloadBuilder);
+
+    var payloadField = descriptor.findFieldByName("payload");
+    var anyDescriptor = payloadField.getMessageType();
+    var anyMessage = DynamicMessage.newBuilder(anyDescriptor)
+        .setField(anyDescriptor.findFieldByName("type_url"), "type.googleapis.com/" + payloadTypeName)
+        .setField(anyDescriptor.findFieldByName("value"), payloadBuilder.build().toByteString())
+        .build();
+
+    return DynamicMessage.newBuilder(descriptor)
+        .setField(descriptor.findFieldByName("name"), "with any")
+        .setField(payloadField, anyMessage)
+        .build()
+        .toByteArray();
   }
 
   @Test

--- a/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
+++ b/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
@@ -340,12 +340,12 @@ class ProtobufFileSerdeTest {
     Path firstPath = ResourceUtils.getFile("classpath:protobuf-serde/messagewithany.proto").toPath();
     Path secondPath = ResourceUtils.getFile("classpath:protobuf-serde/messagewithany2.proto").toPath();
     var firstDescriptor = files.get(firstPath).toDescriptor("test.MessageWithAny");
-    var secondDescriptor = files.get(secondPath).toDescriptor("test2.MessageWithAny2");
+    var secondDescriptor = files.get(secondPath).toDescriptor("test.MessageWithAny2");
 
     byte[] firstBytes = messageWithAny(
         files.get(firstPath), firstDescriptor, "test.PayloadMessage", "payload-1");
     byte[] secondBytes = messageWithAny(
-        files.get(secondPath), secondDescriptor, "test2.PayloadMessage2", "payload-2");
+        files.get(secondPath), secondDescriptor, "test.PayloadMessage2", "payload-2");
 
     var serde = new ProtobufFileSerde();
     serde.configure(
@@ -366,7 +366,7 @@ class ProtobufFileSerdeTest {
 
     assertJsonEquals(
         "{\"name\": \"with any\", \"payload\": "
-            + "{\"@type\": \"type.googleapis.com/test2.PayloadMessage2\", \"id\": \"payload-2\"}}",
+            + "{\"@type\": \"type.googleapis.com/test.PayloadMessage2\", \"id\": \"payload-2\"}}",
         serde.deserializer("any-topic-2", Serde.Target.VALUE).deserialize(null, secondBytes).getResult()
     );
   }

--- a/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
+++ b/api/src/test/java/io/kafbat/ui/serdes/builtin/ProtobufFileSerdeTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.util.JsonFormat;
 import com.squareup.wire.schema.ProtoFile;
 import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
@@ -322,6 +323,53 @@ class ProtobufFileSerdeTest {
     var deserializedBook = serde.deserializer("books", Serde.Target.KEY)
         .deserialize(null, addressBookMessageBytes);
     assertJsonEquals(sampleBookMsgJson, deserializedBook.getResult());
+  }
+
+  @Test
+  void deserializeResolvesAnyPayloadUsingTypesFromLoadedProtoFiles() throws Exception {
+    Map<Path, ProtobufSchema> files = ProtobufFileSerde.Configuration.loadSchemas(
+        Optional.empty(),
+        Optional.of(protoFilesDir())
+    );
+    Path messageWithAnyPath = ResourceUtils.getFile("classpath:protobuf-serde/messagewithany.proto").toPath();
+    var messageWithAnySchema = files.get(messageWithAnyPath);
+    var messageWithAnyDescriptor = messageWithAnySchema.toDescriptor("test.MessageWithAny");
+
+    var payloadBuilder = messageWithAnySchema.newMessageBuilder("test.PayloadMessage");
+    JsonFormat.parser().merge("{ \"id\": \"payload-1\" }", payloadBuilder);
+
+    var payloadField = messageWithAnyDescriptor.findFieldByName("payload");
+    var anyDescriptor = payloadField.getMessageType();
+    var anyMessage = DynamicMessage.newBuilder(anyDescriptor)
+        .setField(anyDescriptor.findFieldByName("type_url"), "type.googleapis.com/test.PayloadMessage")
+        .setField(anyDescriptor.findFieldByName("value"), payloadBuilder.build().toByteString())
+        .build();
+
+    byte[] messageWithAnyBytes = DynamicMessage.newBuilder(messageWithAnyDescriptor)
+        .setField(messageWithAnyDescriptor.findFieldByName("name"), "with any")
+        .setField(payloadField, anyMessage)
+        .build()
+        .toByteArray();
+
+    var serde = new ProtobufFileSerde();
+    serde.configure(
+        new Configuration(
+            null,
+            null,
+            Map.of(messageWithAnyDescriptor, messageWithAnyPath),
+            Map.of("any-topic", messageWithAnyDescriptor),
+            Map.of()
+        )
+    );
+
+    var deserialized = serde.deserializer("any-topic", Serde.Target.VALUE)
+        .deserialize(null, messageWithAnyBytes);
+
+    assertJsonEquals(
+        "{\"name\": \"with any\", \"payload\": "
+            + "{\"@type\": \"type.googleapis.com/test.PayloadMessage\", \"id\": \"payload-1\"}}",
+        deserialized.getResult()
+    );
   }
 
   @Test

--- a/api/src/test/resources/protobuf-serde/messagewithany2.proto
+++ b/api/src/test/resources/protobuf-serde/messagewithany2.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+package test2;
+
+import "google/protobuf/any.proto";
+
+message MessageWithAny2  {
+    string name = 1;
+    google.protobuf.Any payload = 2;
+}
+
+message PayloadMessage2  {
+    string id = 1;
+}

--- a/api/src/test/resources/protobuf-serde/messagewithany2.proto
+++ b/api/src/test/resources/protobuf-serde/messagewithany2.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
-package test2;
+package test;
 
 import "google/protobuf/any.proto";
 


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Closes #1730.

`ProtobufFileSerde` already builds a `TypeRegistry` for the serialize path, but the deserializer converted the parsed message with `ProtobufSchemaUtils.toJson(...)`, which is `JsonFormat.printer()` with no registry. protobuf-java throws on a `google.protobuf.Any` whose `type_url` it can't resolve, so any message carrying an `Any` payload failed to deserialize and the UI silently fell back to the string serde.

The registry now gets built once in `configure(...)` and is used on both paths. On the read path:

```java
JsonFormat.printer()
    .usingTypeRegistry(typeRegistry)
    .includingDefaultValueFields()
    .omittingInsignificantWhitespace()
    .print(protoMsg)
```

Two details worth noting:

- The printer options match what `ProtobufSchemaUtils.toJson` was using, so output for messages without `Any` fields is byte-identical to before. The snippet in the issue drops them, which would have changed existing output.
- `TypeRegistry.Builder#add` pulls in the descriptor's whole file plus its transitive dependencies, so nothing extra needs configuring - the payload types only have to be reachable from the protos already loaded through `protobufFilesDir` / `protobufFiles`.

Also drops the now-unused `ProtobufSchemaUtils` import, and stops rebuilding the registry on every `serializer(...)` call.

**Is there anything you'd like reviewers to focus on?**

Whether the registry should cover *all* loaded proto files rather than just the files reachable from the configured descriptors. Reachability is enough for the common case (the payload types usually live alongside the envelope) and it keeps this symmetric with the existing serializer behaviour, but a payload type defined in an unrelated file that nothing else imports would still be unresolvable. Happy to widen it if you'd prefer.

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [ ] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Added `deserializeResolvesAnyPayloadUsingTypesFromLoadedProtoFiles` to `ProtobufFileSerdeTest`, using the `messagewithany.proto` resource that was already in the tree. It builds a `MessageWithAny` wrapping a packed `test.PayloadMessage` and asserts the deserialized JSON unpacks it:

```json
{"name": "with any", "payload": {"@type": "type.googleapis.com/test.PayloadMessage", "id": "payload-1"}}
```

Without the fix that test fails with `Cannot find type for url: type.googleapis.com/test.PayloadMessage`.

Also confirmed the test fails on `main` and passes with the change, and verified end to end on a real cluster: a topic whose records are a generic event envelope carrying a `google.protobuf.Any` payload. On v1.5.0, with the envelope type mapped through `protobufMessageNameByTopic` and the payload types present in the same `protobufFilesDir`, every message came back as `valueSerde: Fallback` with the `Cannot find type for url` exception in the trace log. With this patch the same topic renders as fully named JSON with the payload unpacked.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Protobuf serialization and deserialization across multiple configured schema descriptors.
  - Protobuf `Any` payloads are now correctly resolved using the appropriate descriptor and displayed as expanded JSON.
  - JSON output consistently includes default fields and uses compact formatting.

- **Tests**
  - Added coverage for loading multiple proto files and resolving `Any` payloads from separate schemas and topics.
  - Added validation for handling multiple message types with `Any` payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->