### PR TITLE
Add "Not consumed by group" polling mode to message browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ We extend our gratitude to Provectus for their past support in groundbreaking wo
 * **Metrics Dashboard** – Track key Kafka metrics in real time with a streamlined, lightweight dashboard.
 * **Kafka Brokers Overview** – Inspect brokers, including partition assignments and controller status.
 * **Consumer Group Details** – Analyze parked offsets per partition, and monitor both combined and partition-specific lag.
-* **Message Browser** – Explore messages in JSON, plain text, or Avro encoding formats. Live view is supported, enriched with user-defined CEL message filters.
+* **Message Browser** – Explore messages in JSON, plain text, or Avro encoding formats. Live view is supported, enriched with user-defined CEL message filters. Messages a consumer group has not consumed yet can be browsed with the "Not consumed by group" polling mode.
 * **Dynamic Topic Management** – Create and configure new topics with flexible, real-time settings.
 * **Pluggable Authentication** – Secure your UI using OAuth 2.0 (GitHub, GitLab, Google), LDAP, or basic authentication.
 * **Cloud IAM Support** – Integrate with **GCP IAM**, **Azure IAM**, and **AWS IAM** for cloud-native identity and access management.

--- a/api/src/main/java/io/kafbat/ui/controller/MessagesController.java
+++ b/api/src/main/java/io/kafbat/ui/controller/MessagesController.java
@@ -22,6 +22,7 @@ import io.kafbat.ui.model.TopicMessageEventDTO;
 import io.kafbat.ui.model.TopicSerdeSuggestionDTO;
 import io.kafbat.ui.model.rbac.AccessContext;
 import io.kafbat.ui.model.rbac.permission.AuditAction;
+import io.kafbat.ui.model.rbac.permission.ConsumerGroupAction;
 import io.kafbat.ui.model.rbac.permission.TopicAction;
 import io.kafbat.ui.serde.api.Serde;
 import io.kafbat.ui.service.DeserializationService;
@@ -104,6 +105,7 @@ public class MessagesController extends AbstractController implements MessagesAp
                                                                              String keySerde,
                                                                              String valueSerde,
                                                                              String cursor,
+                                                                             String consumerGroupId,
                                                                              ServerWebExchange exchange) {
     var contextBuilder = AccessContext.builder()
         .cluster(clusterName)
@@ -113,6 +115,10 @@ public class MessagesController extends AbstractController implements MessagesAp
       contextBuilder.auditActions(AuditAction.VIEW);
     } else {
       contextBuilder.topicActions(topicName, MESSAGES_READ);
+    }
+
+    if (consumerGroupId != null) {
+      contextBuilder.consumerGroupActions(consumerGroupId, ConsumerGroupAction.VIEW);
     }
 
     var accessContext = contextBuilder.build();
@@ -130,7 +136,8 @@ public class MessagesController extends AbstractController implements MessagesAp
           smartFilterId,
           limit,
           keySerde,
-          valueSerde
+          valueSerde,
+          consumerGroupId
       );
     }
     return accessControlService.validateAccess(accessContext)

