### PR TITLE
Use relative OpenAPI server for Swagger "Try it out" to hit current host

### DIFF
--- a/api/src/main/resources/static/openapi/kafbat-ui-api.yaml
+++ b/api/src/main/resources/static/openapi/kafbat-ui-api.yaml
@@ -5520,6 +5520,6 @@ components:
           items:
             $ref: '#/components/schemas/Action'
 servers:
-  - url: http://localhost:8080
-    description: Default endpoint for Kafbat UI API
+  - url: /
+    description: Current host
     variables: {}

--- a/contract-typespec/api/main.tsp
+++ b/contract-typespec/api/main.tsp
@@ -28,6 +28,6 @@ using Rest;
   license: #{ name: "Apache 2.0", url: "https://www.apache.org/licenses/LICENSE-2.0.html" },
   version: "0.2.0"
 })
-@server("http://localhost:8080", "Default endpoint for Kafbat UI API")
+@server("/", "Current host")
 namespace Api;
 

--- a/contract/src/main/resources/swagger/kafbat-ui-api.yaml
+++ b/contract/src/main/resources/swagger/kafbat-ui-api.yaml
@@ -12,7 +12,7 @@ tags:
   - name: /api/clusters
   - name: /api/clusters/connects
 servers:
-  - url: /localhost
+  - url: /
 
 paths:
   /api/clusters:


### PR DESCRIPTION
Fixes #1968

### Changes

- TypeSpec `@server("/")`
- Static OpenAPI `servers.url: /`
- Legacy contract swagger `servers.url: /` (was `/localhost`)

### Test plan

- [x] `SWAGGER_UI_ENABLED=true`, open `/swagger-ui.html` on a non-localhost deploy
- [x] Log in via UI, **Clusters → getClusters → Execute**
- [x] Expect request to current host and same result as `/api/clusters`
- [x] Localhost still works (relative `/` resolves to current origin)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated API documentation and contracts to use the current host automatically instead of a fixed local server address.
  * Improved API access when the application is hosted in environments other than the default local setup.

* **Documentation**
  * Updated server endpoint descriptions to clearly identify the current API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->