### PR TITLE
Show Start Analysis empty state when topic analysis has never been run

### DIFF
--- a/api/src/main/java/io/kafbat/ui/controller/TopicsController.java
+++ b/api/src/main/java/io/kafbat/ui/controller/TopicsController.java
@@ -379,7 +379,7 @@ public class TopicsController extends AbstractController implements TopicsApi, M
     return validateAccess(context)
         .thenReturn(topicAnalysisService.getTopicAnalysis(getCluster(clusterName), topicName)
             .map(ResponseEntity::ok)
-            .orElseGet(() -> ResponseEntity.notFound().build()))
+            .orElseGet(() -> ResponseEntity.ok(new TopicAnalysisDTO())))
         .doOnEach(sig -> audit(context, sig));
   }
 

--- a/frontend/src/components/Topics/Topic/Statistics/Metrics.tsx
+++ b/frontend/src/components/Topics/Topic/Statistics/Metrics.tsx
@@ -44,6 +44,28 @@ const Metrics: React.FC = () => {
     return null;
   }
 
+  if (!data.progress && !data.result) {
+    return (
+      <S.ProgressContainer>
+        <ActionButton
+          onClick={async () => {
+            await analyzeTopic.mutateAsync();
+            setIsAnalyzing(true);
+          }}
+          buttonType="primary"
+          buttonSize="M"
+          permission={{
+            resource: ResourceType.TOPIC,
+            action: Action.ANALYSIS_RUN,
+            value: params.topicName,
+          }}
+        >
+          Start Analysis
+        </ActionButton>
+      </S.ProgressContainer>
+    );
+  }
+
   if (data.progress) {
     return (
       <S.ProgressContainer>

--- a/frontend/src/components/Topics/Topic/Statistics/__test__/Metrics.spec.tsx
+++ b/frontend/src/components/Topics/Topic/Statistics/__test__/Metrics.spec.tsx
@@ -115,11 +115,17 @@ describe('Metrics', () => {
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });
-  it('returns empty container', () => {
+  it('renders Start Analysis when analysis has never been run', () => {
     (useTopicAnalysis as jest.Mock).mockImplementation(() => ({
       data: {},
     }));
+    (useAnalyzeTopic as jest.Mock).mockImplementation(() => ({
+      mutateAsync: jest.fn(),
+    }));
     renderComponent();
+    expect(
+      screen.getByRole('button', { name: 'Start Analysis' })
+    ).toBeInTheDocument();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.queryByRole('progressbar')).not.toBeInTheDocument();
   });

--- a/frontend/src/lib/hooks/api/topics.ts
+++ b/frontend/src/lib/hooks/api/topics.ts
@@ -356,10 +356,7 @@ export function useTopicAnalysis(
 
   React.useEffect(() => {
     if (queryResult.error) {
-      const error = queryResult.error as unknown as Response;
-      if (error?.status !== 404) {
-        showServerError(error);
-      }
+      showServerError(queryResult.error as unknown as Response);
     }
   }, [queryResult.error]);
 


### PR DESCRIPTION
Fixes #1942

### Changes

* Backend: return empty `TopicAnalysisDTO` with `200` instead of `404` when analysis has never been started
* Frontend: render **Start Analysis** empty state in `Metrics` when response has no `progress`/`result`
* Drop the `useTopicAnalysis` 404 toast workaround (no longer needed)

### Test plan

* [x] Open Statistics for a topic that has never been analyzed → **Start Analysis**, no UI error, no `404` in console
* [x] Start analysis → progress UI works as before
* [x] After analysis completes → metrics / **Restart Analysis** as before
* [x] Real API errors (e.g. 500) still go through ErrorBoundary / toast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a **Start Analysis** button when no topic analysis has been started.
  - Users can start analysis directly from the topic statistics view.

- **Improvements**
  - Topics without analysis results now load successfully with an empty analysis state.
  - Analysis errors, including not-found responses, are surfaced to users.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->