### PR TITLE
Fix consumer group authorization failures in bulk reads

### DIFF
--- a/api/src/main/java/io/kafbat/ui/service/ConsumerGroupService.java
+++ b/api/src/main/java/io/kafbat/ui/service/ConsumerGroupService.java
@@ -28,6 +28,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Properties;
@@ -432,7 +433,7 @@ public class ConsumerGroupService {
       case MEMBERS -> {
         var comparator = Comparator.<ConsumerGroupDescription>comparingInt(cg -> cg.members().size());
         var groupNames = groups.stream().map(ConsumerGroupListing::groupId).toList();
-        yield ac.describeConsumerGroups(groupNames)
+        yield ac.describeConsumerGroups(groupNames, true)
             .map(descriptions ->
                 sortAndPaginate(descriptions.values(), comparator, pageNum, perPage, sortOrderDto).toList());
       }
@@ -463,8 +464,8 @@ public class ConsumerGroupService {
     List<String> sortedGroups = sortAndPaginate(listings, comparator, pageNum, perPage, sortOrderDto)
         .map(ConsumerGroupListing::groupId)
         .toList();
-    return ac.describeConsumerGroups(sortedGroups)
-        .map(descrMap -> sortedGroups.stream().map(descrMap::get).toList());
+    return ac.describeConsumerGroups(sortedGroups, true)
+        .map(descrMap -> sortedGroups.stream().map(descrMap::get).filter(Objects::nonNull).toList());
   }
 
   private <T> Stream<T> sortAndPaginate(Collection<T> collection,
@@ -514,7 +515,7 @@ public class ConsumerGroupService {
         }
       }
       if (!notFound.isEmpty()) {
-        return ac.describeConsumerGroups(notFound)
+        return ac.describeConsumerGroups(notFound, true)
             .map(descriptions -> {
               result.addAll(descriptions.values());
               return result;
@@ -523,7 +524,7 @@ public class ConsumerGroupService {
         return Mono.just(result);
       }
     } else {
-      return ac.describeConsumerGroups(groupNames)
+      return ac.describeConsumerGroups(groupNames, true)
           .map(descriptions -> List.copyOf(descriptions.values()));
     }
   }
@@ -541,7 +542,7 @@ public class ConsumerGroupService {
       SortOrderDTO sortOrderDto) {
     var groupNames = groups.stream().map(ConsumerGroupListing::groupId).toList();
 
-    return ac.describeConsumerGroups(groupNames)
+    return ac.describeConsumerGroups(groupNames, true)
         .flatMap(descriptionsMap -> {
               List<ConsumerGroupDescription> descriptions = descriptionsMap.values().stream().toList();
               return getConsumerGroups(cluster, ac, descriptions)

--- a/api/src/main/java/io/kafbat/ui/service/ReactiveAdminClient.java
+++ b/api/src/main/java/io/kafbat/ui/service/ReactiveAdminClient.java
@@ -78,6 +78,7 @@ import org.apache.kafka.common.acl.AclBindingFilter;
 import org.apache.kafka.common.acl.AclOperation;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.ClusterAuthorizationException;
+import org.apache.kafka.common.errors.GroupAuthorizationException;
 import org.apache.kafka.common.errors.GroupIdNotFoundException;
 import org.apache.kafka.common.errors.GroupNotEmptyException;
 import org.apache.kafka.common.errors.GroupSubscribedToTopicException;
@@ -527,11 +528,21 @@ public class ReactiveAdminClient implements Closeable {
   }
 
   public Mono<Map<String, ConsumerGroupDescription>> describeConsumerGroups(Collection<String> groupIds) {
+    return describeConsumerGroups(groupIds, false);
+  }
+
+  public Mono<Map<String, ConsumerGroupDescription>> describeConsumerGroups(Collection<String> groupIds,
+                                                                             boolean skipUnauthorized) {
     return partitionCalls(
         groupIds,
         properties.getDescribeConsumerGroupsPartitionSize(),
         properties.getDescribeConsumerGroupsConcurrency(),
-        ids -> toMono(client.describeConsumerGroups(ids).all()),
+        ids -> {
+          var result = client.describeConsumerGroups(ids);
+          return skipUnauthorized
+              ? collectAuthorizedGroupResults(result.describedGroups())
+              : toMono(result.all());
+        },
         mapMerger()
     );
   }
@@ -541,15 +552,24 @@ public class ReactiveAdminClient implements Closeable {
   public Mono<Table<String, TopicPartition, Long>> listConsumerGroupOffsets(List<String> consumerGroups,
                                                                             // all partitions if null passed
                                                                             @Nullable List<TopicPartition> partitions) {
+    return listConsumerGroupOffsets(consumerGroups, partitions, false);
+  }
+
+  public Mono<Table<String, TopicPartition, Long>> listConsumerGroupOffsets(List<String> consumerGroups,
+                                                                             @Nullable List<TopicPartition> partitions,
+                                                                             boolean skipUnauthorized) {
     Function<Collection<String>, Mono<Map<String, Map<TopicPartition, OffsetAndMetadata>>>> call =
-        groups -> toMono(
-            client.listConsumerGroupOffsets(
-                groups.stream()
-                    .collect(Collectors.toMap(
-                        g -> g,
-                        g -> new ListConsumerGroupOffsetsSpec().topicPartitions(partitions)
-                    ))).all()
-        );
+        groups -> {
+          var result = client.listConsumerGroupOffsets(groups.stream()
+              .collect(Collectors.toMap(
+                  g -> g,
+                  g -> new ListConsumerGroupOffsetsSpec().topicPartitions(partitions)
+              )));
+          return skipUnauthorized
+              ? collectAuthorizedGroupResults(groups.stream().collect(toMap(
+                  Function.identity(), result::partitionsToOffsetAndMetadata)))
+              : toMono(result.all());
+        };
 
     Mono<Map<String, Map<TopicPartition, OffsetAndMetadata>>> merged = partitionCalls(
         consumerGroups,
@@ -569,6 +589,17 @@ public class ReactiveAdminClient implements Closeable {
       }));
       return table.build();
     });
+  }
+
+  private static <T> Mono<Map<String, T>> collectAuthorizedGroupResults(Map<String, KafkaFuture<T>> results) {
+    return Flux.fromIterable(results.entrySet())
+        .flatMap(entry -> toMono(entry.getValue())
+            .map(value -> Map.entry(entry.getKey(), value))
+            .onErrorResume(GroupAuthorizationException.class, error -> {
+              log.warn("Skipping unauthorized consumer group {}: {}", entry.getKey(), error.getMessage());
+              return Mono.empty();
+            }))
+        .collectMap(Map.Entry::getKey, Map.Entry::getValue);
   }
 
   public Mono<Void> alterConsumerGroupOffsets(String groupId, Map<TopicPartition, Long> offsets) {

--- a/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
+++ b/api/src/main/java/io/kafbat/ui/service/metrics/scrape/ScrapedClusterState.java
@@ -137,8 +137,8 @@ public class ScrapedClusterState implements AutoCloseable {
         Mono.zip(
             ac.listOffsets(phase1.getT3().values(), OffsetSpec.latest()),
             ac.listOffsets(phase1.getT3().values(), OffsetSpec.earliest()),
-            ac.describeConsumerGroups(phase1.getT2()),
-            ac.listConsumerGroupOffsets(phase1.getT2(), null)
+            ac.describeConsumerGroups(phase1.getT2(), true),
+            ac.listConsumerGroupOffsets(phase1.getT2(), null, true)
         ).map(phase2 ->
             create(
                 clusterDescription,

--- a/api/src/test/java/io/kafbat/ui/service/ConsumerGroupServiceTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/ConsumerGroupServiceTest.java
@@ -35,12 +35,56 @@ import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
 import reactor.core.publisher.Mono;
 import reactor.util.function.Tuple2;
 
 class ConsumerGroupServiceTest {
+
+  @ParameterizedTest
+  @EnumSource(ConsumerGroupOrderingDTO.class)
+  void consumerGroupPagesSkipMissingDescriptions(ConsumerGroupOrderingDTO ordering) {
+    var cluster = KafkaCluster.builder().name("test").build();
+    var client = Mockito.mock(ReactiveAdminClient.class);
+    var admin = Mockito.mock(AdminClientService.class);
+    Mockito.when(admin.get(cluster)).thenReturn(Mono.just(client));
+    var allowed = new ConsumerGroupDescription("allowed", false, List.of(), "range",
+        ConsumerGroupState.EMPTY, null);
+    Mockito.when(client.listConsumerGroups()).thenReturn(Mono.just(List.of(
+        new ConsumerGroupListing("restricted", false, Optional.of(ConsumerGroupState.EMPTY)),
+        new ConsumerGroupListing("allowed", false, Optional.of(ConsumerGroupState.EMPTY))
+    )));
+    Mockito.when(client.describeConsumerGroups(Mockito.any(), Mockito.eq(true)))
+        .thenReturn(Mono.just(Map.of("allowed", allowed)));
+
+    var cache = Mockito.mock(StatisticsCache.class);
+    Mockito.when(cache.get(cluster)).thenReturn(Statistics.builder()
+        .status(ServerStatusDTO.ONLINE)
+        .clusterState(ScrapedClusterState.builder()
+            .consumerGroupsStates(Map.of("allowed",
+                new ScrapedClusterState.ConsumerGroupState("allowed", allowed, Map.of())))
+            .topicStates(Map.of())
+            .build())
+        .build());
+    var acl = Mockito.mock(AccessControlService.class);
+    Mockito.when(acl.isConsumerGroupAccessible(Mockito.any(), Mockito.any())).thenReturn(Mono.just(true));
+    var service = new ConsumerGroupService(admin, acl, new ClustersProperties(), cache);
+
+    var page = service.getConsumerGroups(cluster, OptionalInt.of(1), OptionalInt.of(25),
+        null, false, ordering, SortOrderDTO.ASC, List.of()).block();
+
+    assertThat(page).isNotNull();
+    assertThat(page.consumerGroups()).extracting(group -> group.getGroupId()).containsExactly("allowed");
+
+    Mockito.when(client.describeConsumerGroups(Mockito.any(), Mockito.eq(true)))
+        .thenReturn(Mono.just(Map.of()));
+    var emptyPage = service.getConsumerGroups(cluster, OptionalInt.of(1), OptionalInt.of(25),
+        null, false, ordering, SortOrderDTO.ASC, List.of()).block();
+    assertThat(emptyPage).isNotNull();
+    assertThat(emptyPage.consumerGroups()).isEmpty();
+  }
 
   @Test
   void getConsumerGroupsForTopicConsumerGroups() {
@@ -125,7 +169,7 @@ class ConsumerGroupServiceTest {
         .thenReturn(Mono.just(Map.of(new TopicPartition(topic, 0), 100L)));
 
     Mockito.when(client.describeConsumerGroups(
-        Mockito.any())
+        Mockito.any(), Mockito.eq(true))
     ).thenReturn(
         Mono.just(
             consumerGroupStates.values().stream()
@@ -460,7 +504,7 @@ class ConsumerGroupServiceTest {
             .toList()
     ));
 
-    Mockito.when(client.describeConsumerGroups(Mockito.any())).thenAnswer(invocation -> {
+    Mockito.when(client.describeConsumerGroups(Mockito.any(), Mockito.eq(true))).thenAnswer(invocation -> {
       List<String> groupIds = invocation.getArgument(0);
       return Mono.just(
           groupIds.stream()

--- a/api/src/test/java/io/kafbat/ui/service/ReactiveAdminClientConsumerGroupsTest.java
+++ b/api/src/test/java/io/kafbat/ui/service/ReactiveAdminClientConsumerGroupsTest.java
@@ -1,0 +1,274 @@
+package io.kafbat.ui.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.kafbat.ui.config.ClustersProperties;
+import io.kafbat.ui.model.KafkaCluster;
+import io.kafbat.ui.service.metrics.scrape.ScrapedClusterState;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ConsumerGroupDescription;
+import org.apache.kafka.clients.admin.ConsumerGroupListing;
+import org.apache.kafka.clients.admin.DescribeConsumerGroupsResult;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsResult;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsSpec;
+import org.apache.kafka.clients.admin.ListConsumerGroupsResult;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.GroupAuthorizationException;
+import org.apache.kafka.common.errors.SaslAuthenticationException;
+import org.apache.kafka.common.errors.TimeoutException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class ReactiveAdminClientConsumerGroupsTest {
+
+  private static final String ALLOWED = "application-group";
+  private static final String DENIED = "restricted-group";
+  private static final TopicPartition PARTITION = new TopicPartition("events", 0);
+
+  private final AdminClient admin = mock(AdminClient.class);
+  private final ClustersProperties.AdminClient properties = new ClustersProperties.AdminClient();
+  private final ReactiveAdminClient client = new ReactiveAdminClient(admin, Mono.empty(), properties, null);
+
+  @Test
+  void describeSkipsUnauthorizedGroupsWithoutSplittingTheRequest() {
+    var description = mock(ConsumerGroupDescription.class);
+    var result = mock(DescribeConsumerGroupsResult.class);
+    var groups = List.of(ALLOWED, DENIED);
+    when(admin.describeConsumerGroups(groups)).thenReturn(result);
+    when(result.describedGroups()).thenReturn(Map.of(
+        ALLOWED, KafkaFuture.completedFuture(description),
+        DENIED, failedFuture(new GroupAuthorizationException(DENIED))
+    ));
+
+    StepVerifier.create(client.describeConsumerGroups(groups, true))
+        .assertNext(descriptions -> assertThat(descriptions).containsOnlyKeys(ALLOWED)
+            .containsEntry(ALLOWED, description))
+        .verifyComplete();
+
+    verify(admin).describeConsumerGroups(groups);
+    verifyNoMoreInteractions(admin);
+  }
+
+  @Test
+  void describeReturnsEmptyMapWhenEveryGroupIsUnauthorized() {
+    var result = mock(DescribeConsumerGroupsResult.class);
+    when(admin.describeConsumerGroups(List.of(DENIED))).thenReturn(result);
+    when(result.describedGroups()).thenReturn(Map.of(
+        DENIED, failedFuture(new GroupAuthorizationException(DENIED))
+    ));
+
+    StepVerifier.create(client.describeConsumerGroups(List.of(DENIED), true))
+        .assertNext(descriptions -> assertThat(descriptions).isEmpty())
+        .verifyComplete();
+  }
+
+  @Test
+  void describePreservesBatchSizeAndMergesAuthorizedResults() {
+    properties.setDescribeConsumerGroupsPartitionSize(2);
+    var description = mock(ConsumerGroupDescription.class);
+    when(admin.describeConsumerGroups(any())).thenAnswer(invocation -> {
+      Collection<String> groups = invocation.getArgument(0);
+      var result = mock(DescribeConsumerGroupsResult.class);
+      when(result.describedGroups()).thenReturn(groups.stream().collect(java.util.stream.Collectors.toMap(
+          group -> group,
+          group -> group.equals(DENIED)
+              ? failedFuture(new GroupAuthorizationException(group))
+              : KafkaFuture.completedFuture(description)
+      )));
+      return result;
+    });
+
+    StepVerifier.create(client.describeConsumerGroups(List.of(ALLOWED, DENIED, "another-group"), true))
+        .assertNext(descriptions -> assertThat(descriptions).containsOnlyKeys(ALLOWED, "another-group"))
+        .verifyComplete();
+
+    verify(admin).describeConsumerGroups(List.of(ALLOWED, DENIED));
+    verify(admin).describeConsumerGroups(List.of("another-group"));
+    verifyNoMoreInteractions(admin);
+  }
+
+  @Test
+  void offsetsSkipUnauthorizedGroupsAndPreservePartitionSelection() {
+    var result = mock(ListConsumerGroupOffsetsResult.class);
+    when(admin.listConsumerGroupOffsets(anyMap())).thenReturn(result);
+    when(result.partitionsToOffsetAndMetadata(ALLOWED))
+        .thenReturn(KafkaFuture.completedFuture(Map.of(PARTITION, new OffsetAndMetadata(42L))));
+    when(result.partitionsToOffsetAndMetadata(DENIED))
+        .thenReturn(failedFuture(new GroupAuthorizationException(DENIED)));
+
+    StepVerifier.create(client.listConsumerGroupOffsets(List.of(ALLOWED, DENIED), List.of(PARTITION), true))
+        .assertNext(offsets -> {
+          assertThat(offsets.rowKeySet()).containsExactly(ALLOWED);
+          assertThat(offsets.get(ALLOWED, PARTITION)).isEqualTo(42L);
+        })
+        .verifyComplete();
+
+    ArgumentCaptor<Map<String, ListConsumerGroupOffsetsSpec>> requests = ArgumentCaptor.captor();
+    verify(admin).listConsumerGroupOffsets(requests.capture());
+    assertThat(requests.getValue()).containsOnlyKeys(ALLOWED, DENIED);
+    requests.getValue().values().forEach(spec -> assertThat(spec.topicPartitions())
+        .containsExactly(PARTITION));
+    verifyNoMoreInteractions(admin);
+  }
+
+  @Test
+  void offsetsReturnEmptyTableWhenEveryGroupIsUnauthorized() {
+    var result = mock(ListConsumerGroupOffsetsResult.class);
+    when(admin.listConsumerGroupOffsets(anyMap())).thenReturn(result);
+    when(result.partitionsToOffsetAndMetadata(DENIED))
+        .thenReturn(failedFuture(new GroupAuthorizationException(DENIED)));
+
+    StepVerifier.create(client.listConsumerGroupOffsets(List.of(DENIED), null, true))
+        .assertNext(offsets -> assertThat(offsets.isEmpty()).isTrue())
+        .verifyComplete();
+  }
+
+  @ParameterizedTest
+  @MethodSource("unrelatedFailures")
+  void describePropagatesOtherErrors(Throwable error) {
+    var result = mock(DescribeConsumerGroupsResult.class);
+    when(admin.describeConsumerGroups(List.of(ALLOWED))).thenReturn(result);
+    when(result.describedGroups()).thenReturn(Map.of(ALLOWED, failedFuture(error)));
+
+    StepVerifier.create(client.describeConsumerGroups(List.of(ALLOWED), true))
+        .expectErrorMatches(actual -> actual == error)
+        .verify();
+  }
+
+  @ParameterizedTest
+  @MethodSource("unrelatedFailures")
+  void offsetsPropagateOtherErrors(Throwable error) {
+    var result = mock(ListConsumerGroupOffsetsResult.class);
+    when(admin.listConsumerGroupOffsets(anyMap())).thenReturn(result);
+    when(result.partitionsToOffsetAndMetadata(ALLOWED)).thenReturn(failedFuture(error));
+
+    StepVerifier.create(client.listConsumerGroupOffsets(List.of(ALLOWED), null, true))
+        .expectErrorMatches(actual -> actual == error)
+        .verify();
+  }
+
+  @Test
+  void strictDescribePreservesAuthorizationFailure() {
+    var error = new GroupAuthorizationException(DENIED);
+    var result = mock(DescribeConsumerGroupsResult.class);
+    when(admin.describeConsumerGroups(List.of(DENIED))).thenReturn(result);
+    when(result.all()).thenReturn(failedFuture(error));
+
+    StepVerifier.create(client.describeConsumerGroups(List.of(DENIED)))
+        .expectErrorMatches(actual -> actual == error)
+        .verify();
+  }
+
+  @Test
+  void deletingOffsetsPreservesAuthorizationFailure() {
+    var error = new GroupAuthorizationException(DENIED);
+    var result = mock(ListConsumerGroupOffsetsResult.class);
+    when(admin.listConsumerGroupOffsets(anyMap())).thenReturn(result);
+    when(result.all()).thenReturn(failedFuture(error));
+
+    StepVerifier.create(client.deleteConsumerGroupOffsets(DENIED, PARTITION.topic()))
+        .expectErrorMatches(actual -> actual == error)
+        .verify();
+
+    verify(admin).listConsumerGroupOffsets(anyMap());
+    verifyNoMoreInteractions(admin);
+  }
+
+  @Test
+  void resettingOffsetsPreservesAuthorizationFailure() {
+    var error = new GroupAuthorizationException(DENIED);
+    var listings = mock(ListConsumerGroupsResult.class);
+    when(admin.listConsumerGroups()).thenReturn(listings);
+    when(listings.all()).thenReturn(KafkaFuture.completedFuture(List.of(new ConsumerGroupListing(DENIED, false))));
+    var descriptions = mock(DescribeConsumerGroupsResult.class);
+    when(admin.describeConsumerGroups(List.of(DENIED))).thenReturn(descriptions);
+    when(descriptions.all()).thenReturn(failedFuture(error));
+    var cluster = KafkaCluster.builder().name("test").build();
+    var adminService = mock(AdminClientService.class);
+    when(adminService.get(cluster)).thenReturn(Mono.just(client));
+
+    StepVerifier.create(new OffsetsResetService(adminService).resetToLatest(cluster, DENIED, PARTITION.topic(), null))
+        .expectErrorMatches(actual -> actual == error)
+        .verify();
+
+    verify(admin).listConsumerGroups();
+    verify(admin).describeConsumerGroups(List.of(DENIED));
+    verifyNoMoreInteractions(admin);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void clusterScrapeSucceedsWithUnauthorizedGroups(boolean allUnauthorized) throws Exception {
+    var groups = List.of(ALLOWED, DENIED);
+    var description = new ConsumerGroupDescription(ALLOWED, false, List.of(), "range",
+        ConsumerGroupState.EMPTY, null);
+    var descriptions = mock(DescribeConsumerGroupsResult.class);
+    when(admin.describeConsumerGroups(groups)).thenReturn(descriptions);
+    when(descriptions.describedGroups()).thenReturn(Map.of(
+        ALLOWED, allUnauthorized ? failedFuture(new GroupAuthorizationException(ALLOWED))
+            : KafkaFuture.completedFuture(description),
+        DENIED, failedFuture(new GroupAuthorizationException(DENIED))
+    ));
+    var offsets = mock(ListConsumerGroupOffsetsResult.class);
+    when(admin.listConsumerGroupOffsets(anyMap())).thenReturn(offsets);
+    when(offsets.partitionsToOffsetAndMetadata(ALLOWED))
+        .thenReturn(allUnauthorized ? failedFuture(new GroupAuthorizationException(ALLOWED))
+            : KafkaFuture.completedFuture(Map.of(PARTITION, new OffsetAndMetadata(42L))));
+    when(offsets.partitionsToOffsetAndMetadata(DENIED))
+        .thenReturn(failedFuture(new GroupAuthorizationException(DENIED)));
+
+    var scrapeClient = spy(client);
+    doReturn(Mono.just(Map.of())).when(scrapeClient).describeLogDirs(any());
+    doReturn(Mono.just(List.of(new ConsumerGroupListing(ALLOWED, false),
+        new ConsumerGroupListing(DENIED, false)))).when(scrapeClient).listConsumerGroups();
+    doReturn(Mono.just(Map.of(PARTITION.topic(), new TopicDescription(PARTITION.topic(), false, List.of()))))
+        .when(scrapeClient).describeTopics();
+    doReturn(Mono.just(Map.of())).when(scrapeClient).getTopicsConfig();
+    doReturn(Mono.just(Map.of())).when(scrapeClient).listOffsets(anyCollection(), any());
+
+    try (var state = ScrapedClusterState.scrape(ReactiveAdminClient.ClusterDescription.empty(),
+        scrapeClient, new ClustersProperties()).block()) {
+      assertThat(state).isNotNull();
+      assertThat(state.getTopicStates()).containsOnlyKeys(PARTITION.topic());
+      if (allUnauthorized) {
+        assertThat(state.getConsumerGroupsStates()).isEmpty();
+      } else {
+        assertThat(state.getConsumerGroupsStates()).containsOnlyKeys(ALLOWED);
+        assertThat(state.getConsumerGroupsStates().get(ALLOWED).committedOffsets()).containsEntry(PARTITION, 42L);
+      }
+    }
+  }
+
+  static Stream<Throwable> unrelatedFailures() {
+    return Stream.of(new TimeoutException("timed out"), new SaslAuthenticationException("authentication failed"));
+  }
+
+  private static <T> KafkaFuture<T> failedFuture(Throwable error) {
+    var future = new KafkaFutureImpl<T>();
+    future.completeExceptionally(error);
+    return future;
+  }
+}


### PR DESCRIPTION
<!-- ignore-task-list-start -->
- [ ] **Breaking change?** No.
<!-- ignore-task-list-end -->

**What changes did you make?**

Fixes #1975.

A consumer group may be returned by `ListConsumerGroups` even though the UI's Kafka principal cannot describe it or fetch its offsets. On GCP Managed Kafka, this happens with `__internal_google_managed_kafka_prober_cg`. Aggregating the per-group futures with `.all()` then fails the entire cluster scrape and consumer-group page.

This change opts bulk description reads and cluster offset scraping into per-group handling of `GroupAuthorizationException`: omit the denied group, log a warning, and retain successful results. Requests still use the existing batch sizes and concurrency limits. Other errors, including timeouts and SASL authentication failures, continue to propagate.

Name/state pagination now filters descriptions omitted from the result map, preventing a subsequent null dereference. Single-group details and the offset deletion/reset preconditions retain strict authorization-error handling. No Google-specific group-name filter, configuration option, dependency, or HTTP contract change is introduced.

**Is there anything you'd like reviewers to focus on?**

The distinction between bulk reads, where partial results are useful, and single-group operations, where an authorization failure must remain explicit. Pagination still uses the listed group count, so a page can contain fewer entries after denied groups are skipped; name/state sorting does not add an unbounded describe-all request to refill pages.

**How Has This Been Tested?**
<!-- ignore-task-list-start -->
- [ ] No need to
- [x] Manually
- [x] Unit checks
- [ ] Integration checks
- [x] Covered by existing automation
<!-- ignore-task-list-end -->

On Java 25, all 26 tests across `ReactiveAdminClientConsumerGroupsTest`, `ConsumerGroupServiceTest`, and `ScrapedClusterStateTest` pass. Coverage includes mixed authorized/denied results, all-denied results, batch preservation, partition selection, all five page orderings, successful cluster scraping with denied groups, unrelated error propagation, and strict offset deletion/reset behavior.

```sh
./gradlew :api:test \
  --tests io.kafbat.ui.service.ReactiveAdminClientConsumerGroupsTest \
  --tests io.kafbat.ui.service.ConsumerGroupServiceTest \
  --tests io.kafbat.ui.service.metrics.scrape.ScrapedClusterStateTest
./gradlew :api:checkstyleMain :api:checkstyleTest
./gradlew :api:bootJar
```

Both Checkstyle tasks and the backend JAR build pass. The full container-based integration suite has not been run locally.

I also ran the patched backend in a temporary loopback-only container against the affected GCP Managed Kafka cluster, using its existing authentication and read-only cluster configuration:

- `/api/clusters` returned HTTP 200, `ONLINE`, three brokers, and six topics.
- Broker and topic list endpoints returned HTTP 200.
- The consumer-group page returned HTTP 200 for all five orderings, with both business groups present and the internal prober group omitted.
- A business consumer-group detail returned HTTP 200 with its lag.
- A bounded message preview (`limit=1`) returned HTTP 200 with one `MESSAGE` event and a `DONE` event.
- The cluster remained `ONLINE`; no cluster-statistics collection failure appeared during the final five-minute log window.

The original UI was not restarted or replaced, and the temporary validation resources were removed.

**Checklist**
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (e.g. **ENVIRONMENT VARIABLES**)
- [x] My changes generate no new warnings (e.g. Sonar is happy)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged

No additional configuration documentation or dependent changes are required. The code follows the existing batching structure, with behavior covered by named regression tests. Existing build-tool/dependency deprecation warnings are unrelated to this change; Sonar results are pending CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Consumer-group listings now handle restricted or unauthorized groups more reliably by omitting inaccessible entries instead of failing the entire request.
  * Pagination remains accurate when consumer groups have missing descriptions, including across different sorting options.
  * Cluster metrics and consumer-group offset operations continue working when some groups cannot be accessed.
  * Improved handling preserves unrelated errors and maintains strict authorization failures where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->