--- a/api/src/main/java/io/kafbat/ui/emitter/Cursor.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/Cursor.java
@@ -62,7 +62,8 @@ public record Cursor(ConsumerRecordDeserializer deserializer,
               new ConsumerPosition(
                   switch (originalPosition.pollingMode()) {
                     case TO_OFFSET, TO_TIMESTAMP, LATEST -> PollingModeDTO.TO_OFFSET;
-                    case FROM_OFFSET, FROM_TIMESTAMP, EARLIEST -> PollingModeDTO.FROM_OFFSET;
+                    case FROM_OFFSET, FROM_TIMESTAMP, EARLIEST, FROM_CONSUMER_GROUP_OFFSET ->
+                        PollingModeDTO.FROM_OFFSET;
                     case TAILING -> throw new IllegalStateException();
                   },
                   originalPosition.topic(),
@@ -74,7 +75,7 @@ public record Cursor(ConsumerRecordDeserializer deserializer,
                           switch (originalPosition.pollingMode()) {
                             case TO_OFFSET, TO_TIMESTAMP, LATEST -> 0;
                             // when doing forward polling we need to start from latest msg's offset + 1
-                            case FROM_OFFSET, FROM_TIMESTAMP, EARLIEST -> 1;
+                            case FROM_OFFSET, FROM_TIMESTAMP, EARLIEST, FROM_CONSUMER_GROUP_OFFSET -> 1;
                             case TAILING -> throw new IllegalStateException();
                           }
                       )

--- a/api/src/main/java/io/kafbat/ui/emitter/SeekOperations.java
+++ b/api/src/main/java/io/kafbat/ui/emitter/SeekOperations.java
@@ -74,7 +74,8 @@ public class SeekOperations {
       case TAILING -> consumer.endOffsets(offsetsInfo.allTargetPartitions());
       case LATEST -> consumer.endOffsets(offsetsInfo.getNonEmptyPartitions());
       case EARLIEST -> consumer.beginningOffsets(offsetsInfo.getNonEmptyPartitions());
-      case FROM_OFFSET, TO_OFFSET -> fixOffsets(offsetsInfo, requireNonNull(position.offsets()));
+      case FROM_OFFSET, TO_OFFSET, FROM_CONSUMER_GROUP_OFFSET ->
+          fixOffsets(offsetsInfo, requireNonNull(position.offsets()));
       case FROM_TIMESTAMP, TO_TIMESTAMP ->
           offsetsForTimestamp(consumer, position.pollingMode(), offsetsInfo, requireNonNull(position.timestamp()));
     };

--- a/api/src/main/java/io/kafbat/ui/service/MessagesService.java
+++ b/api/src/main/java/io/kafbat/ui/service/MessagesService.java
@@ -224,14 +224,16 @@ public class MessagesService {
                                                  @Nullable String filterId,
                                                  @Nullable Integer limit,
                                                  @Nullable String keySerde,
-                                                 @Nullable String valueSerde) {
+                                                 @Nullable String valueSerde,
+                                                 @Nullable String consumerGroupId) {
     return loadMessages(
         cluster,
         topic,
         deserializationService.deserializerFor(cluster, topic, keySerde, valueSerde),
         consumerPosition,
         getMsgFilter(containsStringFilter, filterId),
-        fixPageSize(limit)
+        fixPageSize(limit),
+        consumerGroupId
     );
   }
 
@@ -244,7 +246,8 @@ public class MessagesService {
         cursor.deserializer(),
         cursor.consumerPosition(),
         cursor.filter(),
-        fixPageSize(cursor.limit())
+        fixPageSize(cursor.limit()),
+        null
     );
   }
 
@@ -253,11 +256,53 @@ public class MessagesService {
                                                   ConsumerRecordDeserializer deserializer,
                                                   ConsumerPosition consumerPosition,
                                                   Predicate<TopicMessageDTO> filter,
-                                                  int limit) {
+                                                  int limit,
+                                                  @Nullable String consumerGroupId) {
     return withExistingTopic(cluster, topic)
+        .flatMap(td -> resolveConsumerPosition(cluster, td, consumerPosition, consumerGroupId))
         .flux()
+        // emitters are blocking, so they have to be subscribed to on the elastic scheduler
         .publishOn(Schedulers.boundedElastic())
-        .flatMap(td -> loadMessagesImpl(cluster, deserializer, consumerPosition, filter, limit));
+        .flatMap(position -> loadMessagesImpl(cluster, deserializer, position, filter, limit));
+  }
+
+  /**
+   * For FROM_CONSUMER_GROUP_OFFSET mode replaces the position with the group's committed offsets,
+   * so that polling starts right from the first message that is not consumed yet by the group.
+   * Partitions without a committed offset are read from the very beginning.
+   */
+  private Mono<ConsumerPosition> resolveConsumerPosition(KafkaCluster cluster,
+                                                         TopicDescription topicDescription,
+                                                         ConsumerPosition position,
+                                                         @Nullable String consumerGroupId) {
+    if (position.pollingMode() != PollingModeDTO.FROM_CONSUMER_GROUP_OFFSET) {
+      return Mono.just(position);
+    }
+    if (consumerGroupId == null || consumerGroupId.isBlank()) {
+      return Mono.error(new ValidationException("consumerGroupId not provided for " + position.pollingMode()));
+    }
+    List<TopicPartition> targetPartitions = position.partitions().isEmpty()
+        ? topicDescription.partitions().stream()
+        .map(p -> new TopicPartition(topicDescription.name(), p.partition()))
+        .toList()
+        : position.partitions();
+
+    return adminClientService.get(cluster)
+        .flatMap(ac -> ac.listConsumerGroupOffsets(List.of(consumerGroupId), targetPartitions))
+        .map(committedOffsets -> {
+          Map<TopicPartition, Long> offsets = targetPartitions.stream()
+              .collect(Collectors.toMap(
+                  tp -> tp,
+                  tp -> Optional.ofNullable(committedOffsets.get(consumerGroupId, tp)).orElse(0L)
+              ));
+          return new ConsumerPosition(
+              position.pollingMode(),
+              position.topic(),
+              targetPartitions,
+              null,
+              new ConsumerPosition.Offsets(null, offsets)
+          );
+        });
   }
 
   private Flux<TopicMessageEventDTO> loadMessagesImpl(KafkaCluster cluster,
@@ -276,7 +321,7 @@ public class MessagesService {
           cluster.getPollingSettings(),
           cursorsStorage.createNewCursor(deserializer, consumerPosition, filter, limit)
       );
-      case FROM_OFFSET, FROM_TIMESTAMP, EARLIEST -> new ForwardEmitter(
+      case FROM_OFFSET, FROM_TIMESTAMP, EARLIEST, FROM_CONSUMER_GROUP_OFFSET -> new ForwardEmitter(
           () -> consumerGroupService.createConsumer(cluster,
               Map.of(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, limit)),
           consumerPosition,

--- a/api/src/main/resources/static/openapi/kafbat-ui-api.yaml
+++ b/api/src/main/resources/static/openapi/kafbat-ui-api.yaml
@@ -2673,6 +2673,13 @@ paths:
           schema:
             type: string
           explode: false
+        - name: consumerGroupId
+          in: query
+          required: false
+          description: Consumer group id, required for FROM_CONSUMER_GROUP_OFFSET polling mode
+          schema:
+            type: string
+          explode: false
       responses:
         '200':
           description: The request has succeeded.
@@ -4689,6 +4696,7 @@ components:
         - LATEST
         - EARLIEST
         - TAILING
+        - FROM_CONSUMER_GROUP_OFFSET
     PrometheusApiBaseResponse:
       type: object
       required:

--- a/api/src/test/java/io/kafbat/ui/emitter/TailingEmitterTest.java
+++ b/api/src/test/java/io/kafbat/ui/emitter/TailingEmitterTest.java
@@ -115,7 +115,8 @@ class TailingEmitterTest extends AbstractIntegrationTest {
             null,
             0,
             StringSerde.NAME,
-            StringSerde.NAME);
+            StringSerde.NAME,
+            null);
   }
 
   private List<TopicMessageEventDTO> startTailing(String filterQuery) {

--- a/api/src/test/java/io/kafbat/ui/service/MessagesServiceTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/MessagesServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.kafbat.ui.AbstractIntegrationTest;
 import io.kafbat.ui.exception.TopicNotFoundException;
+import io.kafbat.ui.exception.ValidationException;
 import io.kafbat.ui.model.ConsumerPosition;
 import io.kafbat.ui.model.CreateTopicMessageDTO;
 import io.kafbat.ui.model.KafkaCluster;
@@ -18,10 +19,17 @@ import io.kafbat.ui.serdes.builtin.StringSerde;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -75,7 +83,7 @@ class MessagesServiceTest extends AbstractIntegrationTest {
     StepVerifier.create(messagesService
             .loadMessages(cluster, NON_EXISTING_TOPIC,
                 new ConsumerPosition(PollingModeDTO.TAILING, NON_EXISTING_TOPIC, List.of(), null, null),
-                null, null, 1, "String", "String"))
+                null, null, 1, "String", "String", null))
         .expectError(TopicNotFoundException.class)
         .verify();
   }
@@ -98,7 +106,8 @@ class MessagesServiceTest extends AbstractIntegrationTest {
             null,
             100,
             StringSerde.NAME,
-            StringSerde.NAME
+            StringSerde.NAME,
+            null
         ).filter(evt -> evt.getType() == TopicMessageEventDTO.TypeEnum.MESSAGE)
         .map(TopicMessageEventDTO::getMessage);
 
@@ -130,7 +139,7 @@ class MessagesServiceTest extends AbstractIntegrationTest {
     Flux<String> msgsFlux = messagesService.loadMessages(
             cluster, testTopic,
             new ConsumerPosition(mode, testTopic, List.of(), null, null),
-            null, null, pageSize, StringSerde.NAME, StringSerde.NAME)
+            null, null, pageSize, StringSerde.NAME, StringSerde.NAME, null)
         .doOnNext(evt -> {
           if (evt.getType() == TopicMessageEventDTO.TypeEnum.DONE) {
             assertThat(evt.getCursor()).isNotNull();
@@ -158,6 +167,84 @@ class MessagesServiceTest extends AbstractIntegrationTest {
     StepVerifier.create(remainingMsgs)
         .expectNextCount(msgsToGenerate - pageSize)
         .verifyComplete();
+  }
+
+  @Test
+  void loadMessagesFromConsumerGroupOffsetReturnsOnlyNotConsumedMessages() throws Exception {
+    String testTopic = MessagesServiceTest.class.getSimpleName() + UUID.randomUUID();
+    createTopicWithCleanup(new NewTopic(testTopic, 1, (short) 1));
+
+    int msgsToGenerate = 10;
+    int committedOffset = 6;
+
+    try (var producer = KafkaTestProducer.forKafka(kafka)) {
+      for (int i = 0; i < msgsToGenerate - 1; i++) {
+        producer.send(testTopic, "message_" + i);
+      }
+      // Wait for the last message to ensure all messages are visible before polling
+      producer.send(testTopic, "message_" + (msgsToGenerate - 1)).get();
+    }
+
+    String groupId = "cg-" + UUID.randomUUID();
+    commitOffset(groupId, new TopicPartition(testTopic, 0), committedOffset);
+
+    Flux<String> notConsumedMsgs = messagesService.loadMessages(
+            cluster, testTopic,
+            new ConsumerPosition(PollingModeDTO.FROM_CONSUMER_GROUP_OFFSET, testTopic, List.of(), null, null),
+            null, null, 100, StringSerde.NAME, StringSerde.NAME, groupId)
+        .filter(evt -> evt.getType() == TopicMessageEventDTO.TypeEnum.MESSAGE)
+        .map(evt -> evt.getMessage().getValue());
+
+    StepVerifier.create(notConsumedMsgs)
+        .expectNext("message_6", "message_7", "message_8", "message_9")
+        .verifyComplete();
+  }
+
+  @Test
+  void loadMessagesFromConsumerGroupOffsetReturnsAllMessagesWhenGroupHasNoCommittedOffsets() throws Exception {
+    String testTopic = MessagesServiceTest.class.getSimpleName() + UUID.randomUUID();
+    createTopicWithCleanup(new NewTopic(testTopic, 1, (short) 1));
+
+    try (var producer = KafkaTestProducer.forKafka(kafka)) {
+      producer.send(testTopic, "message1");
+      producer.send(testTopic, "message2").get();
+    }
+
+    Flux<String> notConsumedMsgs = messagesService.loadMessages(
+            cluster, testTopic,
+            new ConsumerPosition(PollingModeDTO.FROM_CONSUMER_GROUP_OFFSET, testTopic, List.of(), null, null),
+            null, null, 100, StringSerde.NAME, StringSerde.NAME, "cg-" + UUID.randomUUID())
+        .filter(evt -> evt.getType() == TopicMessageEventDTO.TypeEnum.MESSAGE)
+        .map(evt -> evt.getMessage().getValue());
+
+    StepVerifier.create(notConsumedMsgs)
+        .expectNext("message1", "message2")
+        .verifyComplete();
+  }
+
+  @Test
+  void loadMessagesFromConsumerGroupOffsetReturnsExceptionWhenGroupNotProvided() {
+    String testTopic = MessagesServiceTest.class.getSimpleName() + UUID.randomUUID();
+    createTopicWithCleanup(new NewTopic(testTopic, 1, (short) 1));
+
+    StepVerifier.create(messagesService.loadMessages(
+            cluster, testTopic,
+            new ConsumerPosition(PollingModeDTO.FROM_CONSUMER_GROUP_OFFSET, testTopic, List.of(), null, null),
+            null, null, 100, StringSerde.NAME, StringSerde.NAME, null))
+        .expectError(ValidationException.class)
+        .verify();
+  }
+
+  private static void commitOffset(String groupId, TopicPartition topicPartition, long offset) {
+    Properties props = new Properties();
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class);
+    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class);
+    try (var consumer = new KafkaConsumer<Bytes, Bytes>(props)) {
+      consumer.assign(List.of(topicPartition));
+      consumer.commitSync(Map.of(topicPartition, new OffsetAndMetadata(offset)));
+    }
   }
 
   private void createTopicWithCleanup(NewTopic newTopic) {

--- a/api/src/test/java/io/kafbat/ui/service/SendAndReadTests.java
+++ b/api/src/test/java/io/kafbat/ui/service/SendAndReadTests.java
@@ -733,7 +733,8 @@ class SendAndReadTests extends AbstractIntegrationTest {
                 null,
                 1,
                 msgToSend.getKeySerde().get(),
-                msgToSend.getValueSerde().get()
+                msgToSend.getValueSerde().get(),
+                null
             ).filter(e -> e.getType().equals(TopicMessageEventDTO.TypeEnum.MESSAGE))
             .map(TopicMessageEventDTO::getMessage)
             .blockLast(Duration.ofSeconds(5000));

--- a/contract-typespec/api/messages.tsp
+++ b/contract-typespec/api/messages.tsp
@@ -84,6 +84,10 @@ interface MessagesApi {
     @query keySerde?: string,
     @query valueSerde?: string,
     @query cursor?: string,
+
+    @doc("Consumer group id, required for FROM_CONSUMER_GROUP_OFFSET polling mode")
+    @query
+    consumerGroupId?: string,
   ): SseResponse<TopicMessageEvent> | ApiBadRequestResponse;
 }
 
@@ -190,6 +194,9 @@ enum PollingMode {
   LATEST,
   EARLIEST,
   TAILING,
+
+  @doc("Reads messages that are not consumed yet by the consumer group passed in consumerGroupId")
+  FROM_CONSUMER_GROUP_OFFSET,
 }
 
 enum MessageFilterType {

--- a/contract/src/main/resources/swagger/kafbat-ui-api.yaml
+++ b/contract/src/main/resources/swagger/kafbat-ui-api.yaml
@@ -975,6 +975,11 @@ paths:
           description: "id of the cursor for pagination, if passed - all other query params ignored"
           schema:
             type: string
+        - name: consumerGroupId
+          in: query
+          description: "Consumer group id, required for FROM_CONSUMER_GROUP_OFFSET polling mode"
+          schema:
+            type: string
       responses:
         200:
           description: OK
@@ -3370,6 +3375,7 @@ components:
         - LATEST
         - EARLIEST
         - TAILING
+        - FROM_CONSUMER_GROUP_OFFSET
 
     MessageFilterType:
       type: string

--- a/frontend/src/components/Topics/Topic/Messages/Filters/ConsumerGroupSelect.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/ConsumerGroupSelect.tsx
@@ -1,0 +1,45 @@
+import React, { useMemo } from 'react';
+import Select from 'components/common/Select/Select';
+import useAppParams from 'lib/hooks/useAppParams';
+import { RouteParamsClusterTopic } from 'lib/paths';
+import { useTopicConsumerGroups } from 'lib/hooks/api/topics';
+
+export interface ConsumerGroupSelectProps {
+  value?: string;
+  onChange: (consumerGroupId: string) => void;
+}
+
+const ConsumerGroupSelect: React.FC<ConsumerGroupSelectProps> = ({
+  value,
+  onChange,
+}) => {
+  const { clusterName, topicName } = useAppParams<RouteParamsClusterTopic>();
+  const { data: consumerGroups = [] } = useTopicConsumerGroups({
+    clusterName,
+    topicName,
+  });
+
+  const options = useMemo(
+    () =>
+      consumerGroups.map(({ groupId }) => ({ label: groupId, value: groupId })),
+    [consumerGroups]
+  );
+
+  return (
+    <Select
+      id="selectConsumerGroup"
+      aria-labelledby="selectConsumerGroup"
+      onChange={onChange}
+      options={options}
+      value={value}
+      minWidth="200px"
+      selectSize="M"
+      disabled={options.length === 0}
+      placeholder={
+        options.length === 0 ? 'No consumer groups' : 'Select consumer group'
+      }
+    />
+  );
+};
+
+export default ConsumerGroupSelect;

--- a/frontend/src/components/Topics/Topic/Messages/Filters/Filters.tsx
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/Filters.tsx
@@ -5,7 +5,7 @@ import {
   TopicMessageConsuming,
   TopicMessage,
 } from 'generated-sources';
-import React, { ChangeEvent, useMemo, useState } from 'react';
+import React, { ChangeEvent, Suspense, useMemo, useState } from 'react';
 import MultiSelect from 'components/common/MultiSelect/MultiSelect.styled';
 import Select from 'components/common/Select/Select';
 import { Button } from 'components/common/Button/Button';
@@ -30,11 +30,13 @@ import {
   ADD_FILTER_ID,
   filterOptions,
   isLiveMode,
+  isModeConsumerGroupSelector,
   isModeOffsetSelector,
   isModeOptionWithInput,
 } from './utils';
 import FiltersSideBar from './FiltersSideBar';
 import FiltersMetrics from './FiltersMetrics';
+import ConsumerGroupSelect from './ConsumerGroupSelect';
 
 interface MessageData {
   Value: string | undefined;
@@ -111,6 +113,8 @@ const Filters: React.FC<FiltersProps> = ({
     setPartition,
     smartFilter,
     setSmartFilter,
+    consumerGroupId,
+    setConsumerGroupId,
     refreshData,
   } = useMessagesFilters(topicName);
 
@@ -212,6 +216,14 @@ const Filters: React.FC<FiltersProps> = ({
                 />
               ))}
           </S.FilterModeTypeSelectorWrapper>
+          {isModeConsumerGroupSelector(mode) && (
+            <Suspense fallback={null}>
+              <ConsumerGroupSelect
+                value={consumerGroupId}
+                onChange={setConsumerGroupId}
+              />
+            </Suspense>
+          )}
           <MultiSelect
             disabled={isLoading}
             options={partitions.list}

--- a/frontend/src/components/Topics/Topic/Messages/Filters/utils.ts
+++ b/frontend/src/components/Topics/Topic/Messages/Filters/utils.ts
@@ -6,12 +6,17 @@ export function isModeOptionWithInput(value: PollingMode) {
   return (
     value !== PollingMode.TAILING &&
     value !== PollingMode.LATEST &&
-    value !== PollingMode.EARLIEST
+    value !== PollingMode.EARLIEST &&
+    value !== PollingMode.FROM_CONSUMER_GROUP_OFFSET
   );
 }
 
 export function isModeOffsetSelector(value: PollingMode) {
   return value === PollingMode.TO_OFFSET || value === PollingMode.FROM_OFFSET;
+}
+
+export function isModeConsumerGroupSelector(value: PollingMode) {
+  return value === PollingMode.FROM_CONSUMER_GROUP_OFFSET;
 }
 
 export function isLiveMode(mode?: PollingMode) {

--- a/frontend/src/components/Topics/Topic/Messages/__test__/utils.spec.ts
+++ b/frontend/src/components/Topics/Topic/Messages/__test__/utils.spec.ts
@@ -7,6 +7,7 @@ import {
   getTimestampFromSeekToParam,
   isEditingFilterMode,
   isLiveMode,
+  isModeConsumerGroupSelector,
   isModeOffsetSelector,
   isModeOptionWithInput,
 } from 'components/Topics/Topic/Messages/Filters/utils';
@@ -132,6 +133,9 @@ describe('utils', () => {
       expect(isModeOptionWithInput(PollingMode.TO_TIMESTAMP)).toBeTruthy();
       expect(isModeOptionWithInput(PollingMode.FROM_OFFSET)).toBeTruthy();
       expect(isModeOptionWithInput(PollingMode.TO_OFFSET)).toBeTruthy();
+      expect(
+        isModeOptionWithInput(PollingMode.FROM_CONSUMER_GROUP_OFFSET)
+      ).toBeFalsy();
     });
   });
 
@@ -144,6 +148,19 @@ describe('utils', () => {
       expect(isModeOffsetSelector(PollingMode.TO_TIMESTAMP)).toBeFalsy();
       expect(isModeOffsetSelector(PollingMode.FROM_OFFSET)).toBeTruthy();
       expect(isModeOffsetSelector(PollingMode.TO_OFFSET)).toBeTruthy();
+      expect(
+        isModeOffsetSelector(PollingMode.FROM_CONSUMER_GROUP_OFFSET)
+      ).toBeFalsy();
+    });
+  });
+
+  describe('isModeConsumerGroupSelector', () => {
+    it('is only truthy for the consumer group offset mode', () => {
+      expect(
+        isModeConsumerGroupSelector(PollingMode.FROM_CONSUMER_GROUP_OFFSET)
+      ).toBeTruthy();
+      expect(isModeConsumerGroupSelector(PollingMode.LATEST)).toBeFalsy();
+      expect(isModeConsumerGroupSelector(PollingMode.FROM_OFFSET)).toBeFalsy();
     });
   });
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -149,6 +149,7 @@ export const MessagesFilterKeys = {
   smartFilterId: 'smartFilterId',
   activeFilterId: 'activeFilterId',
   activeFilterNPId: 'activeFilterNPId', // not persisted filter name to indicate the refresh
+  consumerGroupId: 'consumerGroupId',
   cursor: 'cursor',
   r: 'r', // used tp force refresh of the data
 } as const;

--- a/frontend/src/lib/hooks/api/topicMessages.tsx
+++ b/frontend/src/lib/hooks/api/topicMessages.tsx
@@ -95,6 +95,12 @@ export const useTopicMessages = ({
             searchParams.get(MessagesFilterKeys.offset) || '0'
           );
           break;
+        case PollingMode.FROM_CONSUMER_GROUP_OFFSET:
+          requestParams.set(
+            MessagesFilterKeys.consumerGroupId,
+            searchParams.get(MessagesFilterKeys.consumerGroupId) || ''
+          );
+          break;
         default:
       }
 
@@ -175,7 +181,16 @@ export const useTopicMessages = ({
     };
 
     abortFetchData();
-    fetchData();
+
+    // this mode can only be polled once a consumer group has been picked
+    if (
+      mode === PollingMode.FROM_CONSUMER_GROUP_OFFSET &&
+      !searchParams.get(MessagesFilterKeys.consumerGroupId)
+    ) {
+      setMessages([]);
+    } else {
+      fetchData();
+    }
 
     return abortFetchData;
   }, [searchParams, abortFetchData]);

