### PR TITLE
Add Streamable HTTP transport for MCP endpoint

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -102,6 +102,7 @@ dependencies {
     implementation libs.lz4.yawk
 
     implementation libs.modelcontextprotocol.spring.webflux
+    implementation libs.modelcontextprotocol.json.jackson2
     implementation libs.victools.jsonschema.generator
 
 

--- a/api/src/main/java/io/kafbat/ui/config/McpConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/McpConfig.java
@@ -22,6 +22,21 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RouterFunction;
 
+/**
+ * Spring configuration that wires up the Model Context Protocol (MCP) server.
+ *
+ * <p>Only active when {@code mcp.enabled=true}. Two transports can be exposed,
+ * selected by the {@code mcp.transport} property
+ * ({@link McpProperties.Transport}):
+ * <ul>
+ *   <li>the legacy HTTP+SSE transport ({@code /mcp/sse} + {@code /mcp/message}),
+ *       deprecated in the MCP spec (2025-06-18); and</li>
+ *   <li>the current Streamable HTTP transport (a single {@code /mcp} endpoint).</li>
+ * </ul>
+ * Each active transport is backed by its own {@link McpAsyncServer} exposing the
+ * same set of tools, and its {@link RouterFunction} is picked up by Spring
+ * WebFlux.
+ */
 @Configuration
 @RequiredArgsConstructor
 @EnableConfigurationProperties(McpProperties.class)
@@ -44,8 +59,15 @@ public class McpConfig {
   private final List<McpTool> mcpTools;
   private final McpSpecificationGenerator mcpSpecificationGenerator;
 
-  // The MCP SDK (0.18.x) abstracts JSON handling behind McpJsonMapper; reuse the
-  // application's configured Jackson ObjectMapper.
+  /**
+   * Adapts the application's Jackson {@link ObjectMapper} to the SDK's
+   * {@link McpJsonMapper} abstraction (introduced in mcp-spring-webflux 0.18.x),
+   * so MCP JSON (de)serialization uses the same configuration as the rest of the
+   * app.
+   *
+   * @param mapper the shared application {@link ObjectMapper}
+   * @return an {@link McpJsonMapper} backed by {@code mapper}
+   */
   @Bean
   public McpJsonMapper mcpJsonMapper(ObjectMapper mapper) {
     return new JacksonMcpJsonMapper(mapper);
@@ -55,6 +77,14 @@ public class McpConfig {
   // Legacy SSE transport
   // ---------------------------------------------------------------------------
 
+  /**
+   * Creates the legacy HTTP+SSE transport provider (endpoints {@code /mcp/sse}
+   * and {@code /mcp/message}). Only registered when {@code mcp.transport} is
+   * {@code SSE} or {@code BOTH}.
+   *
+   * @param jsonMapper the MCP JSON mapper
+   * @return the SSE transport provider
+   */
   @Bean
   @ConditionalOnExpression(SSE_ENABLED)
   public WebFluxSseServerTransportProvider sseServerTransport(McpJsonMapper jsonMapper) {
@@ -65,12 +95,26 @@ public class McpConfig {
         .build();
   }
 
+  /**
+   * Exposes the SSE transport's routes to Spring WebFlux. Only present when the
+   * SSE transport provider bean exists.
+   *
+   * @param transport the SSE transport provider
+   * @return the router function serving the SSE endpoints
+   */
   @Bean
   @ConditionalOnBean(WebFluxSseServerTransportProvider.class)
   public RouterFunction<?> mcpSseRouterFunction(WebFluxSseServerTransportProvider transport) {
     return transport.getRouterFunction();
   }
 
+  /**
+   * Builds the {@link McpAsyncServer} bound to the SSE transport. Only present
+   * when the SSE transport provider bean exists.
+   *
+   * @param transport the SSE transport provider
+   * @return the MCP async server for the SSE transport
+   */
   @Bean
   @ConditionalOnBean(WebFluxSseServerTransportProvider.class)
   public McpAsyncServer mcpSseServer(WebFluxSseServerTransportProvider transport) {
@@ -85,6 +129,14 @@ public class McpConfig {
   // Streamable HTTP transport
   // ---------------------------------------------------------------------------
 
+  /**
+   * Creates the current Streamable HTTP transport provider (single {@code /mcp}
+   * endpoint). Only registered when {@code mcp.transport} is {@code STREAMABLE}
+   * or {@code BOTH}.
+   *
+   * @param jsonMapper the MCP JSON mapper
+   * @return the Streamable HTTP transport provider
+   */
   @Bean
   @ConditionalOnExpression(STREAMABLE_ENABLED)
   public WebFluxStreamableServerTransportProvider streamableServerTransport(McpJsonMapper jsonMapper) {
@@ -94,12 +146,26 @@ public class McpConfig {
         .build();
   }
 
+  /**
+   * Exposes the Streamable HTTP transport's routes to Spring WebFlux. Only
+   * present when the Streamable HTTP transport provider bean exists.
+   *
+   * @param transport the Streamable HTTP transport provider
+   * @return the router function serving the {@code /mcp} endpoint
+   */
   @Bean
   @ConditionalOnBean(WebFluxStreamableServerTransportProvider.class)
   public RouterFunction<?> mcpStreamableRouterFunction(WebFluxStreamableServerTransportProvider transport) {
     return transport.getRouterFunction();
   }
 
+  /**
+   * Builds the {@link McpAsyncServer} bound to the Streamable HTTP transport.
+   * Only present when the Streamable HTTP transport provider bean exists.
+   *
+   * @param transport the Streamable HTTP transport provider
+   * @return the MCP async server for the Streamable HTTP transport
+   */
   @Bean
   @ConditionalOnBean(WebFluxStreamableServerTransportProvider.class)
   public McpAsyncServer mcpStreamableServer(WebFluxStreamableServerTransportProvider transport) {
@@ -112,6 +178,13 @@ public class McpConfig {
 
   // ---------------------------------------------------------------------------
 
+  /**
+   * Declares the MCP server capabilities shared by every transport: tools (with
+   * list-change notifications), read-only resources, and logging; prompts are
+   * disabled.
+   *
+   * @return the configured {@link McpSchema.ServerCapabilities}
+   */
   private McpSchema.ServerCapabilities capabilities() {
     return McpSchema.ServerCapabilities.builder()
         .resources(false, true) // Resource support with list changes notifications
@@ -121,6 +194,12 @@ public class McpConfig {
         .build();
   }
 
+  /**
+   * Collects the tool specifications exposed to MCP clients by converting every
+   * {@link McpTool} bean via {@link McpSpecificationGenerator}.
+   *
+   * @return the list of tool specifications
+   */
   private List<AsyncToolSpecification> tools() {
     List<AsyncToolSpecification> tools = new ArrayList<>();
     for (McpTool mcpTool : mcpTools) {

--- a/api/src/main/java/io/kafbat/ui/config/McpConfig.java
+++ b/api/src/main/java/io/kafbat/ui/config/McpConfig.java
@@ -3,57 +3,121 @@ package io.kafbat.ui.config;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.kafbat.ui.service.mcp.McpSpecificationGenerator;
 import io.kafbat.ui.service.mcp.McpTool;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
 import io.modelcontextprotocol.server.McpAsyncServer;
 import io.modelcontextprotocol.server.McpServer;
 import io.modelcontextprotocol.server.McpServerFeatures.AsyncToolSpecification;
 import io.modelcontextprotocol.server.transport.WebFluxSseServerTransportProvider;
+import io.modelcontextprotocol.server.transport.WebFluxStreamableServerTransportProvider;
 import io.modelcontextprotocol.spec.McpSchema;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.reactive.function.server.RouterFunction;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableConfigurationProperties(McpProperties.class)
 @ConditionalOnProperty(value = "mcp.enabled", havingValue = "true")
 public class McpConfig {
+
+  // Legacy SSE transport (deprecated in MCP spec 2025-06-18): two endpoints.
+  private static final String SSE_MESSAGE_ENDPOINT = "/mcp/message";
+  private static final String SSE_ENDPOINT = "/mcp/sse";
+  // Streamable HTTP transport (current MCP spec): a single endpoint.
+  private static final String STREAMABLE_ENDPOINT = "/mcp";
+
+  private static final String SSE_ENABLED =
+      "T(java.lang.String).valueOf('${mcp.transport:BOTH}').equalsIgnoreCase('SSE') "
+      + "|| T(java.lang.String).valueOf('${mcp.transport:BOTH}').equalsIgnoreCase('BOTH')";
+  private static final String STREAMABLE_ENABLED =
+      "T(java.lang.String).valueOf('${mcp.transport:BOTH}').equalsIgnoreCase('STREAMABLE') "
+      + "|| T(java.lang.String).valueOf('${mcp.transport:BOTH}').equalsIgnoreCase('BOTH')";
 
   private final List<McpTool> mcpTools;
   private final McpSpecificationGenerator mcpSpecificationGenerator;
 
-  // SSE transport
+  // The MCP SDK (0.18.x) abstracts JSON handling behind McpJsonMapper; reuse the
+  // application's configured Jackson ObjectMapper.
   @Bean
-  public WebFluxSseServerTransportProvider sseServerTransport(ObjectMapper mapper) {
-    return new WebFluxSseServerTransportProvider(mapper, "/mcp/message", "/mcp/sse");
+  public McpJsonMapper mcpJsonMapper(ObjectMapper mapper) {
+    return new JacksonMcpJsonMapper(mapper);
   }
 
-  // Router function for SSE transport used by Spring WebFlux to start an HTTP
-  // server.
+  // ---------------------------------------------------------------------------
+  // Legacy SSE transport
+  // ---------------------------------------------------------------------------
 
   @Bean
-  public RouterFunction<?> mcpRouterFunction(WebFluxSseServerTransportProvider transport) {
+  @ConditionalOnExpression(SSE_ENABLED)
+  public WebFluxSseServerTransportProvider sseServerTransport(McpJsonMapper jsonMapper) {
+    return WebFluxSseServerTransportProvider.builder()
+        .jsonMapper(jsonMapper)
+        .messageEndpoint(SSE_MESSAGE_ENDPOINT)
+        .sseEndpoint(SSE_ENDPOINT)
+        .build();
+  }
+
+  @Bean
+  @ConditionalOnBean(WebFluxSseServerTransportProvider.class)
+  public RouterFunction<?> mcpSseRouterFunction(WebFluxSseServerTransportProvider transport) {
     return transport.getRouterFunction();
   }
 
   @Bean
-  public McpAsyncServer mcpServer(WebFluxSseServerTransportProvider transport) {
+  @ConditionalOnBean(WebFluxSseServerTransportProvider.class)
+  public McpAsyncServer mcpSseServer(WebFluxSseServerTransportProvider transport) {
+    return McpServer.async(transport)
+        .serverInfo("Kafka UI MCP", "0.0.1")
+        .capabilities(capabilities())
+        .tools(tools())
+        .build();
+  }
 
-    // Configure server capabilities with resource support
-    var capabilities = McpSchema.ServerCapabilities.builder()
-        .resources(false, true)
+  // ---------------------------------------------------------------------------
+  // Streamable HTTP transport
+  // ---------------------------------------------------------------------------
+
+  @Bean
+  @ConditionalOnExpression(STREAMABLE_ENABLED)
+  public WebFluxStreamableServerTransportProvider streamableServerTransport(McpJsonMapper jsonMapper) {
+    return WebFluxStreamableServerTransportProvider.builder()
+        .jsonMapper(jsonMapper)
+        .messageEndpoint(STREAMABLE_ENDPOINT)
+        .build();
+  }
+
+  @Bean
+  @ConditionalOnBean(WebFluxStreamableServerTransportProvider.class)
+  public RouterFunction<?> mcpStreamableRouterFunction(WebFluxStreamableServerTransportProvider transport) {
+    return transport.getRouterFunction();
+  }
+
+  @Bean
+  @ConditionalOnBean(WebFluxStreamableServerTransportProvider.class)
+  public McpAsyncServer mcpStreamableServer(WebFluxStreamableServerTransportProvider transport) {
+    return McpServer.async(transport)
+        .serverInfo("Kafka UI MCP", "0.0.1")
+        .capabilities(capabilities())
+        .tools(tools())
+        .build();
+  }
+
+  // ---------------------------------------------------------------------------
+
+  private McpSchema.ServerCapabilities capabilities() {
+    return McpSchema.ServerCapabilities.builder()
+        .resources(false, true) // Resource support with list changes notifications
         .tools(true) // Tools support with list changes notifications
         .prompts(false) // Prompt support with list changes notifications
         .logging() // Logging support
-        .build();
-
-    // Create the server with both tools and resource capabilities
-    return McpServer.async(transport)
-        .serverInfo("Kafka UI MCP", "0.0.1")
-        .capabilities(capabilities)
-        .tools(tools())
         .build();
   }
 

--- a/api/src/main/java/io/kafbat/ui/config/McpProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/McpProperties.java
@@ -3,10 +3,18 @@ package io.kafbat.ui.config;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * Configuration properties for the MCP (Model Context Protocol) server, bound
+ * from the {@code mcp.*} namespace (e.g. {@code mcp.enabled},
+ * {@code mcp.transport} / {@code MCP_ENABLED}, {@code MCP_TRANSPORT}).
+ */
 @Data
 @ConfigurationProperties("mcp")
 public class McpProperties {
 
+  /**
+   * Whether the MCP server is enabled. Defaults to {@code false}.
+   */
   private boolean enabled = false;
 
   /**
@@ -17,15 +25,35 @@ public class McpProperties {
    */
   private Transport transport = Transport.BOTH;
 
+  /** The MCP transport modes that can be exposed. */
   public enum Transport {
+    /**
+     * Legacy HTTP+SSE transport only ({@code /mcp/sse} + {@code /mcp/message}).
+     */
     SSE,
+    /**
+     * Current Streamable HTTP transport only (single {@code /mcp} endpoint).
+     */
     STREAMABLE,
+    /**
+     * Expose both the SSE and Streamable HTTP transports simultaneously.
+     */
     BOTH;
 
+    /**
+     * Whether the legacy SSE transport should be active for this mode.
+     *
+     * @return {@code true} for {@link #SSE} and {@link #BOTH}
+     */
     public boolean sseEnabled() {
       return this == SSE || this == BOTH;
     }
 
+    /**
+     * Whether the Streamable HTTP transport should be active for this mode.
+     *
+     * @return {@code true} for {@link #STREAMABLE} and {@link #BOTH}
+     */
     public boolean streamableEnabled() {
       return this == STREAMABLE || this == BOTH;
     }

--- a/api/src/main/java/io/kafbat/ui/config/McpProperties.java
+++ b/api/src/main/java/io/kafbat/ui/config/McpProperties.java
@@ -1,0 +1,33 @@
+package io.kafbat.ui.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("mcp")
+public class McpProperties {
+
+  private boolean enabled = false;
+
+  /**
+   * Which MCP transport(s) to expose. Streamable HTTP is the current MCP spec
+   * transport (single {@code /mcp} endpoint); SSE is the deprecated legacy
+   * transport ({@code /mcp/sse} + {@code /mcp/message}) kept for backwards
+   * compatibility. Defaults to {@link Transport#BOTH}.
+   */
+  private Transport transport = Transport.BOTH;
+
+  public enum Transport {
+    SSE,
+    STREAMABLE,
+    BOTH;
+
+    public boolean sseEnabled() {
+      return this == SSE || this == BOTH;
+    }
+
+    public boolean streamableEnabled() {
+      return this == STREAMABLE || this == BOTH;
+    }
+  }
+}

--- a/api/src/main/java/io/kafbat/ui/service/mcp/McpSpecificationGenerator.java
+++ b/api/src/main/java/io/kafbat/ui/service/mcp/McpSpecificationGenerator.java
@@ -73,7 +73,11 @@ public class McpSpecificationGenerator {
     Method interfaceMethod = findAnnotatedMethod(method, instance);
     boolean isWriteOperation = isWriteMethod(interfaceMethod, name);
     return new AsyncToolSpecification(
-        new McpSchema.Tool(name, description, operationSchema(method, interfaceMethod)),
+        McpSchema.Tool.builder()
+            .name(name)
+            .description(description)
+            .inputSchema(operationSchema(method, interfaceMethod))
+            .build(),
         methodCall(method, instance, isWriteOperation)
     );
   }

--- a/api/src/test/java/io/kafbat/ui/service/mcp/McpSpecificationGeneratorTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/mcp/McpSpecificationGeneratorTest.java
@@ -66,35 +66,35 @@ class McpSpecificationGeneratorTest {
 
     assertThat(specifications).hasSize(17);
     List<McpSchema.Tool> tools = List.of(
-        new McpSchema.Tool(
-            "recreateTopic",
-            "recreateTopic",
-            new McpSchema.JsonSchema("object", Map.of(
+        McpSchema.Tool.builder()
+            .name("recreateTopic")
+            .description("recreateTopic")
+            .inputSchema(new McpSchema.JsonSchema("object", Map.of(
                 "clusterName", Map.of("type", "string"),
                 "topicName", Map.of("type", "string")
-            ), List.of("clusterName", "topicName"), false, null, null)
-        ),
-        new McpSchema.Tool(
-            "getTopicConfigs",
-            "getTopicConfigs",
-            new McpSchema.JsonSchema("object", Map.of(
+            ), List.of("clusterName", "topicName"), false, null, null))
+            .build(),
+        McpSchema.Tool.builder()
+            .name("getTopicConfigs")
+            .description("getTopicConfigs")
+            .inputSchema(new McpSchema.JsonSchema("object", Map.of(
                 "clusterName", Map.of("type", "string"),
                 "topicName", Map.of("type", "string")
-            ), List.of("clusterName", "topicName"), false, null, null)
-        ),
-        new McpSchema.Tool(
-            "cloneTopic",
-            "cloneTopic",
-            new McpSchema.JsonSchema("object", Map.of(
+            ), List.of("clusterName", "topicName"), false, null, null))
+            .build(),
+        McpSchema.Tool.builder()
+            .name("cloneTopic")
+            .description("cloneTopic")
+            .inputSchema(new McpSchema.JsonSchema("object", Map.of(
                 "clusterName", Map.of("type", "string"),
                 "topicName", Map.of("type", "string"),
                 "newTopicName", Map.of("type", "string")
-            ), List.of("clusterName", "topicName", "newTopicName"), false, null, null)
-        ),
-        new McpSchema.Tool(
-            "getTopics",
-            "getTopics",
-            new McpSchema.JsonSchema("object", Map.of(
+            ), List.of("clusterName", "topicName", "newTopicName"), false, null, null))
+            .build(),
+        McpSchema.Tool.builder()
+            .name("getTopics")
+            .description("getTopics")
+            .inputSchema(new McpSchema.JsonSchema("object", Map.of(
                 "clusterName", Map.of("type", "string"),
                 "page", Map.of("type", "integer"),
                 "perPage", Map.of("type", "integer"),
@@ -103,17 +103,17 @@ class McpSpecificationGeneratorTest {
                 "orderBy", SCHEMA_GENERATOR.generateSchema(TopicColumnsToSortDTO.class),
                 "sortOrder", SCHEMA_GENERATOR.generateSchema(SortOrderDTO.class),
                 "fts", Map.of("type", "boolean")
-            ), List.of("clusterName"), false, null, null)
-        ),
-        new McpSchema.Tool(
-            "updateTopic",
-            "updateTopic",
-            new McpSchema.JsonSchema("object", Map.of(
+            ), List.of("clusterName"), false, null, null))
+            .build(),
+        McpSchema.Tool.builder()
+            .name("updateTopic")
+            .description("updateTopic")
+            .inputSchema(new McpSchema.JsonSchema("object", Map.of(
                 "clusterName", Map.of("type", "string"),
                 "topicName", Map.of("type", "string"),
                 "topicUpdate", SCHEMA_GENERATOR.generateSchema(TopicUpdateDTO.class)
-            ), List.of("clusterName", "topicName", "topicUpdate"), false, null, null)
-        )
+            ), List.of("clusterName", "topicName", "topicUpdate"), false, null, null))
+            .build()
     );
     assertThat(tools).allMatch(tool ->
         specifications.stream().anyMatch(s -> s.tool().equals(tool))

--- a/documentation/compose/DOCKER_COMPOSE.md
+++ b/documentation/compose/DOCKER_COMPOSE.md
@@ -11,3 +11,19 @@
 9. [kafka-ui-traefik-proxy.yaml](./traefik-proxy.yaml) - Traefik-specific proxy configuration.
 10. [kafka-ui-with-jmx-exporter.yaml](./ui-with-jmx-exporter.yaml) - A configuration with 2 Kafka clusters with enabled Prometheus JMX exporters instead of JMX.
 11. [kafka-with-zookeeper.yaml](./kafka-zookeeper.yaml) - An example of using Kafka with ZooKeeper.
+12. [kafbat-ui-mcp.yaml](./kafbat-ui-mcp.yaml) - Enables the MCP (Model Context Protocol) server for AI clients. `MCP_ENABLED` / `MCP_TRANSPORT` are ordinary Spring Boot properties, so they can be set either as environment variables (as in the compose example) or via a config file:
+
+    | Property | Environment variable | Values (default) |
+    | --- | --- | --- |
+    | `mcp.enabled` | `MCP_ENABLED` | `true` / `false` (`false`) |
+    | `mcp.transport` | `MCP_TRANSPORT` | `STREAMABLE` \| `SSE` \| `BOTH` (`BOTH`) |
+
+    YAML equivalent of the compose example:
+
+    ```yaml
+    mcp:
+      enabled: true
+      transport: STREAMABLE   # STREAMABLE | SSE | BOTH (case-insensitive)
+    ```
+
+    `STREAMABLE` exposes a single `/mcp` endpoint (current MCP spec); `SSE` exposes the deprecated legacy `/mcp/sse` + `/mcp/message` endpoints.

--- a/documentation/compose/kafbat-ui-mcp.yaml
+++ b/documentation/compose/kafbat-ui-mcp.yaml
@@ -1,0 +1,69 @@
+---
+# Example configuration that enables the built-in MCP (Model Context Protocol)
+# server so AI agents/clients (e.g. Claude Code, Cursor, opencode) can talk to
+# Kafbat UI.
+#
+# MCP options (Spring properties -> environment variables):
+#   mcp.enabled   -> MCP_ENABLED    Enable the MCP server (default: false).
+#   mcp.transport -> MCP_TRANSPORT  Which transport(s) to expose:
+#       STREAMABLE  Streamable HTTP (current MCP spec) - single endpoint:
+#                     POST/GET/DELETE http://<host>:8080/mcp
+#       SSE         Legacy HTTP+SSE transport (deprecated in MCP spec
+#                   2025-06-18) - two endpoints:
+#                     GET  http://<host>:8080/mcp/sse       (event stream)
+#                     POST http://<host>:8080/mcp/message   (client -> server)
+#       BOTH        Expose both transports simultaneously (default).
+#
+# These are ordinary Spring Boot properties, so they can be set either as the
+# environment variables used below or via a mounted config file, e.g.:
+#
+#   mcp:
+#     enabled: true
+#     transport: STREAMABLE   # STREAMABLE | SSE | BOTH (case-insensitive)
+#
+# Prefer STREAMABLE for modern clients: it is a single HTTP endpoint and lets
+# clients send an `Authorization` header on every request. SSE is kept only for
+# backwards compatibility with older clients.
+version: '2'
+services:
+
+  kafbat-ui:
+    container_name: kafbat-ui
+    image: ghcr.io/kafbat/kafka-ui:latest
+    ports:
+      - 8080:8080
+    depends_on:
+      - kafka0
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka0:29092
+      DYNAMIC_CONFIG_ENABLED: 'true'
+      # --- MCP server ---
+      MCP_ENABLED: 'true'
+      MCP_TRANSPORT: STREAMABLE   # STREAMABLE | SSE | BOTH
+
+  kafka0:
+    image: confluentinc/cp-kafka:7.8.0
+    hostname: kafka0
+    container_name: kafka0
+    ports:
+      - "9092:9092"
+      - "9997:9997"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT'
+      KAFKA_ADVERTISED_LISTENERS: 'PLAINTEXT://kafka0:29092,PLAINTEXT_HOST://localhost:9092'
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_JMX_PORT: 9997
+      KAFKA_JMX_OPTS: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=kafka0 -Dcom.sun.management.jmxremote.rmi.port=9997
+      KAFKA_PROCESS_ROLES: 'broker,controller'
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: '1@kafka0:29093'
+      KAFKA_LISTENERS: 'PLAINTEXT://kafka0:29092,CONTROLLER://kafka0:29093,PLAINTEXT_HOST://0.0.0.0:9092'
+      KAFKA_INTER_BROKER_LISTENER_NAME: 'PLAINTEXT'
+      KAFKA_CONTROLLER_LISTENER_NAMES: 'CONTROLLER'
+      KAFKA_LOG_DIRS: '/tmp/kraft-combined-logs'
+      CLUSTER_ID: 'MkU3OEVBNTcwNTJENDM2Qk'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -131,7 +131,8 @@ bouncycastle-bcpkix = { module = 'org.bouncycastle:bcpkix-jdk18on', version = '1
 google-managed-kafka-login-handler = {module = 'com.google.cloud.hosted.kafka:managed-kafka-auth-login-handler', version = '1.0.5'}
 google-oauth-client = { module = 'com.google.oauth-client:google-oauth-client', version = '1.39.0' }
 
-modelcontextprotocol-spring-webflux = {module = 'io.modelcontextprotocol.sdk:mcp-spring-webflux', version = '0.10.0'}
+modelcontextprotocol-spring-webflux = {module = 'io.modelcontextprotocol.sdk:mcp-spring-webflux', version = '0.18.2'}
+modelcontextprotocol-json-jackson2 = {module = 'io.modelcontextprotocol.sdk:mcp-json-jackson2', version = '0.18.2'}
 victools-jsonschema-generator = {module = 'com.github.victools:jsonschema-generator', version = '4.38.0'}
 
 prometheus-metrics-core = {module = 'io.prometheus:prometheus-metrics-core', version.ref = 'prometheus'}


### PR DESCRIPTION
The MCP endpoint only supported the legacy HTTP+SSE transport (`GET /mcp/sse` + `POST /mcp/message`), which is deprecated in the MCP spec (2025-06-18). Modern MCP clients (Claude Code, Cursor, opencode) speak Streamable HTTP and cannot connect.

This addresses issue #1137 and is a precursor to an additional PR adding the required framework to allow Clause/Opencode/etc to easily authenticate to the MSP endpoint.

**What changes did you make?**
Bumped mcp-spring-webflux 0.10.0 -> 0.18.2 and exposed the reactive `WebFluxStreamableServerTransportProvider` at a single `/mcp` endpoint alongside the existing SSE routes. A new `mcp.transport` property (SSE | STREAMABLE | BOTH, default BOTH) selects which transport(s) are active, keeping full backwards compatibility.

Notes on the SDK upgrade (0.18.x is not purely additive):
- transport providers now build via builders taking McpJsonMapper; added the mcp-json-jackson2 binding and reuse the app ObjectMapper.
- WebFluxSseServerTransportProvider 3-arg constructor -> builder.
- McpSchema.Tool 3-arg constructor removed -> Tool.builder() (McpSpecificationGenerator + test updated accordingly).

Documentation is via the docker-compose example added.

**Is there anything you'd like reviewers to focus on?**
Nothing specific for focus. This is my first contribution to the project for something that would be helpful to get in place for my workplace. Once this has been reviewed and merged a followup PR will be raised with the changes needed for OpenCode etc to be able to handle the oauth2 workflows for authtnetication.

**How Has This Been Tested?** 
- [X] Unit checks
- [X] Covered by existing automation (relevant unit test already existed and was updated)

**Checklist**
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged


**A picture of a cute animal (not mandatory but encouraged)**
Alas my corporate proxy limits the ability to upload images to github 😿 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for MCP Streamable HTTP transport alongside SSE.
  * Added configuration options to enable MCP and select SSE, Streamable HTTP, or both transports.
  * Added a ready-to-use Docker Compose setup for MCP with Kafka.

* **Documentation**
  * Documented MCP configuration options, environment variables, transport modes, and endpoints.

* **Improvements**
  * Updated MCP tool generation and JSON handling for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->