--- a/frontend/src/lib/hooks/filterUtils.ts
+++ b/frontend/src/lib/hooks/filterUtils.ts
@@ -8,6 +8,10 @@ export const ModeOptions = [
   { value: PollingMode.TO_OFFSET, label: 'To offset' },
   { value: PollingMode.FROM_TIMESTAMP, label: 'Since time' },
   { value: PollingMode.TO_TIMESTAMP, label: 'To time' },
+  {
+    value: PollingMode.FROM_CONSUMER_GROUP_OFFSET,
+    label: 'Not consumed by group',
+  },
 ];
 
 export function convertStrToPollingMode(

--- a/frontend/src/lib/hooks/useMessagesFilters.ts
+++ b/frontend/src/lib/hooks/useMessagesFilters.ts
@@ -112,6 +112,9 @@ export function useMessagesFilters(topicName: string) {
     .split(',')
     .filter((v) => v);
 
+  const consumerGroupId =
+    searchParams.get(MessagesFilterKeys.consumerGroupId) || undefined;
+
   const smartFilterId =
     searchParams.get(MessagesFilterKeys.activeFilterId) || '';
 
@@ -129,6 +132,24 @@ export function useMessagesFilters(topicName: string) {
       params.set(MessagesFilterKeys.mode, newMode);
       params.delete(MessagesFilterKeys.offset);
       params.delete(MessagesFilterKeys.timestamp);
+
+      // the selected consumer group is only meaningful for FROM_CONSUMER_GROUP_OFFSET
+      if (newMode !== PollingMode.FROM_CONSUMER_GROUP_OFFSET) {
+        removeMessagesFiltersField(MessagesFilterKeys.consumerGroupId);
+        params.delete(MessagesFilterKeys.consumerGroupId);
+      }
+
+      return params;
+    });
+  };
+
+  const setConsumerGroupId = (newConsumerGroupId: string) => {
+    setSearchParams((params) => {
+      setMessagesFiltersField(
+        MessagesFilterKeys.consumerGroupId,
+        newConsumerGroupId
+      );
+      params.set(MessagesFilterKeys.consumerGroupId, newConsumerGroupId);
       return params;
     });
   };
@@ -265,6 +286,8 @@ export function useMessagesFilters(topicName: string) {
     setPartition,
     smartFilter,
     setSmartFilter,
+    consumerGroupId,
+    setConsumerGroupId,
     refreshData,
   };
 }

--- a/frontend/src/lib/hooks/useMessagesFiltersFields.ts
+++ b/frontend/src/lib/hooks/useMessagesFiltersFields.ts
@@ -15,6 +15,7 @@ type MessagesFilterFieldsType = Pick<
   | 'stringFilter'
   | 'activeFilterId'
   | 'smartFilterId'
+  | 'consumerGroupId'
 >;
 
 export const useActiveFilters = () => {
@@ -118,6 +119,9 @@ export function useMessagesFiltersFields(resourceName: string) {
       setTopicMessageFiltersFromLocalStorage(MessagesFilterKeys.stringFilter);
       setTopicMessageFiltersFromLocalStorage(MessagesFilterKeys.activeFilterId);
       setTopicMessageFiltersFromLocalStorage(MessagesFilterKeys.smartFilterId);
+      setTopicMessageFiltersFromLocalStorage(
+        MessagesFilterKeys.consumerGroupId
+      );
     } else {
       removeMessagesFilterFields();
       setTopicMessageFiltersFromUrlParams(MessagesFilterKeys.mode);
@@ -128,6 +132,7 @@ export function useMessagesFiltersFields(resourceName: string) {
       setTopicMessageFiltersFromUrlParams(MessagesFilterKeys.valueSerde);
       setTopicMessageFiltersFromUrlParams(MessagesFilterKeys.activeFilterId);
       setTopicMessageFiltersFromUrlParams(MessagesFilterKeys.smartFilterId);
+      setTopicMessageFiltersFromUrlParams(MessagesFilterKeys.consumerGroupId);
     }
   };
 


### PR DESCRIPTION
- [ ] **Breaking change?** (if so, please describe the impact and migration path for existing application instances)


<!-- ignore-task-list-end -->
**What changes did you make?** (Give an overview)

Adds a new polling mode to the topic message browser that shows the messages a consumer group has **not consumed yet**, so the backlog behind a lag can be inspected without manually looking up committed offsets and typing them into "From offset".

The mode is picked from the existing polling mode dropdown on **Topics → \<topic\> → Messages** as **"Not consumed by group"**. Selecting it reveals a consumer group picker (populated from the topic's own consumer groups); polling starts at that group's committed offset on every partition and runs forward to the end of the topic. All the other controls — partition filter, serdes, string/smart filters, export, cursor pagination — keep working unchanged.

Contract:
- New `PollingMode` value: `FROM_CONSUMER_GROUP_OFFSET`.
- New optional `consumerGroupId` query parameter on `GET /api/clusters/{clusterName}/topics/{topicName}/messages/v2`, required for that mode (a `ValidationException` is raised otherwise).

Backend (`MessagesService#resolveConsumerPosition`):
- Reads the group's committed offsets via `ReactiveAdminClient#listConsumerGroupOffsets` for the target partitions and rebuilds the `ConsumerPosition` with a per-partition offsets map.
- Partitions the group has no committed offset for are read from the very beginning — from that group's point of view nothing on them has been consumed.
- From there the existing `ForwardEmitter` + cursor pagination path is reused as-is; the new mode only needed to be added to the existing `SeekOperations` / `Cursor` switches, where it behaves exactly like `FROM_OFFSET` (a cursor for the next page is registered as `FROM_OFFSET`, so paging works the same way).
- RBAC: when `consumerGroupId` is passed, `ConsumerGroupAction.VIEW` on that group is required on top of `TopicAction.MESSAGES_READ`.

Frontend:
- New `ConsumerGroupSelect` component, rendered only for this mode and behind its own `Suspense` boundary so picking the mode doesn't blank out the whole Messages tab.
- The selected group is kept in the URL search params and in the per-topic filter local storage, like the other filters, and is cleared when switching to another mode.
- No request is fired until a group is picked, so the mode doesn't produce a 400 while the user is still choosing.

**Is there anything you'd like reviewers to focus on?**

- `MessagesService#loadMessages`: `publishOn(Schedulers.boundedElastic())` had to move *after* the offset resolution. The resolution is an async admin-client call, so without the reorder the (blocking) emitter would be subscribed to on a Kafka admin client thread instead of the elastic scheduler.
- The choice to fall back to offset `0` for partitions with no committed offset. `SeekOperations#fixOffsets` clamps it up to the real beginning offset, so it is safe on compacted/retained topics, but it is a product decision worth confirming.
- Whether `FROM_CONSUMER_GROUP_OFFSET` is the right name, vs. something closer to the UI wording ("not consumed by group").

**How Has This Been Tested?** (put an "x" (case-sensitive!) next to an item)
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually (please, describe, if necessary)
- [x] Unit checks
- [x] Integration checks
- [ ] Covered by existing automation
<!-- ignore-task-list-end -->

Manually: ran the built image against a local Kafka, produced messages to a topic, committed a partial offset for a consumer group, and confirmed the mode lists exactly the messages after the committed offset, that the lag shrinks as the group catches up, and that the partition filter and pagination still apply.

Integration (`MessagesServiceTest`, 3 new cases):
- `loadMessagesFromConsumerGroupOffsetReturnsOnlyNotConsumedMessages` — 10 messages, offset 6 committed, expects `message_6`…`message_9`.
- `loadMessagesFromConsumerGroupOffsetReturnsAllMessagesWhenGroupHasNoCommittedOffsets`.
- `loadMessagesFromConsumerGroupOffsetReturnsExceptionWhenGroupNotProvided`.

Unit: extended `Filters/utils` specs for the new mode predicates; existing `SeekOperationsTest`, `CursorTest` and the frontend Messages/hooks suites pass unchanged.

**Checklist** (put an "x" (case-sensitive!) next to all the items, otherwise the build will fail)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Not consumed by group” message browsing mode.
  * Users can select a consumer group to view messages it has not yet consumed.
  * Consumer-group selection is preserved in the URL and filters.
  * Added API support for consumer-group offset polling.

* **Bug Fixes**
  * Improved handling of consumer-group offsets, including groups without committed offsets.
  * Added validation when a consumer group is required but not selected.

* **Documentation**
  * Documented the new polling mode in the feature list and API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->